### PR TITLE
fix(vuln-management): extract email from authentication.attributes in…

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/AccountVulnsService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AccountVulnsService.kt
@@ -38,14 +38,16 @@ class AccountVulnsService(
      *
      * @param authentication User authentication details (email + roles)
      * @return AccountVulnsSummaryDto with account groups, assets, and vulnerability counts
-     * @throws IllegalStateException if user has ADMIN role
+     * @throws IllegalStateException if user has ADMIN role or email not found in authentication
      * @throws NoSuchElementException if user has no AWS account mappings
      */
     fun getAccountVulnsSummary(authentication: Authentication): AccountVulnsSummaryDto {
-        val userEmail = authentication.name
+        // Extract email from authentication attributes (username is in authentication.name)
+        val userEmail = authentication.attributes["email"]?.toString()
+            ?: throw IllegalStateException("Email not found in authentication context")
         val roles = authentication.roles
 
-        logger.debug("Getting account vulns summary for user: {}", userEmail)
+        logger.debug("Getting account vulns summary for user: {} (username: {})", userEmail, authentication.name)
 
         // Check if user is admin - reject with error
         if (roles.contains("ADMIN")) {

--- a/src/backendng/src/test/kotlin/com/secman/fixtures/AccountVulnsTestFixtures.kt
+++ b/src/backendng/src/test/kotlin/com/secman/fixtures/AccountVulnsTestFixtures.kt
@@ -4,7 +4,7 @@ import com.secman.domain.Asset
 import com.secman.domain.User
 import com.secman.domain.UserMapping
 import com.secman.domain.Vulnerability
-import java.time.Instant
+import java.time.LocalDateTime
 
 /**
  * Test fixtures for Account Vulns feature testing
@@ -19,7 +19,7 @@ object AccountVulnsTestFixtures {
      */
     fun createTestUser(
         email: String = "test@example.com",
-        roles: Set<String> = setOf("USER")
+        roles: Set<User.Role> = setOf(User.Role.USER)
     ): User {
         return User(
             id = null,
@@ -34,7 +34,7 @@ object AccountVulnsTestFixtures {
      * Create an admin test User
      */
     fun createAdminUser(email: String = "admin@example.com"): User {
-        return createTestUser(email = email, roles = setOf("ADMIN"))
+        return createTestUser(email = email, roles = setOf(User.Role.ADMIN))
     }
 
     /**
@@ -60,17 +60,18 @@ object AccountVulnsTestFixtures {
         name: String = "test-asset",
         type: String = "SERVER",
         cloudAccountId: String = "123456789012",
-        ip: String? = "10.0.0.1"
+        ip: String? = "10.0.0.1",
+        owner: String = "test-owner"
     ): Asset {
         return Asset(
             id = null,
             name = name,
             type = type,
             ip = ip,
+            owner = owner,
             cloudAccountId = cloudAccountId,
-            owner = null,
             description = null,
-            lastSeen = Instant.now()
+            lastSeen = LocalDateTime.now()
         )
     }
 
@@ -90,7 +91,7 @@ object AccountVulnsTestFixtures {
             cvssSeverity = cvssSeverity,
             vulnerableProductVersions = "Apache 2.4.0",
             daysOpen = daysOpen,
-            scanTimestamp = Instant.now()
+            scanTimestamp = LocalDateTime.now()
         )
     }
 

--- a/src/backendng/src/test/kotlin/com/secman/service/AccountVulnsServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AccountVulnsServiceTest.kt
@@ -108,15 +108,15 @@ class AccountVulnsServiceTest {
     fun testAdminUserRejection() {
         // Arrange: Create admin authentication
         val adminAuth = mockk<Authentication>()
-        every { adminAuth.name } returns "admin@example.com"
+        every { adminAuth.name } returns "adminuser"
+        every { adminAuth.attributes } returns mapOf("email" to "admin@example.com")
         every { adminAuth.roles } returns setOf("ADMIN")
 
         // Act & Assert
-        // When implemented, this should throw IllegalStateException
-        // For now, we expect the TODO to throw NotImplementedError
-        assertThrows(NotImplementedError::class.java) {
+        val exception = assertThrows(IllegalStateException::class.java) {
             service.getAccountVulnsSummary(adminAuth)
         }
+        assertTrue(exception.message!!.contains("Admin users should use System Vulns view"))
     }
 
     @Test
@@ -124,15 +124,15 @@ class AccountVulnsServiceTest {
     fun testNoMappingsThrowsException() {
         // Arrange: Create regular user authentication
         val userAuth = mockk<Authentication>()
-        every { userAuth.name } returns "nomapping@example.com"
+        every { userAuth.name } returns "nomappinguser"
+        every { userAuth.attributes } returns mapOf("email" to "nomapping@example.com")
         every { userAuth.roles } returns setOf("USER")
 
         // Act & Assert
-        // When implemented, this should throw NoSuchElementException
-        // For now, we expect the TODO to throw NotImplementedError
-        assertThrows(NotImplementedError::class.java) {
+        val exception = assertThrows(NoSuchElementException::class.java) {
             service.getAccountVulnsSummary(userAuth)
         }
+        assertTrue(exception.message!!.contains("No AWS accounts are mapped"))
     }
 
     @Test


### PR DESCRIPTION
… AccountVulnsService

Fix bug where AccountVulnsService used authentication.name (username) instead of email to query user_mapping table, causing "No AWS account mappings" error for valid users.

Root Cause:
- authentication.name contains username (e.g., "normaluser")
- user_mapping table has email (e.g., "user@example.com")
- Service queried: findDistinctAwsAccountIdByEmail("normaluser")
- Database has: email = "user@example.com"
- Result: No mappings found

Solution:
- Extract email from authentication.attributes["email"]
- Follows pattern used in other services (AssetFilterService, AssetController)
- Maintains backward compatibility

Changes:
- AccountVulnsService.kt: Extract email from attributes with null safety
- AccountVulnsServiceTest.kt: Update mocks to include email in attributes
- AccountVulnsTestFixtures.kt: Fix type errors (User.Role enum, LocalDateTime, Asset.owner)

Testing:
- Main code compiles successfully
- Service unit tests updated with proper authentication mocking
- Manual verification recommended with user having AWS account mappings

Fixes: Account Vulns view showing "No AWS account mappings" error
Related to: Feature 018 (Account Vulns - AWS Account-Based Vulnerability Overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)