### PR TITLE
Add Crowdstrike vulnerability filter to import script

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/config/VulnerabilitySettings.kt
+++ b/src/backendng/src/main/kotlin/com/secman/config/VulnerabilitySettings.kt
@@ -1,0 +1,21 @@
+package com.secman.config
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Configuration properties for vulnerability import and processing behavior
+ *
+ * Related to: Feature 041-falcon-instance-lookup (CrowdStrike patch publication date support)
+ *
+ * @property usePatchPublicationDate When true, calculate days_open from patch publication date
+ *                                   instead of detection time
+ * @property requirePatchPublicationDate When true, filter out vulnerabilities without
+ *                                       patch publication date during import
+ */
+@ConfigurationProperties("secman.vulnerability")
+@Serdeable
+data class VulnerabilitySettings(
+    val usePatchPublicationDate: Boolean = false,
+    val requirePatchPublicationDate: Boolean = false
+)

--- a/src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt
@@ -22,6 +22,7 @@ import java.time.LocalDateTime
  * @property vulnerableProductVersions Affected product/version information
  * @property daysOpen Text representation of days open (e.g., "58 days")
  * @property scanTimestamp When the scan was performed (user-specified, required)
+ * @property patchPublicationDate When the vendor published the patch/fix (optional, from CrowdStrike API)
  * @property createdAt When the record was imported into the system (auto-generated)
  */
 @Entity
@@ -60,6 +61,9 @@ data class Vulnerability(
     @Column(name = "scan_timestamp", nullable = false)
     @NotNull
     var scanTimestamp: LocalDateTime,
+
+    @Column(name = "patch_publication_date")
+    var patchPublicationDate: LocalDateTime? = null,
 
     @Column(name = "created_at", updatable = false)
     var createdAt: LocalDateTime? = null

--- a/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeVulnerabilityDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeVulnerabilityDto.kt
@@ -62,6 +62,11 @@ data class CrowdStrikeVulnerabilityDto(
     val detectedAt: LocalDateTime,
 
     /**
+     * Patch publication date from vendor (nullable, from CrowdStrike API)
+     */
+    val patchPublicationDate: LocalDateTime? = null,
+
+    /**
      * Vulnerability status (always "open" for this query)
      */
     @field:NotBlank

--- a/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityDto.kt
@@ -4,6 +4,7 @@ import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
 
 /**
  * DTO for individual vulnerability data in CrowdStrike import requests
@@ -15,6 +16,7 @@ import jakarta.validation.constraints.Size
  * @property severity CVSS severity level (HIGH, CRITICAL)
  * @property affectedProduct Affected product/version information
  * @property daysOpen Number of days vulnerability has been open (minimum 30 per FR-004)
+ * @property patchPublicationDate Date when the patch was published by the vendor (optional)
  */
 @Serdeable
 data class VulnerabilityDto(
@@ -30,5 +32,7 @@ data class VulnerabilityDto(
     val affectedProduct: String?,
 
     @field:Min(0)
-    val daysOpen: Int
+    val daysOpen: Int,
+
+    val patchPublicationDate: LocalDateTime? = null
 )

--- a/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
@@ -1,5 +1,6 @@
 package com.secman.service
 
+import com.secman.config.VulnerabilitySettings
 import com.secman.domain.Asset
 import com.secman.domain.CrowdStrikeImportHistory
 import com.secman.domain.Vulnerability
@@ -14,6 +15,7 @@ import jakarta.inject.Singleton
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 /**
  * Service for importing CrowdStrike server vulnerabilities with automatic asset creation
@@ -34,7 +36,8 @@ open class CrowdStrikeVulnerabilityImportService(
     private val assetRepository: AssetRepository,
     private val vulnerabilityRepository: VulnerabilityRepository,
     private val importHistoryRepository: CrowdStrikeImportHistoryRepository,
-    private val materializedViewRefreshService: MaterializedViewRefreshService
+    private val materializedViewRefreshService: MaterializedViewRefreshService,
+    private val vulnerabilitySettings: VulnerabilitySettings
 ) {
     private val log = LoggerFactory.getLogger(CrowdStrikeVulnerabilityImportService::class.java)
 
@@ -154,26 +157,59 @@ open class CrowdStrikeVulnerabilityImportService(
         }
 
         // Filter vulnerabilities with CVE IDs (FR-013)
-        val vulnsWithCve = batch.vulnerabilities.filter { !it.cveId.isNullOrBlank() }
-        val skippedCount = batch.vulnerabilities.size - vulnsWithCve.size
+        var vulnsWithCve = batch.vulnerabilities.filter { !it.cveId.isNullOrBlank() }
+        var skippedCount = batch.vulnerabilities.size - vulnsWithCve.size
+
+        // Filter vulnerabilities without patch publication date if required (Feature 041)
+        if (vulnerabilitySettings.requirePatchPublicationDate) {
+            val beforeFilterCount = vulnsWithCve.size
+            vulnsWithCve = vulnsWithCve.filter { it.patchPublicationDate != null }
+            val additionalSkipped = beforeFilterCount - vulnsWithCve.size
+            skippedCount += additionalSkipped
+
+            if (additionalSkipped > 0) {
+                log.debug("Skipped {} vulnerabilities without patch publication date for asset '{}' (requirePatchPublicationDate=true)",
+                    additionalSkipped, asset.name)
+            }
+        }
 
         if (skippedCount > 0) {
-            log.debug("Skipped {} vulnerabilities without CVE IDs for asset '{}'", skippedCount, asset.name)
+            log.debug("Skipped {} vulnerabilities (no CVE ID or no patch publication date) for asset '{}'", skippedCount, asset.name)
         }
 
         // Create new vulnerability records (T021)
         val vulnerabilities = vulnsWithCve.map { vulnDto ->
-            // Calculate correct scan timestamp from daysOpen
-            // This ensures overdue calculation works correctly: age = now - scanTimestamp = daysOpen
-            val scanTimestamp = LocalDateTime.now().minusDays(vulnDto.daysOpen.toLong())
+            // Calculate scan timestamp and days open based on configuration
+            val (scanTimestamp, daysOpenText) = if (vulnerabilitySettings.usePatchPublicationDate && vulnDto.patchPublicationDate != null) {
+                // Use patch publication date for calculation (Feature 041)
+                // days_open = scan_timestamp - patch_publication_date
+                val currentTime = LocalDateTime.now()
+                val patchDate = vulnDto.patchPublicationDate
+                val daysFromPatch = ChronoUnit.DAYS.between(patchDate, currentTime).toInt()
+
+                // scanTimestamp is set to current time - daysFromPatch
+                val calculatedScanTime = currentTime.minusDays(daysFromPatch.toLong())
+                val daysText = if (daysFromPatch == 1) "1 day" else "$daysFromPatch days"
+
+                log.trace("Using patch publication date for CVE {}: patch_date={}, days_from_patch={}",
+                    vulnDto.cveId, patchDate, daysFromPatch)
+
+                Pair(calculatedScanTime, daysText)
+            } else {
+                // Use original logic: days_open from detection time (current behavior)
+                val scanTime = LocalDateTime.now().minusDays(vulnDto.daysOpen.toLong())
+                val daysText = "${vulnDto.daysOpen} days"
+                Pair(scanTime, daysText)
+            }
 
             Vulnerability(
                 asset = asset,
                 vulnerabilityId = vulnDto.cveId,
                 cvssSeverity = vulnDto.severity,
                 vulnerableProductVersions = vulnDto.affectedProduct,
-                daysOpen = "${vulnDto.daysOpen} days",  // Convert Int to String format
-                scanTimestamp = scanTimestamp
+                daysOpen = daysOpenText,
+                scanTimestamp = scanTimestamp,
+                patchPublicationDate = vulnDto.patchPublicationDate
             )
         }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityImportService.kt
@@ -1,5 +1,6 @@
 package com.secman.service
 
+import com.secman.config.VulnerabilitySettings
 import com.secman.domain.Vulnerability
 import com.secman.dto.SkippedRowDetail
 import com.secman.dto.VulnerabilityImportResponse
@@ -10,6 +11,9 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
 
 /**
  * Service for importing vulnerabilities from Excel files
@@ -26,7 +30,8 @@ import java.time.LocalDateTime
 @Singleton
 class VulnerabilityImportService(
     private val vulnerabilityRepository: VulnerabilityRepository,
-    private val assetMergeService: AssetMergeService
+    private val assetMergeService: AssetMergeService,
+    private val vulnerabilitySettings: VulnerabilitySettings
 ) {
     private val log = LoggerFactory.getLogger(VulnerabilityImportService::class.java)
 
@@ -35,6 +40,11 @@ class VulnerabilityImportService(
             "Hostname", "Local IP", "Host groups", "Cloud service account ID",
             "Cloud service instance ID", "OS version", "Active Directory domain",
             "Vulnerability ID", "CVSS severity", "Vulnerable product versions", "Days open"
+        )
+
+        // Optional headers (for backward compatibility)
+        private val OPTIONAL_HEADERS = listOf(
+            "Patch Publication Date"
         )
     }
 
@@ -109,10 +119,17 @@ class VulnerabilityImportService(
             if (cell != null) {
                 val headerName = getCellValueAsString(cell).trim()
 
-                // Map to standardized header names (case-insensitive)
+                // Map required headers (case-insensitive)
                 REQUIRED_HEADERS.forEach { required ->
                     if (headerName.equals(required, ignoreCase = true)) {
                         headerMap[required] = cellIndex
+                    }
+                }
+
+                // Map optional headers (case-insensitive)
+                OPTIONAL_HEADERS.forEach { optional ->
+                    if (headerName.equals(optional, ignoreCase = true)) {
+                        headerMap[optional] = cellIndex
                     }
                 }
             }
@@ -161,6 +178,17 @@ class VulnerabilityImportService(
         val vulnerableProductVersions = getCellValue(row, headerMap, "Vulnerable product versions")?.trim()
         val daysOpen = getCellValue(row, headerMap, "Days open")?.trim()
 
+        // Parse patch publication date (optional column)
+        val patchPublicationDateStr = getCellValue(row, headerMap, "Patch Publication Date")?.trim()
+        val patchPublicationDate = parsePatchPublicationDate(patchPublicationDateStr)
+
+        // Skip vulnerability if patch publication date is required but not present (Feature 041)
+        if (vulnerabilitySettings.requirePatchPublicationDate && patchPublicationDate == null) {
+            log.debug("Skipping vulnerability {} for asset {} - patch publication date required but not present",
+                vulnerabilityId, hostname)
+            return null // Skip this row
+        }
+
         // Find or create asset
         val assetBefore = assetMergeService.findOrCreateAsset(
             hostname = hostname,
@@ -178,14 +206,31 @@ class VulnerabilityImportService(
             createdAssets.add(hostname)
         }
 
+        // Calculate effective scan timestamp and days open based on configuration
+        val (effectiveScanTimestamp, effectiveDaysOpen) = if (vulnerabilitySettings.usePatchPublicationDate && patchPublicationDate != null) {
+            // Use patch publication date for calculation (Feature 041)
+            val daysFromPatch = ChronoUnit.DAYS.between(patchPublicationDate, scanDate).toInt()
+            val calculatedScanTime = scanDate
+            val daysText = if (daysFromPatch == 1) "1 day" else "$daysFromPatch days"
+
+            log.trace("Using patch publication date for CVE {}: patch_date={}, scan_date={}, days_from_patch={}",
+                vulnerabilityId, patchPublicationDate, scanDate, daysFromPatch)
+
+            Pair(calculatedScanTime, daysText)
+        } else {
+            // Use original logic: use provided days open and scan date
+            Pair(scanDate, daysOpen?.takeIf { it.isNotEmpty() })
+        }
+
         // Create vulnerability entity
         val vulnerability = Vulnerability(
             asset = assetBefore,
             vulnerabilityId = vulnerabilityId?.takeIf { it.isNotEmpty() },
             cvssSeverity = cvssSeverity?.takeIf { it.isNotEmpty() },
             vulnerableProductVersions = vulnerableProductVersions?.takeIf { it.isNotEmpty() },
-            daysOpen = daysOpen?.takeIf { it.isNotEmpty() },
-            scanTimestamp = scanDate
+            daysOpen = effectiveDaysOpen,
+            scanTimestamp = effectiveScanTimestamp,
+            patchPublicationDate = patchPublicationDate
         )
 
         return vulnerability
@@ -241,6 +286,40 @@ class VulnerabilityImportService(
                 }
             }
             else -> ""
+        }
+    }
+
+    /**
+     * Parse patch publication date from string value
+     * Supports multiple date formats:
+     * - ISO 8601: "2024-05-15T22:18:26" or "2024-05-15T22:18:26Z"
+     * - Date only: "2024-05-15"
+     * - Excel default: LocalDateTime from cell
+     *
+     * @param dateStr Date string from Excel cell
+     * @return Parsed LocalDateTime or null if parsing fails or empty
+     */
+    private fun parsePatchPublicationDate(dateStr: String?): LocalDateTime? {
+        if (dateStr.isNullOrBlank()) {
+            return null
+        }
+
+        return try {
+            // Try parsing as ISO 8601 with time
+            LocalDateTime.parse(dateStr, DateTimeFormatter.ISO_DATE_TIME)
+        } catch (e: DateTimeParseException) {
+            try {
+                // Try parsing as date-only (add time component)
+                LocalDateTime.parse(dateStr + "T00:00:00")
+            } catch (e2: DateTimeParseException) {
+                try {
+                    // Try parsing without timezone indicator
+                    LocalDateTime.parse(dateStr.replace("Z", "").replace(" ", "T"))
+                } catch (e3: DateTimeParseException) {
+                    log.debug("Failed to parse patch publication date '{}': {}", dateStr, e3.message)
+                    null
+                }
+            }
         }
     }
 }

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -108,6 +108,15 @@ secman:
     notifications:
       batch-size: 50
       async-processing: true
+  vulnerability:
+    # Use patch publication date for calculating days open
+    # When true: days_open = scan_timestamp - patch_publication_date
+    # When false: days_open = current_time - detection_time (current behavior)
+    use-patch-publication-date: ${VULN_USE_PATCH_PUBLICATION_DATE:false}
+    # Filter to import only vulnerabilities with patch publication date set
+    # When true: vulnerabilities without patch_publication_date are skipped during import
+    # When false: all vulnerabilities are imported (current behavior)
+    require-patch-publication-date: ${VULN_REQUIRE_PATCH_PUBLICATION_DATE:false}
   http:
     services:
       translation:


### PR DESCRIPTION
…oggle

Implements comprehensive patch publication date tracking and filtering for CrowdStrike vulnerabilities with configurable days-open calculation.

Database Changes:
- Add patch_publication_date column to vulnerability table
- Column is nullable for backward compatibility
- Stores vendor patch publication timestamp

Configuration:
- Add secman.vulnerability.use-patch-publication-date toggle When true: calculates days_open from patch publication date When false: uses detection time (current behavior)
- Add secman.vulnerability.require-patch-publication-date filter When true: skips vulnerabilities without patch publication date When false: imports all vulnerabilities (current behavior)
- Environment variables: VULN_USE_PATCH_PUBLICATION_DATE, VULN_REQUIRE_PATCH_PUBLICATION_DATE

CrowdStrike API Client:
- Extract patch publication date from multiple API response fields:
  * cve.published_date, cve.published
  * remediation.published_date, remediation.vendor_release_date
  * patch_published_date, patch_publication_date
- Flexible date parsing: ISO-8601, date-only, various formats
- Graceful fallback when field not present

Import Services:
- CrowdStrikeVulnerabilityImportService: Apply filters and calculations
- VulnerabilityImportService: Support optional "Patch Publication Date" column
- Backward compatible: existing imports work without changes

Days Open Calculation Logic:
- Default: days_open = current_time - detection_time (unchanged)
- With patch date: days_open = current_time - patch_publication_date
- User-controlled via configuration toggle

Excel Import:
- Added optional "Patch Publication Date" column
- Supports ISO-8601, date-only formats
- Backward compatible with existing templates

Files Modified:
- src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt
- src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeVulnerabilityDto.kt
- src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityDto.kt
- src/backendng/src/main/kotlin/com/secman/config/VulnerabilitySettings.kt (new)
- src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
- src/backendng/src/main/kotlin/com/secman/service/VulnerabilityImportService.kt
- src/backendng/src/main/resources/application.yml
- src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt

Related to: Feature 041-crowdstrike-patch-date