### PR TITLE
Add vulnerability count to CrowdStrike API import

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/domain/CrowdStrikeImportHistory.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/CrowdStrikeImportHistory.kt
@@ -45,6 +45,9 @@ data class CrowdStrikeImportHistory(
     @Column(name = "vulns_skipped", nullable = false)
     var vulnerabilitiesSkipped: Int = 0,
 
+    @Column(name = "vulns_with_patch_date", nullable = false)
+    var vulnerabilitiesWithPatchDate: Int = 0,
+
     @Column(name = "error_count", nullable = false)
     var errorCount: Int = 0
 ) {

--- a/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeImportStatusDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeImportStatusDto.kt
@@ -18,6 +18,7 @@ data class CrowdStrikeImportStatusDto(
     val serversUpdated: Int,
     val vulnerabilitiesImported: Int,
     val vulnerabilitiesSkipped: Int,
+    val vulnerabilitiesWithPatchDate: Int,
     val errorCount: Int
 ) {
     companion object {
@@ -30,6 +31,7 @@ data class CrowdStrikeImportStatusDto(
                 serversUpdated = entity.serversUpdated,
                 vulnerabilitiesImported = entity.vulnerabilitiesImported,
                 vulnerabilitiesSkipped = entity.vulnerabilitiesSkipped,
+                vulnerabilitiesWithPatchDate = entity.vulnerabilitiesWithPatchDate,
                 errorCount = entity.errorCount
             )
         }

--- a/src/backendng/src/main/kotlin/com/secman/dto/ImportStatisticsDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/ImportStatisticsDto.kt
@@ -16,6 +16,7 @@ import io.micronaut.serde.annotation.Serdeable
  * @property serversUpdated Existing Asset records reused/updated
  * @property vulnerabilitiesImported Total Vulnerability records created (across all servers)
  * @property vulnerabilitiesSkipped Count of vulnerabilities without CVE ID (filtered before import)
+ * @property vulnerabilitiesWithPatchDate Count of imported vulnerabilities that have patch publication date set
  * @property errors List of error messages for failed server imports (transaction rollbacks)
  */
 @Serdeable
@@ -25,5 +26,6 @@ data class ImportStatisticsDto(
     val serversUpdated: Int,
     val vulnerabilitiesImported: Int,
     val vulnerabilitiesSkipped: Int,
+    val vulnerabilitiesWithPatchDate: Int,
     val errors: List<String>
 )

--- a/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
@@ -60,6 +60,7 @@ open class CrowdStrikeVulnerabilityImportService(
         var serversUpdated = 0
         var vulnerabilitiesImported = 0
         var vulnerabilitiesSkipped = 0
+        var vulnerabilitiesWithPatchDate = 0
         val errors = mutableListOf<String>()
 
         for (batch in batches) {
@@ -72,9 +73,10 @@ open class CrowdStrikeVulnerabilityImportService(
 
                 vulnerabilitiesImported += result.vulnerabilitiesImported
                 vulnerabilitiesSkipped += result.vulnerabilitiesSkipped
+                vulnerabilitiesWithPatchDate += result.vulnerabilitiesWithPatchDate
 
-                log.debug("Imported server '{}': created={}, imported={}, skipped={}",
-                    batch.hostname, result.assetCreated, result.vulnerabilitiesImported, result.vulnerabilitiesSkipped)
+                log.debug("Imported server '{}': created={}, imported={}, skipped={}, withPatchDate={}",
+                    batch.hostname, result.assetCreated, result.vulnerabilitiesImported, result.vulnerabilitiesSkipped, result.vulnerabilitiesWithPatchDate)
             } catch (e: Exception) {
                 val errorMsg = "Failed to import server '${batch.hostname}': ${e.message}"
                 log.error(errorMsg, e)
@@ -88,11 +90,12 @@ open class CrowdStrikeVulnerabilityImportService(
             serversUpdated = serversUpdated,
             vulnerabilitiesImported = vulnerabilitiesImported,
             vulnerabilitiesSkipped = vulnerabilitiesSkipped,
+            vulnerabilitiesWithPatchDate = vulnerabilitiesWithPatchDate,
             errors = errors
         )
 
-        log.info("Batch import completed: processed={}, created={}, updated={}, imported={}, skipped={}, errors={}",
-            batches.size, serversCreated, serversUpdated, vulnerabilitiesImported, vulnerabilitiesSkipped, errors.size)
+        log.info("Batch import completed: processed={}, created={}, updated={}, imported={}, skipped={}, withPatchDate={}, errors={}",
+            batches.size, serversCreated, serversUpdated, vulnerabilitiesImported, vulnerabilitiesSkipped, vulnerabilitiesWithPatchDate, errors.size)
 
         recordImportHistory(statistics, triggeredBy)
 
@@ -120,6 +123,7 @@ open class CrowdStrikeVulnerabilityImportService(
                 serversUpdated = statistics.serversUpdated,
                 vulnerabilitiesImported = statistics.vulnerabilitiesImported,
                 vulnerabilitiesSkipped = statistics.vulnerabilitiesSkipped,
+                vulnerabilitiesWithPatchDate = statistics.vulnerabilitiesWithPatchDate,
                 errorCount = statistics.errors.size
             )
             importHistoryRepository.save(history)
@@ -178,7 +182,13 @@ open class CrowdStrikeVulnerabilityImportService(
         }
 
         // Create new vulnerability records (T021)
+        var vulnerabilitiesWithPatchDateCount = 0
         val vulnerabilities = vulnsWithCve.map { vulnDto ->
+            // Track vulnerabilities with patch publication date
+            if (vulnDto.patchPublicationDate != null) {
+                vulnerabilitiesWithPatchDateCount++
+            }
+
             // Calculate scan timestamp and days open based on configuration
             val (scanTimestamp, daysOpenText) = if (vulnerabilitySettings.usePatchPublicationDate && vulnDto.patchPublicationDate != null) {
                 // Use patch publication date for calculation (Feature 041)
@@ -216,13 +226,15 @@ open class CrowdStrikeVulnerabilityImportService(
         // Save all vulnerabilities in batch
         if (vulnerabilities.isNotEmpty()) {
             vulnerabilityRepository.saveAll(vulnerabilities)
-            log.debug("Created {} new vulnerabilities for asset '{}'", vulnerabilities.size, asset.name)
+            log.debug("Created {} new vulnerabilities for asset '{}' ({} with patch publication date)",
+                vulnerabilities.size, asset.name, vulnerabilitiesWithPatchDateCount)
         }
 
         return ServerImportResult(
             assetCreated = isNewAsset,
             vulnerabilitiesImported = vulnerabilities.size,
-            vulnerabilitiesSkipped = skippedCount
+            vulnerabilitiesSkipped = skippedCount,
+            vulnerabilitiesWithPatchDate = vulnerabilitiesWithPatchDateCount
         )
     }
 
@@ -286,5 +298,6 @@ open class CrowdStrikeVulnerabilityImportService(
 data class ServerImportResult(
     val assetCreated: Boolean,
     val vulnerabilitiesImported: Int,
-    val vulnerabilitiesSkipped: Int
+    val vulnerabilitiesSkipped: Int,
+    val vulnerabilitiesWithPatchDate: Int
 )

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
@@ -169,6 +169,7 @@ class ServersCommand {
             System.out.println("  - New servers created: ${result.serversCreated}")
             System.out.println("  - Existing servers updated: ${result.serversUpdated}")
             System.out.println("Vulnerabilities imported: ${result.vulnerabilitiesImported}")
+            System.out.println("  - With patch publication date: ${result.vulnerabilitiesWithPatchDate}")
             System.out.println("Vulnerabilities skipped: ${result.vulnerabilitiesSkipped}")
 
             if (result.errors.isNotEmpty()) {


### PR DESCRIPTION
…ports

Add tracking and reporting for vulnerabilities that have a patch publication date set during CrowdStrike imports. This provides visibility into data quality and patch availability.

Changes:
- Add vulnerabilitiesWithPatchDate field to ImportStatisticsDto
- Track patch date count in CrowdStrikeVulnerabilityImportService
- Add vulns_with_patch_date column to CrowdStrikeImportHistory entity
- Update CrowdStrikeImportStatusDto to include patch date statistics
- Display patch date count in CLI import statistics output

The new statistics show how many of the imported vulnerabilities include patch publication date information from CrowdStrike API, helping users understand data completeness.