### PR TITLE
Fix OAuth authentication redirect issue

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/config/AppConfig.kt
+++ b/src/backendng/src/main/kotlin/com/secman/config/AppConfig.kt
@@ -1,0 +1,16 @@
+package com.secman.config
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.serde.annotation.Serdeable
+
+@ConfigurationProperties("app")
+@Serdeable
+data class AppConfig(
+    val frontend: FrontendConfig = FrontendConfig()
+)
+
+@ConfigurationProperties("frontend")
+@Serdeable
+data class FrontendConfig(
+    val baseUrl: String = "http://localhost:4321"
+)

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -95,8 +95,8 @@ jackson:
 logger:
   levels:
     com.secman: DEBUG
+    io.micronaut.security: DEBUG
 
 app:
   frontend:
     base-url: ${FRONTEND_URL:http://localhost:4321}
-    io.micronaut.security: DEBUG


### PR DESCRIPTION
## Summary
- Fixed GitHub OAuth authentication flow that was causing 404 errors after successful login
- Resolved incorrect redirect URL construction that was redirecting to `localhost:8080/oauth/4321/login/success`
- Fixed configuration parsing issue where `frontendBaseUrl` was being set to just "4321"

## Changes
- Created `AppConfig` class to properly handle nested configuration properties
- Fixed YAML configuration formatting issue (misplaced logging configuration)
- Updated `OAuthController` to pass authentication data as URL parameters (as expected by frontend)
- Added validation and debug logging for frontend URL configuration

## Test Plan
- [x] Tested OAuth login flow with GitHub provider
- [x] Verified correct redirect to `http://localhost:4321/login/success` with token and user data
- [x] Confirmed successful authentication and user session creation
- [x] Checked that existing local login functionality still works

## Before
After GitHub authentication, users were redirected to:
`localhost:8080/oauth/4321/login/success` → 404 Not Found

## After
Users are now correctly redirected to:
`http://localhost:4321/login/success?token=...&user=...` → Success

🤖 Generated with [Claude Code](https://claude.ai/code)