### PR TITLE
Add MFA attribute to user object

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/UserController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/UserController.kt
@@ -34,7 +34,8 @@ open class UserController(
         val email: String,
         val password: String,
         val roles: List<String>? = null,
-        val workgroupIds: List<Long>? = null
+        val workgroupIds: List<Long>? = null,
+        val mfaEnabled: Boolean? = null
     )
 
     @Serdeable
@@ -43,7 +44,8 @@ open class UserController(
         val email: String? = null,
         val password: String? = null,
         val roles: List<String>? = null,
-        val workgroupIds: List<Long>? = null
+        val workgroupIds: List<Long>? = null,
+        val mfaEnabled: Boolean? = null
     )
 
     @Serdeable
@@ -52,6 +54,7 @@ open class UserController(
         val username: String,
         val email: String,
         val roles: List<String>,
+        val mfaEnabled: Boolean,
         val createdAt: String?,
         val updatedAt: String?,
         val workgroups: List<WorkgroupSummary>? = null,
@@ -64,6 +67,7 @@ open class UserController(
                     username = user.username,
                     email = user.email,
                     roles = user.roles.map { it.name },
+                    mfaEnabled = user.mfaEnabled,
                     createdAt = user.createdAt?.toString(),
                     updatedAt = user.updatedAt?.toString(),
                     workgroups = if (includeWorkgroups) {
@@ -131,7 +135,8 @@ open class UserController(
                 username = request.username,
                 email = request.email,
                 passwordHash = passwordEncoder.encode(request.password),
-                roles = roles
+                roles = roles,
+                mfaEnabled = request.mfaEnabled ?: false
             )
 
             val savedUser = userRepository.save(user)
@@ -218,10 +223,14 @@ open class UserController(
                 }
             }
 
-            request.password?.let { 
+            request.password?.let {
                 if (it.isNotBlank()) {
                     user.passwordHash = passwordEncoder.encode(it)
                 }
+            }
+
+            request.mfaEnabled?.let {
+                user.mfaEnabled = it
             }
 
             request.roles?.let { roleStrings ->

--- a/src/backendng/src/main/kotlin/com/secman/domain/User.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/User.kt
@@ -49,6 +49,9 @@ data class User(
     )
     var workgroups: MutableSet<Workgroup> = mutableSetOf(),
 
+    @Column(name = "mfa_enabled", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    var mfaEnabled: Boolean = false,
+
     @Column(name = "created_at", updatable = false)
     var createdAt: Instant? = null,
 


### PR DESCRIPTION
- Add mfaEnabled field to User entity with default value false
- Add database column mfa_enabled with BOOLEAN DEFAULT FALSE
- Update UserResponse DTO to include mfaEnabled field
- Update CreateUserRequest and UpdateUserRequest to support mfaEnabled
- Update create and update endpoints to handle mfaEnabled field
- Backward compatible: existing users default to MFA disabled
- OAuth-created users automatically get mfaEnabled = false

This ensures that:
1. All new users have mfaEnabled = false by default
2. Existing users without the field are treated as MFA disabled
3. ADMIN users can create/update users with MFA settings via API