### PR TITLE
Add back button to all admin pages

### DIFF
--- a/src/frontend/src/pages/admin/email-config.astro
+++ b/src/frontend/src/pages/admin/email-config.astro
@@ -559,4 +559,9 @@ import Layout from '../../layouts/Layout.astro';
         }
       }
     </script>
+    <div class="container-fluid p-4">
+      <div class="mt-4">
+        <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+      </div>
+    </div>
 </Layout>

--- a/src/frontend/src/pages/admin/falcon-config.astro
+++ b/src/frontend/src/pages/admin/falcon-config.astro
@@ -5,4 +5,7 @@ import FalconConfigManagement from '../../components/FalconConfigManagement';
 
 <Layout title="CrowdStrike Falcon Configuration - Admin">
   <FalconConfigManagement client:load />
+  <div class="mt-4">
+    <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+  </div>
 </Layout>

--- a/src/frontend/src/pages/admin/identity-providers.astro
+++ b/src/frontend/src/pages/admin/identity-providers.astro
@@ -5,4 +5,7 @@ import IdentityProviderManagement from '../../components/IdentityProviderManagem
 
 <Layout title="Identity Provider Management">
     <IdentityProviderManagement client:load />
+    <div class="mt-4">
+      <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+    </div>
 </Layout>

--- a/src/frontend/src/pages/admin/mcp-api-keys.astro
+++ b/src/frontend/src/pages/admin/mcp-api-keys.astro
@@ -6,4 +6,7 @@ import McpApiKeyManagement from '../../components/McpApiKeyManagement.tsx';
 
 <Layout title="MCP API Keys - Admin - Secman">
   <McpApiKeyManagement client:load />
+  <div class="mt-4">
+    <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+  </div>
 </Layout>

--- a/src/frontend/src/pages/admin/releases.astro
+++ b/src/frontend/src/pages/admin/releases.astro
@@ -5,4 +5,7 @@ import ReleaseManagement from '../../components/ReleaseManagement.tsx';
 
 <Layout title="Release Management - Secman">
     <ReleaseManagement client:load />
+    <div class="mt-4">
+      <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+    </div>
 </Layout>

--- a/src/frontend/src/pages/admin/requirements.astro
+++ b/src/frontend/src/pages/admin/requirements.astro
@@ -5,4 +5,7 @@ import RequirementsAdmin from '../../components/RequirementsAdmin';
 
 <Layout title="Admin - Requirements Management">
     <RequirementsAdmin client:load />
+    <div class="mt-4">
+      <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+    </div>
 </Layout>

--- a/src/frontend/src/pages/admin/test-email-accounts.astro
+++ b/src/frontend/src/pages/admin/test-email-accounts.astro
@@ -5,4 +5,7 @@ import TestEmailAccountManagement from '../../components/TestEmailAccountManagem
 
 <Layout title="Test Email Accounts">
   <TestEmailAccountManagement client:load />
+  <div class="mt-4">
+    <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+  </div>
 </Layout>

--- a/src/frontend/src/pages/admin/translation-config.astro
+++ b/src/frontend/src/pages/admin/translation-config.astro
@@ -6,4 +6,7 @@ import TranslationConfigManagement from '../../components/TranslationConfigManag
 
 <Layout title="Translation Configuration - Secman Admin">
     <TranslationConfigManagement client:load />
+    <div class="mt-4">
+      <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+    </div>
 </Layout>

--- a/src/frontend/src/pages/admin/user-mappings.astro
+++ b/src/frontend/src/pages/admin/user-mappings.astro
@@ -14,5 +14,9 @@ import UserMappingManager from '../../components/UserMappingManager';
         </nav>
 
         <UserMappingManager client:load />
+
+        <div class="mt-4">
+          <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+        </div>
     </div>
 </Layout>

--- a/src/frontend/src/pages/admin/vulnerability-config.astro
+++ b/src/frontend/src/pages/admin/vulnerability-config.astro
@@ -69,5 +69,9 @@ import VulnerabilityExceptionsTable from '../../components/VulnerabilityExceptio
                 <VulnerabilityExceptionsTable client:load />
             </div>
         </div>
+
+        <div class="mt-4">
+          <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+        </div>
     </div>
 </Layout>


### PR DESCRIPTION
Add consistent navigation by including 'Back to Admin' button to all admin pages that were missing it:
- email-config.astro
- falcon-config.astro
- identity-providers.astro
- mcp-api-keys.astro
- releases.astro
- requirements.astro
- test-email-accounts.astro
- translation-config.astro
- user-mappings.astro
- vulnerability-config.astro

This provides a consistent user experience across all admin pages, matching the pattern from user-management.astro.