### PR TITLE
Add CLI command for manual vulnerability entry

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,20 +5,18 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
+      <change afterPath="$PROJECT_DIR$/scripts/test/addvuln.sh" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.specify/scripts/bash/create-new-feature.sh" beforeDir="false" afterPath="$PROJECT_DIR$/.specify/scripts/bash/create-new-feature.sh" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.specify/scripts/bash/update-agent-context.sh" beforeDir="false" afterPath="$PROJECT_DIR$/.specify/scripts/bash/update-agent-context.sh" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/CLAUDE.md" beforeDir="false" afterPath="$PROJECT_DIR$/CLAUDE.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/ENVIRONMENT.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/ENVIRONMENT.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/DomainVulnsController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/DomainVulnsController.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/dto/DomainVulnsSummaryDto.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/dto/DomainVulnsSummaryDto.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/CLI.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/CLI.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/DomainVulnsService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/DomainVulnsService.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/resources/application.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/CrowdStrikeVulnerabilityLookup.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/CrowdStrikeVulnerabilityLookup.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/DomainVulnsView.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/DomainVulnsView.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/Login.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/Login.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/frontend/src/services/domainVulnsService.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/services/domainVulnsService.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/QueryCommand.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/QueryCommand.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -94,36 +92,36 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_MARK_IGNORED_FILES_AS_EXCLUDED&quot;: &quot;true&quot;,
-    &quot;Gradle.OAuthServiceTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.backendng [build].executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;SHELLCHECK.PATH&quot;: &quot;/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.1/plugins/Shell Script/shellcheck&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/flake/sources/misc/secman&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.12135923&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.409894&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/flake/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_MARK_IGNORED_FILES_AS_EXCLUDED": "true",
+    "Gradle.OAuthServiceTest.executor": "Run",
+    "Gradle.backendng [build].executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
+    "git-widget-placeholder": "052-cli-add-vulnerability",
+    "junie.onboarding.icon.badge.shown": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/flake/sources/misc/secman",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.12135923",
+    "project.structure.side.proportion": "0.409894",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "ts.external.directory.path": "/Users/flake/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;mariadb&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "mariadb"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scripts/install/db" />

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -128,32 +128,23 @@ get_highest_from_branches() {
 
 # Function to check existing branches (local and remote) and return next available number
 check_existing_branches() {
-    local short_name="$1"
-    local specs_dir="$2"
-    
+    local specs_dir="$1"
+
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
     git fetch --all --prune 2>/dev/null || true
-    
-    # Find all branches matching the pattern using git ls-remote (more reliable)
-    local remote_branches=$(git ls-remote --heads origin 2>/dev/null | grep -E "refs/heads/[0-9]+-${short_name}$" | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n)
-    
-    # Also check local branches
-    local local_branches=$(git branch 2>/dev/null | grep -E "^[* ]*[0-9]+-${short_name}$" | sed 's/^[* ]*//' | sed 's/-.*//' | sort -n)
-    
-    # Check specs directory as well
-    local spec_dirs=""
-    if [ -d "$specs_dir" ]; then
-        spec_dirs=$(find "$specs_dir" -maxdepth 1 -type d -name "[0-9]*-${short_name}" 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/-.*//' | sort -n)
+
+    # Get highest number from ALL branches (not just matching short name)
+    local highest_branch=$(get_highest_from_branches)
+
+    # Get highest number from ALL specs (not just matching short name)
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
+
+    # Take the maximum of both
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
     fi
-    
-    # Combine all sources and get the highest number
-    local max_num=0
-    for num in $remote_branches $local_branches $spec_dirs; do
-        if [ "$num" -gt "$max_num" ]; then
-            max_num=$num
-        fi
-    done
-    
+
     # Return next number
     echo $((max_num + 1))
 }
@@ -247,7 +238,7 @@ fi
 if [ -z "$BRANCH_NUMBER" ]; then
     if [ "$HAS_GIT" = true ]; then
         # Check existing branches on remotes
-        BRANCH_NUMBER=$(check_existing_branches "$BRANCH_SUFFIX" "$SPECS_DIR")
+        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
     else
         # Fall back to local directory check
         HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
@@ -255,7 +246,8 @@ if [ -z "$BRANCH_NUMBER" ]; then
     fi
 fi
 
-FEATURE_NUM=$(printf "%03d" "$BRANCH_NUMBER")
+# Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
 BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 
 # GitHub enforces a 244-byte limit on branch names

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -30,12 +30,12 @@
 #
 # 5. Multi-Agent Support
 #    - Handles agent-specific file paths and naming conventions
-#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Amp, SHAI, or Amazon Q Developer CLI
+#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, or Amazon Q Developer CLI
 #    - Can update single agents or all existing agent files
 #    - Creates default Claude file if no agent files exist
 #
 # Usage: ./update-agent-context.sh [agent_type]
-# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|shai|q
+# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|shai|q|bob|qoder
 # Leave empty to update all existing agent files
 
 set -e
@@ -70,9 +70,11 @@ KILOCODE_FILE="$REPO_ROOT/.kilocode/rules/specify-rules.md"
 AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 CODEBUDDY_FILE="$REPO_ROOT/CODEBUDDY.md"
+QODER_FILE="$REPO_ROOT/QODER.md"
 AMP_FILE="$REPO_ROOT/AGENTS.md"
 SHAI_FILE="$REPO_ROOT/SHAI.md"
 Q_FILE="$REPO_ROOT/AGENTS.md"
+BOB_FILE="$REPO_ROOT/AGENTS.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -616,6 +618,9 @@ update_specific_agent() {
         codebuddy)
             update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
             ;;
+        qoder)
+            update_agent_file "$QODER_FILE" "Qoder CLI"
+            ;;
         amp)
             update_agent_file "$AMP_FILE" "Amp"
             ;;
@@ -625,9 +630,12 @@ update_specific_agent() {
         q)
             update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
             ;;
+        bob)
+            update_agent_file "$BOB_FILE" "IBM Bob"
+            ;;
         *)
             log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|shai|q"
+            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|shai|q|bob|qoder"
             exit 1
             ;;
     esac
@@ -697,8 +705,18 @@ update_all_existing_agents() {
         found_agent=true
     fi
 
+    if [[ -f "$QODER_FILE" ]]; then
+        update_agent_file "$QODER_FILE" "Qoder CLI"
+        found_agent=true
+    fi
+
     if [[ -f "$Q_FILE" ]]; then
         update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
+        found_agent=true
+    fi
+    
+    if [[ -f "$BOB_FILE" ]]; then
+        update_agent_file "$BOB_FILE" "IBM Bob"
         found_agent=true
     fi
     
@@ -726,7 +744,7 @@ print_summary() {
     
     echo
 
-    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|shai|q]"
+    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|shai|q|bob|qoder]"
 }
 
 #==============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Users access assets if **ANY** is true:
 
 **User Profile (051)**: GET /api/users/profile, PUT /api/users/profile/change-password (LOCAL users only), GET /api/users/profile/mfa-status, PUT /api/users/profile/mfa-toggle
 
+**CLI Add Vulnerability (052)**: POST /api/vulnerabilities/cli-add (ADMIN/VULN) - Add or update vulnerability for a hostname with auto-asset creation
+
 ## Development
 
 **Git**: Commits `type(scope): description`, Branches `###-feature-name`
@@ -68,6 +70,7 @@ Users access assets if **ANY** is true:
 - Frontend: `npm run dev`
 - CLI Notifications: `./gradlew cli:run --args='send-notifications [--dry-run] [--verbose] [--outdated-only]'`
 - CLI User Mappings (049): `./gradlew cli:run --args='manage-user-mappings <subcommand>'` (see `src/cli/src/main/resources/cli-docs/USER_MAPPING_COMMANDS.md`)
+- CLI Add Vulnerability (052): `./gradlew cli:run --args='add-vulnerability --hostname <host> --cve <cve> --criticality <CRITICAL|HIGH|MEDIUM|LOW> [--days-open <n>] --username <user> --password <pass>'`
 
 **Principles**:
 1. Security-First: File validation, input sanitization, RBAC, security review required
@@ -169,6 +172,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 12 (existing mcp_api_keys, mcp_audit_logs tables, users table) (050-mcp-user-delegation)
 - Kotlin 2.2.21 / Java 21 (backend), TypeScript (frontend with Astro 5.15 + React 19) + Micronaut 4.10, Hibernate JPA (backend), Astro 5.15, React 19, Bootstrap 5.3 (frontend) (051-user-password-change)
 - MariaDB 12 (existing users table, Flyway migration) (051-user-password-change)
+- Kotlin 2.2.21 / Java 21 + Micronaut 4.10, Picocli 4.7, Hibernate JPA (052-cli-add-vulnerability)
+- MariaDB 12 (existing Asset, Vulnerability entities) (052-cli-add-vulnerability)
 
 ## Recent Changes
 - 048-prevent-duplicate-vulnerabilities: Fixed critical 99% data loss bug by removing JPA cascade from Asset.vulnerabilities; added transactional replace pattern for duplicate prevention, comprehensive documentation

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,9 +1,9 @@
 # Secman CLI Reference
 
-**Last Updated:** 2025-11-26
+**Last Updated:** 2025-12-07
 **Version:** 1.0
 
-Command-line interface for CrowdStrike vulnerability queries, notifications, and user mapping management.
+Command-line interface for CrowdStrike vulnerability queries, notifications, user mapping management, and manual vulnerability entry.
 
 ---
 
@@ -25,6 +25,7 @@ The Secman CLI provides command-line access to:
 - Query CrowdStrike Falcon API for vulnerabilities
 - Send automated notification emails for outdated assets
 - Manage user-to-asset mappings (AWS accounts, AD domains)
+- Manually add vulnerabilities for assets (with auto-asset creation)
 - Export vulnerability data to JSON/CSV
 
 ### Requirements
@@ -235,6 +236,74 @@ java -jar secman-cli.jar manage-user-mappings remove --id 42
 | `add-domain` | Add AD domain mapping |
 | `import` | Bulk import from CSV/JSON |
 | `remove` | Remove mapping by ID |
+
+### Add Vulnerability
+
+Manually add or update vulnerability records for assets.
+
+```bash
+# Basic usage - add vulnerability to existing asset
+java -jar secman-cli.jar add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --username admin \
+  --password secret
+
+# With days open (how long vulnerability has been present)
+java -jar secman-cli.jar add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality CRITICAL \
+  --days-open 30 \
+  --username admin \
+  --password secret
+
+# Auto-creates asset if hostname not found
+java -jar secman-cli.jar add-vulnerability \
+  --hostname newserver99 \
+  --cve CVE-2024-5678 \
+  --criticality MEDIUM \
+  --username admin \
+  --password secret
+
+# Update existing vulnerability (upsert pattern)
+java -jar secman-cli.jar add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 45 \
+  --username admin \
+  --password secret
+
+# With custom backend URL and verbose output
+java -jar secman-cli.jar add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --backend-url https://api.yourdomain.com \
+  --username admin \
+  --password secret \
+  --verbose
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--hostname` | Target asset hostname (required) | - |
+| `--cve` | CVE identifier or custom ID (required) | - |
+| `--criticality` | CRITICAL, HIGH, MEDIUM, or LOW (required) | - |
+| `--days-open` | Days the vulnerability has been open | 0 |
+| `--username` | Backend authentication username (required) | - |
+| `--password` | Backend authentication password (required) | - |
+| `--backend-url` | Backend API URL | http://localhost:8080 |
+| `--verbose` | Show detailed output | false |
+
+**Behavior:**
+- **Upsert pattern**: If same CVE exists for asset, updates instead of creating duplicate
+- **Auto-create**: If hostname not found, creates asset with type=SERVER, owner=CLI-IMPORT
+- **Exit codes**: 0=success, 1=validation/auth error, 2=connection error
 
 ### Manage Workgroups
 
@@ -574,6 +643,7 @@ exit 0
 - [CrowdStrike Import](./CROWDSTRIKE_IMPORT.md) - Import technical details
 - [User Mapping Commands](../src/cli/src/main/resources/cli-docs/USER_MAPPING_COMMANDS.md) - Detailed user mapping CLI subcommands
 - [Workgroup Commands](../src/cli/src/main/resources/cli-docs/WORKGROUP_COMMANDS.md) - Detailed workgroup management CLI subcommands
+- [Add Vulnerability Command](../src/cli/src/main/resources/cli-docs/ADD_VULNERABILITY_COMMANDS.md) - Detailed add-vulnerability CLI command
 
 ---
 

--- a/scripts/test/addvuln.sh
+++ b/scripts/test/addvuln.sh
@@ -1,0 +1,1 @@
+./gradlew :cli:run --args="add-vulnerability  --hostname X --cve CVE-2023-5678 --criticality CRITICAL --days-open 1000 --username adminuser --password Test4321% --backend-url http://127.0.0.1:8080"

--- a/specs/052-cli-add-vulnerability/checklists/requirements.md
+++ b/specs/052-cli-add-vulnerability/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: CLI Add Vulnerability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Key assumptions documented: authentication mechanism, hostname matching behavior, default asset type, CVE format flexibility, days-open defaults

--- a/specs/052-cli-add-vulnerability/contracts/api.yaml
+++ b/specs/052-cli-add-vulnerability/contracts/api.yaml
@@ -1,0 +1,193 @@
+openapi: 3.0.3
+info:
+  title: CLI Add Vulnerability API
+  version: 1.0.0
+  description: Backend endpoint for CLI vulnerability addition
+
+servers:
+  - url: http://localhost:8080
+    description: Local development
+
+paths:
+  /api/vulnerabilities/cli-add:
+    post:
+      summary: Add or update a vulnerability via CLI
+      description: |
+        Creates a new vulnerability record for the specified hostname.
+        - If hostname doesn't exist, creates the asset first
+        - If CVE already exists for the asset, updates the existing record (upsert)
+        - Requires authentication with ADMIN or VULN role
+      operationId: addVulnerabilityFromCli
+      tags:
+        - Vulnerabilities
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddVulnerabilityRequest'
+            examples:
+              newVulnerability:
+                summary: Add new vulnerability to existing asset
+                value:
+                  hostname: "webserver01"
+                  cve: "CVE-2024-1234"
+                  criticality: "HIGH"
+                  daysOpen: 30
+              withAutoCreate:
+                summary: Add vulnerability with auto-created asset
+                value:
+                  hostname: "newserver99"
+                  cve: "CVE-2023-5678"
+                  criticality: "CRITICAL"
+                  daysOpen: 15
+      responses:
+        '200':
+          description: Vulnerability added or updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddVulnerabilityResponse'
+              examples:
+                created:
+                  summary: New vulnerability created
+                  value:
+                    success: true
+                    message: "Vulnerability CVE-2024-1234 added to asset webserver01"
+                    assetName: "webserver01"
+                    assetCreated: false
+                    vulnerabilityId: "CVE-2024-1234"
+                    operation: "CREATED"
+                updated:
+                  summary: Existing vulnerability updated
+                  value:
+                    success: true
+                    message: "Vulnerability CVE-2024-1234 updated on asset webserver01"
+                    assetName: "webserver01"
+                    assetCreated: false
+                    vulnerabilityId: "CVE-2024-1234"
+                    operation: "UPDATED"
+                withAssetCreated:
+                  summary: Asset auto-created
+                  value:
+                    success: true
+                    message: "Asset newserver99 created. Vulnerability CVE-2023-5678 added."
+                    assetName: "newserver99"
+                    assetCreated: true
+                    vulnerabilityId: "CVE-2023-5678"
+                    operation: "CREATED"
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidCriticality:
+                  summary: Invalid criticality value
+                  value:
+                    error: "Validation failed"
+                    message: "Criticality must be CRITICAL, HIGH, MEDIUM, or LOW"
+                missingHostname:
+                  summary: Missing required field
+                  value:
+                    error: "Validation failed"
+                    message: "Hostname is required"
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "Unauthorized"
+                message: "Authentication required"
+        '403':
+          description: Insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "Forbidden"
+                message: "ADMIN or VULN role required"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    AddVulnerabilityRequest:
+      type: object
+      required:
+        - hostname
+        - cve
+        - criticality
+      properties:
+        hostname:
+          type: string
+          description: Target asset hostname (case-insensitive lookup)
+          example: "webserver01"
+          minLength: 1
+          maxLength: 255
+        cve:
+          type: string
+          description: CVE identifier or custom vulnerability ID
+          example: "CVE-2024-1234"
+          minLength: 1
+          maxLength: 255
+        criticality:
+          type: string
+          description: Severity level
+          enum:
+            - CRITICAL
+            - HIGH
+            - MEDIUM
+            - LOW
+          example: "HIGH"
+        daysOpen:
+          type: integer
+          description: Number of days the vulnerability has been open (default 0)
+          minimum: 0
+          default: 0
+          example: 30
+
+    AddVulnerabilityResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Whether the operation succeeded
+        message:
+          type: string
+          description: Human-readable result message
+        assetName:
+          type: string
+          description: Name of the asset (existing or newly created)
+        assetCreated:
+          type: boolean
+          description: True if asset was auto-created
+        vulnerabilityId:
+          type: string
+          description: CVE identifier of the vulnerability
+        operation:
+          type: string
+          enum:
+            - CREATED
+            - UPDATED
+          description: Whether vulnerability was created or updated
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error type
+        message:
+          type: string
+          description: Error details

--- a/specs/052-cli-add-vulnerability/data-model.md
+++ b/specs/052-cli-add-vulnerability/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: CLI Add Vulnerability
+
+**Feature**: 052-cli-add-vulnerability
+**Date**: 2025-12-07
+
+## Overview
+
+This feature uses existing entities (Asset, Vulnerability) with no schema changes. Only new repository methods are required.
+
+---
+
+## Existing Entities (No Changes)
+
+### Asset
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/Asset.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| name | String | NOT NULL, max 255 | Hostname for matching |
+| type | String | NOT NULL | Default "SERVER" for auto-created |
+| owner | String | NOT NULL, max 255 | Default "CLI-IMPORT" for auto-created |
+| createdAt | LocalDateTime | auto-set | |
+| lastSeen | LocalDateTime | nullable | Set to current time |
+
+**Relevant method**: `findByNameIgnoreCase(name: String): Asset?`
+
+---
+
+### Vulnerability
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| asset | Asset | FK, NOT NULL | ManyToOne relationship |
+| vulnerabilityId | String | max 255 | CVE identifier |
+| cvssSeverity | String | max 50 | "Critical", "High", "Medium", "Low" |
+| daysOpen | String | max 50 | Display text, e.g., "30 days" |
+| scanTimestamp | LocalDateTime | NOT NULL | Calculated from daysOpen |
+| importTimestamp | LocalDateTime | nullable | Set to current time |
+| createdAt | LocalDateTime | auto-set | |
+
+---
+
+## New Repository Method
+
+### VulnerabilityRepository
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt`
+
+**New Method**:
+```kotlin
+/**
+ * Find vulnerability by asset and CVE ID for upsert operation
+ * Feature: 052-cli-add-vulnerability (FR-014)
+ *
+ * @param asset The asset entity
+ * @param vulnerabilityId The CVE identifier
+ * @return The vulnerability if found, null otherwise
+ */
+fun findByAssetAndVulnerabilityId(asset: Asset, vulnerabilityId: String): Vulnerability?
+```
+
+**Purpose**: Enables upsert pattern - find existing vulnerability to update, or return null for insert.
+
+---
+
+## New DTO
+
+### AddVulnerabilityRequestDto
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityRequestDto.kt`
+
+```kotlin
+@Serdeable
+data class AddVulnerabilityRequestDto(
+    @field:NotBlank
+    val hostname: String,
+
+    @field:NotBlank
+    val cve: String,
+
+    @field:NotBlank
+    @field:Pattern(regexp = "CRITICAL|HIGH|MEDIUM|LOW", message = "Criticality must be CRITICAL, HIGH, MEDIUM, or LOW")
+    val criticality: String,
+
+    @field:Min(0)
+    val daysOpen: Int = 0
+)
+```
+
+### AddVulnerabilityResponseDto
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt`
+
+```kotlin
+@Serdeable
+data class AddVulnerabilityResponseDto(
+    val success: Boolean,
+    val message: String,
+    val assetName: String,
+    val assetCreated: Boolean,
+    val vulnerabilityId: String,
+    val operation: String  // "CREATED" or "UPDATED"
+)
+```
+
+---
+
+## State Transitions
+
+### Vulnerability Lifecycle
+
+```
+[CLI Input]
+    ↓
+[Lookup Asset by hostname]
+    ↓
+┌─────────────────────────────────────┐
+│ Asset exists?                       │
+│   YES → use existing asset          │
+│   NO  → create new asset            │
+└─────────────────────────────────────┘
+    ↓
+[Lookup Vulnerability by asset+CVE]
+    ↓
+┌─────────────────────────────────────┐
+│ Vulnerability exists?               │
+│   YES → UPDATE (daysOpen, severity) │
+│   NO  → INSERT new vulnerability    │
+└─────────────────────────────────────┘
+    ↓
+[Return response with operation type]
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule | Error Message |
+|-------|------|---------------|
+| hostname | Required, non-blank | "Hostname is required" |
+| cve | Required, non-blank | "CVE is required" |
+| criticality | Must be CRITICAL/HIGH/MEDIUM/LOW | "Criticality must be CRITICAL, HIGH, MEDIUM, or LOW" |
+| daysOpen | Must be >= 0 | "Days open must be a positive number or zero" |
+
+---
+
+## Index Usage
+
+Existing indexes used by this feature:
+
+| Table | Index | Used By |
+|-------|-------|---------|
+| asset | idx_asset_name | `findByNameIgnoreCase()` |
+| vulnerability | idx_vulnerability_asset_cve | `findByAssetAndVulnerabilityId()` (new method uses existing index) |
+
+No new indexes required.

--- a/specs/052-cli-add-vulnerability/plan.md
+++ b/specs/052-cli-add-vulnerability/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: CLI Add Vulnerability
+
+**Branch**: `052-cli-add-vulnerability` | **Date**: 2025-12-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/052-cli-add-vulnerability/spec.md`
+
+## Summary
+
+Implement a CLI command `add-vulnerability` that allows manual vulnerability entry for a given hostname. The command accepts CVE, criticality, and days-open parameters. If the hostname doesn't exist, create the asset automatically. Uses upsert pattern - if the same CVE already exists for the asset, update it instead of creating a duplicate.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.2.21 / Java 21
+**Primary Dependencies**: Micronaut 4.10, Picocli 4.7, Hibernate JPA
+**Storage**: MariaDB 12 (existing Asset, Vulnerability entities)
+**Testing**: N/A (per constitution - user-requested only)
+**Target Platform**: Linux/macOS CLI (JVM-based)
+**Project Type**: CLI module within monorepo
+**Performance Goals**: Single command execution < 5 seconds
+**Constraints**: Must use existing backend API authentication pattern
+**Scale/Scope**: Single vulnerability per invocation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | Uses existing JWT auth; input sanitization via Picocli validation |
+| III. API-First | PASS | CLI calls backend REST API `/api/vulnerabilities/cli-add` |
+| IV. User-Requested Testing | PASS | No test tasks included (not requested) |
+| V. RBAC | PASS | Requires authentication; backend enforces ADMIN or VULN role |
+| VI. Schema Evolution | PASS | Uses existing entities; new repository method only |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/052-cli-add-vulnerability/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cli/src/main/kotlin/com/secman/cli/
+│   ├── commands/
+│   │   └── AddVulnerabilityCommand.kt   # NEW: Picocli command
+│   ├── service/
+│   │   └── VulnerabilityCliService.kt   # NEW: CLI service layer
+│   └── SecmanCli.kt                     # MODIFY: Add command routing
+│
+├── backendng/src/main/kotlin/com/secman/
+│   ├── controller/
+│   │   └── VulnerabilityManagementController.kt  # MODIFY: Add CLI endpoint
+│   ├── service/
+│   │   └── VulnerabilityService.kt               # MODIFY: Add upsert method
+│   ├── repository/
+│   │   └── VulnerabilityRepository.kt            # MODIFY: Add findByAssetAndVulnerabilityId
+│   └── dto/
+│       └── AddVulnerabilityRequestDto.kt         # NEW: Request DTO
+```
+
+**Structure Decision**: CLI module with backend API integration (matches existing `manage-user-mappings` pattern)
+
+## Complexity Tracking
+
+> No violations - implementation uses existing patterns with minimal additions.

--- a/specs/052-cli-add-vulnerability/quickstart.md
+++ b/specs/052-cli-add-vulnerability/quickstart.md
@@ -1,0 +1,171 @@
+# Quickstart: CLI Add Vulnerability
+
+**Feature**: 052-cli-add-vulnerability
+
+## Usage
+
+### Basic Command
+
+```bash
+# Add vulnerability to existing asset
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 30 \
+  --username admin \
+  --password secret'
+```
+
+### With Auto-Created Asset
+
+```bash
+# If hostname doesn't exist, asset is created automatically
+./gradlew cli:run --args='add-vulnerability \
+  --hostname newserver99 \
+  --cve CVE-2023-5678 \
+  --criticality CRITICAL \
+  --days-open 15 \
+  --username admin \
+  --password secret'
+```
+
+### Using Custom Backend URL
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality MEDIUM \
+  --days-open 0 \
+  --backend-url http://api.example.com:8080 \
+  --username admin \
+  --password secret'
+```
+
+### With Verbose Output
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 30 \
+  --username admin \
+  --password secret \
+  --verbose'
+```
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `--hostname` | Yes | - | Target asset hostname |
+| `--cve` | Yes | - | CVE identifier (e.g., CVE-2024-1234) |
+| `--criticality` | Yes | - | CRITICAL, HIGH, MEDIUM, or LOW |
+| `--days-open` | No | 0 | Number of days vulnerability has been open |
+| `--username` | Yes | - | Backend username for authentication |
+| `--password` | Yes | - | Backend password for authentication |
+| `--backend-url` | No | http://localhost:8080 | Backend API URL |
+| `--verbose` | No | false | Enable detailed logging |
+
+## Output Examples
+
+### Successful Creation
+
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+✅ Authentication successful
+
+Processing vulnerability...
+Hostname: webserver01
+CVE: CVE-2024-1234
+Criticality: HIGH
+Days Open: 30
+
+✅ Vulnerability CVE-2024-1234 added to asset webserver01
+
+============================================================
+Summary
+============================================================
+Asset: webserver01
+Operation: CREATED
+```
+
+### Asset Auto-Created
+
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+✅ Authentication successful
+
+Processing vulnerability...
+Hostname: newserver99
+CVE: CVE-2023-5678
+Criticality: CRITICAL
+Days Open: 15
+
+⚠️  Asset newserver99 created (type: SERVER, owner: CLI-IMPORT)
+✅ Vulnerability CVE-2023-5678 added to asset newserver99
+
+============================================================
+Summary
+============================================================
+Asset: newserver99 (auto-created)
+Operation: CREATED
+```
+
+### Existing Vulnerability Updated
+
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+✅ Authentication successful
+
+Processing vulnerability...
+Hostname: webserver01
+CVE: CVE-2024-1234
+Criticality: HIGH
+Days Open: 45
+
+✅ Vulnerability CVE-2024-1234 updated on asset webserver01
+
+============================================================
+Summary
+============================================================
+Asset: webserver01
+Operation: UPDATED (existing vulnerability)
+```
+
+### Validation Error
+
+```
+❌ Error: Criticality must be CRITICAL, HIGH, MEDIUM, or LOW
+   Received: IMPORTANT
+
+Usage: add-vulnerability --hostname <host> --cve <cve> --criticality <level> [options]
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Validation error or authentication failure |
+| 2 | Backend connection error |
+
+## Prerequisites
+
+1. Backend server running at specified URL
+2. User with ADMIN or VULN role
+3. Network connectivity to backend

--- a/specs/052-cli-add-vulnerability/research.md
+++ b/specs/052-cli-add-vulnerability/research.md
@@ -1,0 +1,132 @@
+# Research: CLI Add Vulnerability
+
+**Feature**: 052-cli-add-vulnerability
+**Date**: 2025-12-07
+
+## Research Summary
+
+All technical decisions are based on existing codebase patterns. No external research needed.
+
+---
+
+## Decision 1: CLI Command Pattern
+
+**Decision**: Use Picocli with Micronaut DI (matching `manage-user-mappings` pattern)
+
+**Rationale**:
+- Existing pattern in `ManageUserMappingsCommand.kt` and `AddDomainCommand.kt`
+- Picocli provides parameter validation, help generation, and type conversion
+- Micronaut DI allows injection of HTTP client and services
+
+**Alternatives considered**:
+- Manual arg parsing (like `QueryCommand`) - rejected for complexity
+- Separate executable - rejected for code reuse
+
+**Reference**: `src/cli/src/main/kotlin/com/secman/cli/commands/AddDomainCommand.kt:22-30`
+
+---
+
+## Decision 2: Backend API Integration
+
+**Decision**: Create new endpoint `POST /api/vulnerabilities/cli-add` with upsert logic
+
+**Rationale**:
+- Follows API-first principle from constitution
+- Allows RBAC enforcement at controller level
+- Separates CLI from direct database access
+- Existing `VulnerabilityStorageService.kt` uses HTTP client pattern
+
+**Alternatives considered**:
+- Direct database access from CLI - rejected (violates RBAC principle)
+- Reuse existing `/api/crowdstrike/vulnerabilities/save` - rejected (different payload structure, batch-oriented)
+
+**Reference**: `src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityStorageService.kt:41-70`
+
+---
+
+## Decision 3: Upsert Implementation
+
+**Decision**: Add `findByAssetAndVulnerabilityId()` to VulnerabilityRepository, use update-or-create in service
+
+**Rationale**:
+- Micronaut Data JPA supports derived query methods
+- Keeps logic in service layer (not raw SQL)
+- Matches existing patterns in AssetRepository
+
+**Implementation**:
+```kotlin
+// VulnerabilityRepository.kt
+fun findByAssetAndVulnerabilityId(asset: Asset, vulnerabilityId: String): Vulnerability?
+```
+
+**Alternatives considered**:
+- Native SQL UPSERT - rejected (less portable, harder to test)
+- Delete-then-insert - rejected (loses created_at timestamp)
+
+**Reference**: `src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt:41`
+
+---
+
+## Decision 4: Asset Auto-Creation
+
+**Decision**: Use existing `findByNameIgnoreCase()` + create pattern
+
+**Rationale**:
+- Case-insensitive lookup prevents duplicates
+- Default type "SERVER" and owner "CLI-IMPORT" match spec requirements
+- Existing pattern in CrowdStrike import flow
+
+**Reference**: `src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt:41`
+
+---
+
+## Decision 5: Authentication Flow
+
+**Decision**: Reuse `VulnerabilityStorageService.authenticate()` pattern
+
+**Rationale**:
+- Already handles JWT token exchange
+- Uses `--username` and `--password` parameters
+- Returns token for subsequent API calls
+
+**Reference**: `src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityStorageService.kt:41-70`
+
+---
+
+## Decision 6: Criticality Mapping
+
+**Decision**: Map CLI input (CRITICAL/HIGH/MEDIUM/LOW) to database format (Critical/High/Medium/Low)
+
+**Rationale**:
+- Database uses title case for cvss_severity
+- CLI input is uppercase for user convenience
+- Simple string transformation in service layer
+
+**Mapping**:
+| CLI Input | Database Value |
+|-----------|----------------|
+| CRITICAL | Critical |
+| HIGH | High |
+| MEDIUM | Medium |
+| LOW | Low |
+
+**Reference**: `src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt:60`
+
+---
+
+## Decision 7: Days Open Calculation
+
+**Decision**: Calculate `scan_timestamp` as `LocalDateTime.now().minusDays(daysOpen)`
+
+**Rationale**:
+- Matches existing Vulnerability entity structure
+- `daysOpen` stored as text (e.g., "30 days") for display
+- `scan_timestamp` enables accurate overdue calculations
+
+**Reference**: `src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt:69-70`
+
+---
+
+## Open Questions
+
+None - all technical decisions resolved based on existing patterns.

--- a/specs/052-cli-add-vulnerability/spec.md
+++ b/specs/052-cli-add-vulnerability/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: CLI Add Vulnerability
+
+**Feature Branch**: `052-cli-add-vulnerability`
+**Created**: 2025-12-07
+**Status**: Draft
+**Input**: User description: "implement a command line function to add a vulnerability for a given hostname, i want to add CVE number, criticality and days open. If a hostname is not yet found, create the asset in secman."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add Vulnerability to Existing Asset (Priority: P1)
+
+A security analyst wants to manually add a vulnerability record to an asset that already exists in secman. This is useful for recording vulnerabilities discovered through manual penetration testing, security audits, or external reports that are not automatically imported from CrowdStrike.
+
+**Why this priority**: This is the core functionality - adding vulnerabilities is the primary use case, and most assets will already exist in the system from prior imports.
+
+**Independent Test**: Can be fully tested by running the CLI command with a valid CVE, criticality, days open, and an existing hostname - the vulnerability appears in the asset's vulnerability list.
+
+**Acceptance Scenarios**:
+
+1. **Given** an asset named "webserver01" exists in secman, **When** the user runs `secman add-vulnerability --hostname webserver01 --cve CVE-2024-1234 --criticality HIGH --days-open 30`, **Then** a new vulnerability record is created linked to the asset with the specified CVE, criticality, and days open value
+2. **Given** an asset named "dbserver02" exists in secman, **When** the user runs the add-vulnerability command with valid parameters, **Then** the system confirms successful creation and displays the created vulnerability details
+3. **Given** an asset exists in secman, **When** the user adds a vulnerability with criticality "CRITICAL", **Then** the vulnerability is stored with cvss_severity set to "Critical"
+
+---
+
+### User Story 2 - Add Vulnerability with Auto-Created Asset (Priority: P2)
+
+A security analyst wants to add a vulnerability for a hostname that does not yet exist in secman. The system should automatically create the asset before linking the vulnerability to it.
+
+**Why this priority**: Asset auto-creation enables complete workflows without requiring separate asset creation steps, making the CLI more user-friendly.
+
+**Independent Test**: Can be fully tested by running the CLI command with a non-existent hostname - the asset is created and the vulnerability is linked to it.
+
+**Acceptance Scenarios**:
+
+1. **Given** no asset named "newserver99" exists in secman, **When** the user runs `secman add-vulnerability --hostname newserver99 --cve CVE-2023-5678 --criticality MEDIUM --days-open 15`, **Then** the system creates a new asset named "newserver99" with default type "SERVER" and owner "CLI-IMPORT", then creates the vulnerability linked to it
+2. **Given** no asset with the specified hostname exists, **When** the user runs the add-vulnerability command, **Then** the system displays a message indicating the asset was auto-created before confirming vulnerability creation
+3. **Given** no asset exists, **When** the asset is auto-created, **Then** the created_at and last_seen timestamps are set to the current time
+
+---
+
+### User Story 3 - Validation and Error Handling (Priority: P3)
+
+A user attempts to add a vulnerability with invalid or incomplete data. The system should provide clear validation errors.
+
+**Why this priority**: Good error handling improves usability and prevents bad data from entering the system.
+
+**Independent Test**: Can be fully tested by running commands with various invalid inputs and verifying appropriate error messages are displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** any system state, **When** the user runs the command without a required parameter (hostname, CVE, or criticality), **Then** the system displays a clear error message indicating which parameter is missing
+2. **Given** any system state, **When** the user provides an invalid criticality value (not CRITICAL/HIGH/MEDIUM/LOW), **Then** the system displays an error listing valid criticality options
+3. **Given** any system state, **When** the user provides a negative days-open value, **Then** the system displays an error that days-open must be a positive number or zero
+
+---
+
+### Edge Cases
+
+- What happens when the CVE already exists for the same asset? System uses upsert pattern - updates existing record with new days-open value
+- How does the system handle CVE format validation? Accept any string format for flexibility (manual entries may use non-standard identifiers)
+- What happens when database connection fails? Display connection error and exit with non-zero code
+- What happens when days-open is 0? Allow it - represents a newly discovered vulnerability
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a CLI command `add-vulnerability` to create vulnerability records
+- **FR-002**: System MUST require `--hostname`, `--cve`, and `--criticality` parameters
+- **FR-003**: System MUST support optional `--days-open` parameter (defaults to 0 if not provided)
+- **FR-004**: System MUST validate criticality against allowed values: CRITICAL, HIGH, MEDIUM, LOW
+- **FR-005**: System MUST look up existing asset by hostname (case-insensitive match)
+- **FR-006**: System MUST auto-create asset if hostname not found, with type "SERVER" and owner "CLI-IMPORT"
+- **FR-007**: System MUST calculate scan_timestamp from days-open value (current date minus days open)
+- **FR-008**: System MUST store the days_open value as text (e.g., "30 days")
+- **FR-009**: System MUST require authentication via `--username` and `--password` flags for database write operations
+- **FR-010**: System MUST display confirmation message on successful creation including asset name and vulnerability details
+- **FR-011**: System MUST exit with non-zero code on validation or database errors
+- **FR-012**: System MUST support `--verbose` flag for detailed logging output
+- **FR-013**: System MUST support `--backend-url` parameter for specifying the API endpoint (defaults to http://localhost:8080)
+- **FR-014**: System MUST use upsert pattern - if vulnerability with same CVE exists for the asset, update the existing record (days-open, scan_timestamp, criticality) instead of creating a duplicate
+
+### Key Entities
+
+- **Asset**: Host/server record - uses existing entity with name, type, owner, lastSeen attributes
+- **Vulnerability**: Security vulnerability record - uses existing entity with vulnerabilityId (CVE), cvssSeverity, daysOpen, scanTimestamp, asset relationship
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can add a vulnerability to an existing asset in a single command execution
+- **SC-002**: Users can add a vulnerability to a new hostname without pre-creating the asset
+- **SC-003**: All required parameter validation errors are displayed before any database operations occur
+- **SC-004**: Added vulnerabilities appear in the asset's vulnerability list through the web interface and API
+- **SC-005**: Command provides clear success/failure feedback with appropriate exit codes
+
+## Clarifications
+
+### Session 2025-12-07
+
+- Q: How should duplicate vulnerabilities (same CVE + same asset) be handled? → A: Overwrite existing entry in database and adapt "days open" (upsert pattern)
+
+## Assumptions
+
+- Authentication will use the existing backend API authentication mechanism (username/password to obtain JWT)
+- Asset hostname lookup is case-insensitive (consistent with existing asset matching behavior)
+- Auto-created assets use default type "SERVER" as this is the most common use case for manual vulnerability entry
+- The CVE field accepts any string format to allow for non-CVE vulnerability identifiers
+- Days-open defaults to 0 when not specified, representing a vulnerability just discovered today

--- a/specs/052-cli-add-vulnerability/tasks.md
+++ b/specs/052-cli-add-vulnerability/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: CLI Add Vulnerability
+
+**Input**: Design documents from `/specs/052-cli-add-vulnerability/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Not requested - no test tasks included per constitution (User-Requested Testing principle).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `src/backendng/src/main/kotlin/com/secman/`
+- **CLI**: `src/cli/src/main/kotlin/com/secman/cli/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create DTOs and repository method needed by all user stories
+
+- [x] T001 [P] Create AddVulnerabilityRequestDto in src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityRequestDto.kt
+- [x] T002 [P] Create AddVulnerabilityResponseDto in src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt
+- [x] T003 Add findByAssetAndVulnerabilityId method to VulnerabilityRepository in src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt
+
+---
+
+## Phase 2: Foundational (Backend API)
+
+**Purpose**: Backend endpoint that MUST be complete before CLI can be tested
+
+**⚠️ CRITICAL**: No CLI implementation can work until this phase is complete
+
+- [x] T004 Add addVulnerabilityFromCli method to VulnerabilityService with upsert logic in src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+- [x] T005 Add POST /api/vulnerabilities/cli-add endpoint to VulnerabilityManagementController with @Secured(ADMIN, VULN) in src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
+- [x] T006 Verify backend compiles and endpoint is accessible via ./gradlew :backendng:compileKotlin
+
+**Checkpoint**: Backend API ready - CLI implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Add Vulnerability to Existing Asset (Priority: P1) 🎯 MVP
+
+**Goal**: Security analyst can add a vulnerability record to an existing asset via CLI
+
+**Independent Test**: Run `./gradlew cli:run --args='add-vulnerability --hostname <existing-asset> --cve CVE-2024-1234 --criticality HIGH --days-open 30 --username admin --password secret'` and verify vulnerability appears in asset's vulnerability list
+
+### Implementation for User Story 1
+
+- [x] T007 [P] [US1] Create VulnerabilityCliService with authenticate and addVulnerability methods in src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityCliService.kt
+- [x] T008 [P] [US1] Create AddVulnerabilityCommand Picocli command with required options (--hostname, --cve, --criticality) in src/cli/src/main/kotlin/com/secman/cli/commands/AddVulnerabilityCommand.kt
+- [x] T009 [US1] Add optional parameters (--days-open, --verbose, --backend-url) to AddVulnerabilityCommand in src/cli/src/main/kotlin/com/secman/cli/commands/AddVulnerabilityCommand.kt
+- [x] T010 [US1] Add add-vulnerability command routing to SecmanCli.kt in src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+- [x] T011 [US1] Add success message display showing asset name and vulnerability details in AddVulnerabilityCommand
+- [x] T012 [US1] Verify US1 works: compile with ./gradlew :cli:compileKotlin and test with existing asset
+
+**Checkpoint**: User Story 1 complete - can add vulnerabilities to existing assets
+
+---
+
+## Phase 4: User Story 2 - Add Vulnerability with Auto-Created Asset (Priority: P2)
+
+**Goal**: Security analyst can add a vulnerability for a new hostname, with asset auto-created
+
+**Independent Test**: Run CLI with non-existent hostname, verify asset is created with type "SERVER" and owner "CLI-IMPORT", and vulnerability is linked
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Add asset auto-creation logic (type=SERVER, owner=CLI-IMPORT) to VulnerabilityService.addVulnerabilityFromCli in src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+- [x] T014 [US2] Add assetCreated indicator to response and display message when asset is auto-created in AddVulnerabilityCommand
+- [x] T015 [US2] Verify US2 works: test with non-existent hostname, verify asset created with correct defaults
+
+**Checkpoint**: User Story 2 complete - auto-creates assets when hostname not found
+
+---
+
+## Phase 5: User Story 3 - Validation and Error Handling (Priority: P3)
+
+**Goal**: Clear error messages for invalid input before any database operations
+
+**Independent Test**: Run CLI with missing/invalid parameters, verify appropriate error messages
+
+### Implementation for User Story 3
+
+- [x] T016 [US3] Add Picocli required=true validation for --hostname, --cve, --criticality in AddVulnerabilityCommand
+- [x] T017 [US3] Add criticality enum validation (CRITICAL/HIGH/MEDIUM/LOW) with completionCandidates in AddVulnerabilityCommand
+- [x] T018 [US3] Add days-open minimum value validation (>=0) in AddVulnerabilityCommand
+- [x] T019 [US3] Add authentication error handling with clear message in VulnerabilityCliService
+- [x] T020 [US3] Add backend connection error handling with exit code 2 in VulnerabilityCliService
+- [x] T021 [US3] Verify US3 works: test with invalid criticality, missing hostname, negative days-open
+
+**Checkpoint**: User Story 3 complete - all validation errors display correctly
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update documentation and verify full integration
+
+- [x] T022 Add add-vulnerability command help text to SecmanCli.showHelp() in src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+- [x] T023 Update CLAUDE.md with new CLI command and endpoint in CLAUDE.md
+- [x] T024 Verify full build passes: ./gradlew build
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all CLI work
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion
+  - US1 can start immediately after Phase 2
+  - US2 extends US1 (adds auto-creation logic)
+  - US3 can be done in parallel with US1/US2 (validation is CLI-side)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - Core CLI command
+- **User Story 2 (P2)**: Builds on US1 - adds backend auto-creation, minor CLI change
+- **User Story 3 (P3)**: Can start after Phase 2 - CLI validation independent of US1/US2
+
+### Within Each Phase
+
+- T001, T002 can run in parallel (different files)
+- T007, T008 can run in parallel (different files)
+- Services before controller integration
+- Backend before CLI (CLI depends on API)
+
+### Parallel Opportunities
+
+- T001, T002 (Phase 1 DTOs)
+- T007, T008 (Phase 3 CLI service + command)
+- US3 validation tasks can proceed in parallel with US1/US2 implementation
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# Launch DTOs in parallel:
+Task: "Create AddVulnerabilityRequestDto in src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityRequestDto.kt"
+Task: "Create AddVulnerabilityResponseDto in src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt"
+```
+
+## Parallel Example: User Story 1 Start
+
+```bash
+# Launch CLI service and command in parallel:
+Task: "Create VulnerabilityCliService in src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityCliService.kt"
+Task: "Create AddVulnerabilityCommand in src/cli/src/main/kotlin/com/secman/cli/commands/AddVulnerabilityCommand.kt"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (DTOs + repository method)
+2. Complete Phase 2: Foundational (backend endpoint)
+3. Complete Phase 3: User Story 1 (CLI command)
+4. **STOP and VALIDATE**: Test with existing asset
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Backend API ready
+2. Add User Story 1 → Basic CLI works → **MVP!**
+3. Add User Story 2 → Auto-creation works
+4. Add User Story 3 → Validation polished
+5. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Backend must compile before CLI testing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently

--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
@@ -1,6 +1,8 @@
 package com.secman.controller
 
 import com.secman.domain.VulnerabilityException.ExceptionType
+import com.secman.dto.AddVulnerabilityRequestDto
+import com.secman.dto.AddVulnerabilityResponseDto
 import com.secman.dto.CreateVulnerabilityExceptionRequest
 import com.secman.dto.UpdateVulnerabilityExceptionRequest
 import com.secman.dto.VulnerabilityExceptionDto
@@ -503,6 +505,50 @@ open class VulnerabilityManagementController(
             log.error("Error during importTimestamp migration", e)
             HttpResponse.serverError<ErrorResponse>()
                 .body(ErrorResponse("Error during importTimestamp migration: ${e.message}"))
+        }
+    }
+
+    /**
+     * Add or update vulnerability via CLI
+     * Feature: 052-cli-add-vulnerability
+     *
+     * POST /api/vulnerabilities/cli-add
+     * Auth: ADMIN or VULN role
+     * Request: AddVulnerabilityRequestDto
+     * Response: AddVulnerabilityResponseDto (200 OK)
+     *
+     * Implements upsert pattern:
+     * - If asset doesn't exist: create it with type=SERVER, owner=CLI-IMPORT
+     * - If vulnerability with same CVE exists for asset: update it
+     * - Otherwise: create new vulnerability
+     *
+     * User Story 1: Add vulnerability to existing asset (P1)
+     * User Story 2: Add vulnerability with auto-created asset (P2)
+     */
+    @Post("/api/vulnerabilities/cli-add")
+    @Secured("ADMIN", "VULN")
+    open fun addVulnerabilityFromCli(
+        @Valid @Body request: AddVulnerabilityRequestDto,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        return try {
+            log.info("CLI add-vulnerability requested by user: {} - hostname: {}, cve: {}",
+                authentication.name, request.hostname, request.cve)
+
+            val result = vulnerabilityService.addVulnerabilityFromCli(request)
+
+            log.info("CLI add-vulnerability completed: assetName={}, operation={}, assetCreated={}",
+                result.assetName, result.operation, result.assetCreated)
+
+            HttpResponse.ok(result)
+
+        } catch (e: IllegalArgumentException) {
+            log.warn("Invalid CLI add-vulnerability request: {}", e.message)
+            HttpResponse.badRequest(ErrorResponse(e.message ?: "Invalid request"))
+        } catch (e: Exception) {
+            log.error("Error adding vulnerability via CLI", e)
+            HttpResponse.serverError<ErrorResponse>()
+                .body(ErrorResponse("Error adding vulnerability: ${e.message}"))
         }
     }
 }

--- a/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityRequestDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityRequestDto.kt
@@ -1,0 +1,29 @@
+package com.secman.dto
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+/**
+ * Request DTO for CLI add-vulnerability command
+ * Feature: 052-cli-add-vulnerability (FR-001, FR-002, FR-003, FR-004)
+ */
+@Serdeable
+data class AddVulnerabilityRequestDto(
+    @field:NotBlank(message = "Hostname is required")
+    val hostname: String,
+
+    @field:NotBlank(message = "CVE is required")
+    val cve: String,
+
+    @field:NotBlank(message = "Criticality is required")
+    @field:Pattern(
+        regexp = "CRITICAL|HIGH|MEDIUM|LOW",
+        message = "Criticality must be CRITICAL, HIGH, MEDIUM, or LOW"
+    )
+    val criticality: String,
+
+    @field:Min(value = 0, message = "Days open must be a positive number or zero")
+    val daysOpen: Int = 0
+)

--- a/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt
@@ -1,0 +1,17 @@
+package com.secman.dto
+
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Response DTO for CLI add-vulnerability command
+ * Feature: 052-cli-add-vulnerability (FR-010, FR-014)
+ */
+@Serdeable
+data class AddVulnerabilityResponseDto(
+    val success: Boolean,
+    val message: String,
+    val assetName: String,
+    val assetCreated: Boolean,
+    val vulnerabilityId: String,
+    val operation: String  // "CREATED" or "UPDATED"
+)

--- a/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityRepository.kt
@@ -827,4 +827,16 @@ interface VulnerabilityRepository : JpaRepository<Vulnerability, Long> {
         domainFilter: String?,
         pageable: Pageable
     ): Page<Vulnerability>
+
+    // Feature 052: CLI Add Vulnerability - Upsert Support
+
+    /**
+     * Find vulnerability by asset and CVE ID for upsert operation
+     * Feature: 052-cli-add-vulnerability (FR-014)
+     *
+     * @param asset The asset entity
+     * @param vulnerabilityId The CVE identifier
+     * @return The vulnerability if found, null otherwise
+     */
+    fun findByAssetAndVulnerabilityId(asset: com.secman.domain.Asset, vulnerabilityId: String): Vulnerability?
 }

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -3,12 +3,15 @@ package com.secman.service
 import com.secman.domain.Asset
 import com.secman.domain.Vulnerability
 import com.secman.domain.VulnerabilityException
+import com.secman.dto.AddVulnerabilityRequestDto
+import com.secman.dto.AddVulnerabilityResponseDto
 import com.secman.dto.OverdueStatus
 import com.secman.dto.VulnerabilityWithExceptionDto
 import com.secman.repository.VulnerabilityRepository
 import com.secman.repository.VulnerabilityExceptionRepository
 import io.micronaut.cache.annotation.Cacheable
 import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -621,5 +624,106 @@ open class VulnerabilityService(
         } else {
             com.secman.dto.VulnerabilityCleanupResult.noCleanupNeeded(totalScanned)
         }
+    }
+
+    /**
+     * Add or update vulnerability from CLI command
+     * Feature: 052-cli-add-vulnerability
+     *
+     * Implements upsert pattern:
+     * - If asset doesn't exist: create it with type=SERVER, owner=CLI-IMPORT
+     * - If vulnerability with same CVE exists for asset: update it
+     * - Otherwise: create new vulnerability
+     *
+     * @param request The add vulnerability request DTO
+     * @return AddVulnerabilityResponseDto with operation result
+     */
+    @Transactional
+    open fun addVulnerabilityFromCli(request: AddVulnerabilityRequestDto): AddVulnerabilityResponseDto {
+        log.info("Adding vulnerability from CLI: hostname={}, cve={}, criticality={}, daysOpen={}",
+            request.hostname, request.cve, request.criticality, request.daysOpen)
+
+        // Step 1: Find or create asset
+        var assetCreated = false
+        var asset = assetRepository.findByNameIgnoreCase(request.hostname)
+
+        if (asset == null) {
+            // Create new asset with defaults
+            asset = Asset(
+                name = request.hostname,
+                type = "SERVER",
+                owner = "CLI-IMPORT"
+            )
+            asset.lastSeen = LocalDateTime.now()
+            asset = assetRepository.save(asset)
+            assetCreated = true
+            log.info("Created new asset: id={}, name={}", asset.id, asset.name)
+        } else {
+            // Update lastSeen timestamp
+            asset.lastSeen = LocalDateTime.now()
+            asset = assetRepository.update(asset)
+            log.debug("Found existing asset: id={}, name={}", asset.id, asset.name)
+        }
+
+        // Step 2: Map criticality to database format (title case)
+        val cvssSeverity = when (request.criticality.uppercase()) {
+            "CRITICAL" -> "Critical"
+            "HIGH" -> "High"
+            "MEDIUM" -> "Medium"
+            "LOW" -> "Low"
+            else -> request.criticality // Fallback to original
+        }
+
+        // Step 3: Calculate scan timestamp from daysOpen
+        val scanTimestamp = LocalDateTime.now().minusDays(request.daysOpen.toLong())
+        val daysOpenText = if (request.daysOpen == 1) "1 day" else "${request.daysOpen} days"
+
+        // Step 4: Find existing vulnerability or create new one (upsert)
+        val existingVuln = vulnerabilityRepository.findByAssetAndVulnerabilityId(asset, request.cve)
+        val operation: String
+
+        val vulnerability = if (existingVuln != null) {
+            // Update existing vulnerability
+            existingVuln.cvssSeverity = cvssSeverity
+            existingVuln.daysOpen = daysOpenText
+            existingVuln.scanTimestamp = scanTimestamp
+            existingVuln.importTimestamp = LocalDateTime.now()
+            vulnerabilityRepository.update(existingVuln)
+            operation = "UPDATED"
+            log.info("Updated existing vulnerability: id={}, cve={}", existingVuln.id, request.cve)
+            existingVuln
+        } else {
+            // Create new vulnerability
+            val newVuln = Vulnerability(
+                asset = asset,
+                vulnerabilityId = request.cve,
+                cvssSeverity = cvssSeverity,
+                daysOpen = daysOpenText,
+                scanTimestamp = scanTimestamp
+            )
+            newVuln.importTimestamp = LocalDateTime.now()
+            vulnerabilityRepository.save(newVuln)
+            operation = "CREATED"
+            log.info("Created new vulnerability: id={}, cve={}", newVuln.id, request.cve)
+            newVuln
+        }
+
+        // Step 5: Build response message
+        val message = if (assetCreated) {
+            "Asset ${asset.name} created. Vulnerability ${request.cve} added."
+        } else if (operation == "UPDATED") {
+            "Vulnerability ${request.cve} updated on asset ${asset.name}"
+        } else {
+            "Vulnerability ${request.cve} added to asset ${asset.name}"
+        }
+
+        return AddVulnerabilityResponseDto(
+            success = true,
+            message = message,
+            assetName = asset.name,
+            assetCreated = assetCreated,
+            vulnerabilityId = request.cve,
+            operation = operation
+        )
     }
 }

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/AddVulnerabilityCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/AddVulnerabilityCommand.kt
@@ -1,0 +1,201 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.VulnerabilityCliService
+import io.micronaut.configuration.picocli.PicocliRunner
+import jakarta.inject.Inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * CLI command to add a vulnerability to an asset
+ * Feature: 052-cli-add-vulnerability
+ *
+ * Usage:
+ *   secman add-vulnerability --hostname <host> --cve <cve> --criticality <level> [options]
+ *
+ * Examples:
+ *   secman add-vulnerability --hostname webserver01 --cve CVE-2024-1234 --criticality HIGH --days-open 30 --username admin --password secret
+ *   secman add-vulnerability --hostname newserver99 --cve CVE-2023-5678 --criticality CRITICAL --username admin --password secret
+ *
+ * User Stories:
+ * - US1: Add vulnerability to existing asset (P1)
+ * - US2: Add vulnerability with auto-created asset (P2)
+ * - US3: Validation and error handling (P3)
+ */
+@Command(
+    name = "add-vulnerability",
+    description = ["Add or update a vulnerability for a hostname"],
+    mixinStandardHelpOptions = true
+)
+class AddVulnerabilityCommand : Runnable {
+
+    @Inject
+    lateinit var vulnerabilityCliService: VulnerabilityCliService
+
+    // Required parameters (US3: FR-002)
+    @Option(
+        names = ["--hostname"],
+        description = ["Target asset hostname (required)"],
+        required = true
+    )
+    lateinit var hostname: String
+
+    @Option(
+        names = ["--cve"],
+        description = ["CVE identifier (required, e.g., CVE-2024-1234)"],
+        required = true
+    )
+    lateinit var cve: String
+
+    @Option(
+        names = ["--criticality"],
+        description = ["Severity level: CRITICAL, HIGH, MEDIUM, or LOW (required)"],
+        required = true,
+        completionCandidates = CriticalityCandidates::class
+    )
+    lateinit var criticality: String
+
+    // Optional parameters (FR-003, FR-012, FR-013)
+    @Option(
+        names = ["--days-open"],
+        description = ["Number of days the vulnerability has been open (default: 0)"],
+        defaultValue = "0"
+    )
+    var daysOpen: Int = 0
+
+    @Option(
+        names = ["--backend-url"],
+        description = ["Backend API URL (default: http://localhost:8080)"],
+        defaultValue = "http://localhost:8080"
+    )
+    var backendUrl: String = "http://localhost:8080"
+
+    @Option(
+        names = ["--username", "-u"],
+        description = ["Backend username (or set SECMAN_USERNAME env var)"],
+        required = false
+    )
+    var username: String? = null
+
+    @Option(
+        names = ["--password", "-p"],
+        description = ["Backend password (or set SECMAN_PASSWORD env var)"],
+        required = false
+    )
+    var password: String? = null
+
+    @Option(
+        names = ["--verbose", "-v"],
+        description = ["Enable verbose output"]
+    )
+    var verbose: Boolean = false
+
+    override fun run() {
+        // Resolve credentials from environment variables if not provided via CLI
+        val effectiveUsername = username
+            ?: System.getenv("SECMAN_USERNAME")
+            ?: run {
+                System.err.println("Error: Username required via --username or SECMAN_USERNAME env var")
+                System.exit(1)
+                return
+            }
+
+        val effectivePassword = password
+            ?: System.getenv("SECMAN_PASSWORD")
+            ?: run {
+                System.err.println("Error: Password required via --password or SECMAN_PASSWORD env var")
+                System.exit(1)
+                return
+            }
+
+        // US3: Validate criticality value (FR-004)
+        val validCriticalities = listOf("CRITICAL", "HIGH", "MEDIUM", "LOW")
+        val normalizedCriticality = criticality.uppercase()
+        if (normalizedCriticality !in validCriticalities) {
+            System.err.println("Error: Criticality must be CRITICAL, HIGH, MEDIUM, or LOW")
+            System.err.println("   Received: $criticality")
+            System.exit(1)
+            return
+        }
+
+        // US3: Validate days-open value (FR-003)
+        if (daysOpen < 0) {
+            System.err.println("Error: Days open must be a positive number or zero")
+            System.err.println("   Received: $daysOpen")
+            System.exit(1)
+            return
+        }
+
+        println("============================================================")
+        println("Add Vulnerability")
+        println("============================================================")
+        println()
+
+        // Step 1: Authenticate
+        println("Authenticating with backend...")
+        val token = vulnerabilityCliService.authenticate(effectiveUsername, effectivePassword, backendUrl)
+
+        if (token == null) {
+            System.err.println("Error: Authentication failed")
+            System.err.println("   Check username and password")
+            System.exit(1)
+            return
+        }
+        println("Authentication successful")
+        println()
+
+        // Step 2: Display request details
+        if (verbose) {
+            println("Processing vulnerability...")
+            println("Hostname: $hostname")
+            println("CVE: $cve")
+            println("Criticality: $normalizedCriticality")
+            println("Days Open: $daysOpen")
+            println()
+        }
+
+        // Step 3: Add vulnerability
+        val result = vulnerabilityCliService.addVulnerability(
+            hostname = hostname,
+            cve = cve,
+            criticality = normalizedCriticality,
+            daysOpen = daysOpen,
+            backendUrl = backendUrl,
+            authToken = token
+        )
+
+        // Step 4: Display result (FR-010)
+        if (result.success) {
+            if (result.assetCreated) {
+                println("Asset ${result.assetName} created (type: SERVER, owner: CLI-IMPORT)")
+            }
+
+            val operationEmoji = when (result.operation) {
+                "CREATED" -> "+"
+                "UPDATED" -> "~"
+                else -> "*"
+            }
+            println("$operationEmoji ${result.message}")
+            println()
+            println("============================================================")
+            println("Summary")
+            println("============================================================")
+            println("Asset: ${result.assetName}${if (result.assetCreated) " (auto-created)" else ""}")
+            println("Operation: ${result.operation}${if (result.operation == "UPDATED") " (existing vulnerability)" else ""}")
+        } else {
+            System.err.println("Error: ${result.message}")
+            System.exit(result.exitCode)
+            return
+        }
+    }
+
+    /**
+     * Completion candidates for criticality option
+     * Provides tab completion for valid criticality values
+     */
+    class CriticalityCandidates : Iterable<String> {
+        override fun iterator(): Iterator<String> {
+            return listOf("CRITICAL", "HIGH", "MEDIUM", "LOW").iterator()
+        }
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/QueryCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/QueryCommand.kt
@@ -7,6 +7,10 @@ import com.secman.crowdstrike.auth.CrowdStrikeAuthService
 import com.secman.crowdstrike.client.CrowdStrikeApiClient
 import com.secman.crowdstrike.client.CrowdStrikeApiClientImpl
 import com.secman.crowdstrike.dto.FalconConfigDto
+import com.secman.crowdstrike.exception.AuthenticationException
+import com.secman.crowdstrike.exception.CrowdStrikeException
+import com.secman.crowdstrike.exception.NotFoundException
+import com.secman.crowdstrike.exception.RateLimitException
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.client.HttpClient
 import org.slf4j.LoggerFactory
@@ -188,6 +192,31 @@ class QueryCommand {
             }
 
             0
+        } catch (e: NotFoundException) {
+            System.err.println()
+            System.err.println("Error: Hostname '$hostname' not found in CrowdStrike")
+            System.err.println("   The hostname may not exist or may not be monitored by CrowdStrike Falcon.")
+            System.err.println("   Please verify the hostname is correct and the device is enrolled.")
+            1
+        } catch (e: AuthenticationException) {
+            System.err.println()
+            System.err.println("Error: CrowdStrike authentication failed")
+            System.err.println("   Please check your CrowdStrike API credentials.")
+            System.err.println("   Run 'secman config --show' to verify your configuration.")
+            1
+        } catch (e: RateLimitException) {
+            System.err.println()
+            System.err.println("Error: CrowdStrike API rate limit exceeded")
+            System.err.println("   Please wait a few minutes before trying again.")
+            1
+        } catch (e: CrowdStrikeException) {
+            System.err.println()
+            System.err.println("Error: CrowdStrike API error")
+            System.err.println("   ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            1
         } catch (e: IllegalStateException) {
             System.err.println("Error: ${e.message}")
             1

--- a/src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityCliService.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/service/VulnerabilityCliService.kt
@@ -1,0 +1,182 @@
+package com.secman.cli.service
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * Service for adding vulnerabilities via CLI
+ * Feature: 052-cli-add-vulnerability
+ *
+ * Functionality:
+ * - Authenticate with backend API
+ * - POST vulnerability to backend CLI endpoint
+ * - Return operation result
+ */
+@Singleton
+class VulnerabilityCliService(
+    @Client("\${secman.backend.base-url:http://localhost:8080}")
+    private val httpClient: HttpClient
+) {
+    private val log = LoggerFactory.getLogger(VulnerabilityCliService::class.java)
+
+    /**
+     * Authenticate with backend API and get JWT token
+     *
+     * @param username Backend username
+     * @param password Backend password
+     * @param backendUrl Backend API URL
+     * @return JWT token or null if authentication failed
+     */
+    fun authenticate(username: String, password: String, backendUrl: String): String? {
+        try {
+            val endpoint = "$backendUrl/api/auth/login"
+            val request = HttpRequest.POST(endpoint, mapOf(
+                "username" to username,
+                "password" to password
+            )).contentType(io.micronaut.http.MediaType.APPLICATION_JSON)
+
+            val response: HttpResponse<Map<*, *>> = httpClient.toBlocking()
+                .exchange(request, Map::class.java)
+
+            if (response.status.code == 200) {
+                val body = response.body() as? Map<*, *>
+                val token = body?.get("access_token")?.toString()
+                    ?: body?.get("token")?.toString()
+                    ?: body?.get("accessToken")?.toString()
+
+                if (token != null) {
+                    log.info("Successfully authenticated with backend")
+                    return token
+                }
+            }
+
+            log.error("Authentication failed: status={}", response.status)
+            return null
+        } catch (e: io.micronaut.http.client.exceptions.HttpClientResponseException) {
+            log.error("Authentication error: {} - {}", e.status.code, e.message)
+            return null
+        } catch (e: Exception) {
+            log.error("Authentication error: {}", e.message, e)
+            return null
+        }
+    }
+
+    /**
+     * Add or update vulnerability via backend API
+     *
+     * @param hostname Target asset hostname
+     * @param cve CVE identifier
+     * @param criticality Severity level (CRITICAL/HIGH/MEDIUM/LOW)
+     * @param daysOpen Number of days the vulnerability has been open
+     * @param backendUrl Backend API URL
+     * @param authToken JWT authentication token
+     * @return AddVulnerabilityResult with operation result
+     */
+    fun addVulnerability(
+        hostname: String,
+        cve: String,
+        criticality: String,
+        daysOpen: Int,
+        backendUrl: String,
+        authToken: String
+    ): AddVulnerabilityResult {
+        log.info("Adding vulnerability: hostname={}, cve={}, criticality={}, daysOpen={}",
+            hostname, cve, criticality, daysOpen)
+
+        try {
+            val endpoint = "$backendUrl/api/vulnerabilities/cli-add"
+            val request = HttpRequest.POST(endpoint, mapOf(
+                "hostname" to hostname,
+                "cve" to cve,
+                "criticality" to criticality,
+                "daysOpen" to daysOpen
+            ))
+                .contentType(io.micronaut.http.MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer $authToken")
+
+            val response: HttpResponse<Map<*, *>> = httpClient.toBlocking()
+                .exchange(request, Map::class.java)
+
+            if (response.status.code == 200) {
+                val body = response.body() as? Map<*, *>
+                return AddVulnerabilityResult(
+                    success = body?.get("success") as? Boolean ?: true,
+                    message = body?.get("message")?.toString() ?: "Vulnerability added",
+                    assetName = body?.get("assetName")?.toString() ?: hostname,
+                    assetCreated = body?.get("assetCreated") as? Boolean ?: false,
+                    vulnerabilityId = body?.get("vulnerabilityId")?.toString() ?: cve,
+                    operation = body?.get("operation")?.toString() ?: "CREATED"
+                )
+            } else {
+                return AddVulnerabilityResult(
+                    success = false,
+                    message = "Backend API returned status ${response.status.code}",
+                    assetName = hostname,
+                    assetCreated = false,
+                    vulnerabilityId = cve,
+                    operation = "FAILED"
+                )
+            }
+        } catch (e: io.micronaut.http.client.exceptions.HttpClientResponseException) {
+            val errorMsg = when (e.status.code) {
+                400 -> {
+                    val body = try { e.response.getBody(Map::class.java).orElse(null) } catch (ex: Exception) { null }
+                    body?.get("error")?.toString() ?: "Invalid request: ${e.message}"
+                }
+                401 -> "Authentication required"
+                403 -> "Insufficient permissions (ADMIN or VULN role required)"
+                else -> "Backend API error: ${e.status.code} - ${e.message}"
+            }
+            log.error("Add vulnerability error: {}", errorMsg)
+            return AddVulnerabilityResult(
+                success = false,
+                message = errorMsg,
+                assetName = hostname,
+                assetCreated = false,
+                vulnerabilityId = cve,
+                operation = "FAILED"
+            )
+        } catch (e: java.net.ConnectException) {
+            val errorMsg = "Cannot connect to backend at $backendUrl"
+            log.error(errorMsg, e)
+            return AddVulnerabilityResult(
+                success = false,
+                message = errorMsg,
+                assetName = hostname,
+                assetCreated = false,
+                vulnerabilityId = cve,
+                operation = "CONNECTION_ERROR",
+                exitCode = 2
+            )
+        } catch (e: Exception) {
+            val errorMsg = "Failed to add vulnerability: ${e.message}"
+            log.error(errorMsg, e)
+            return AddVulnerabilityResult(
+                success = false,
+                message = errorMsg,
+                assetName = hostname,
+                assetCreated = false,
+                vulnerabilityId = cve,
+                operation = "FAILED"
+            )
+        }
+    }
+}
+
+/**
+ * Result of add vulnerability operation
+ * Feature: 052-cli-add-vulnerability
+ */
+data class AddVulnerabilityResult(
+    val success: Boolean,
+    val message: String,
+    val assetName: String,
+    val assetCreated: Boolean,
+    val vulnerabilityId: String,
+    val operation: String,
+    val exitCode: Int = if (success) 0 else 1
+)

--- a/src/cli/src/main/resources/cli-docs/ADD_VULNERABILITY_COMMANDS.md
+++ b/src/cli/src/main/resources/cli-docs/ADD_VULNERABILITY_COMMANDS.md
@@ -1,0 +1,649 @@
+# Add Vulnerability Command
+
+**Feature**: 052-cli-add-vulnerability
+**Version**: 1.0.0
+**Last Updated**: 2025-12-07
+
+## Overview
+
+The `add-vulnerability` command provides a CLI tool for manually adding vulnerability records to assets in SecMan. This is useful for recording vulnerabilities discovered through manual penetration testing, security audits, or external reports that are not automatically imported from CrowdStrike.
+
+**Key Features**:
+- Add vulnerability to existing asset by hostname
+- Auto-create asset if hostname not found
+- Upsert pattern: update existing CVE record instead of creating duplicates
+- Validate criticality levels and days-open values
+- Clear success/failure feedback with exit codes
+
+## Prerequisites
+
+### Authentication
+All operations require authentication with a user that has **ADMIN** or **VULN** role. Specify credentials via:
+- `--username <user>` and `--password <pass>` flags (required)
+
+### Backend Connection
+The command connects to the SecMan backend API. Ensure:
+- Backend server is running and accessible
+- Default URL: `http://localhost:8080`
+- Override with `--backend-url` if needed
+
+---
+
+## Command Syntax
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname <hostname> \
+  --cve <cve-id> \
+  --criticality <level> \
+  [--days-open <number>] \
+  [--backend-url <url>] \
+  [--username <user>] \
+  [--password <pass>] \
+  [--verbose]'
+```
+
+**Note**: `--username` and `--password` are optional if `SECMAN_USERNAME` and `SECMAN_PASSWORD` environment variables are set.
+
+### Required Options
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `--hostname` | Target asset hostname | `webserver01` |
+| `--cve` | CVE identifier or custom vulnerability ID | `CVE-2024-1234` |
+| `--criticality` | Severity level: CRITICAL, HIGH, MEDIUM, or LOW | `HIGH` |
+| `--username`, `-u` | Backend username (or set `SECMAN_USERNAME` env var) | `admin` |
+| `--password`, `-p` | Backend password (or set `SECMAN_PASSWORD` env var) | `secret` |
+
+### Optional Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--days-open` | Number of days the vulnerability has been open | `0` |
+| `--backend-url` | Backend API URL | `http://localhost:8080` |
+| `--verbose`, `-v` | Enable detailed logging output | `false` |
+
+---
+
+## Examples
+
+### Basic Usage - Add Vulnerability to Existing Asset
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --username admin \
+  --password secret'
+```
+
+**Output:**
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+Authentication successful
+
++ Vulnerability CVE-2024-1234 added to asset webserver01
+
+============================================================
+Summary
+============================================================
+Asset: webserver01
+Operation: CREATED
+```
+
+### With Days Open
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname dbserver02 \
+  --cve CVE-2023-5678 \
+  --criticality CRITICAL \
+  --days-open 45 \
+  --username admin \
+  --password secret'
+```
+
+### Auto-Create Asset (Hostname Not Found)
+
+When the hostname doesn't exist in SecMan, the asset is automatically created with default values.
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname newserver99 \
+  --cve CVE-2024-9999 \
+  --criticality MEDIUM \
+  --days-open 15 \
+  --username admin \
+  --password secret'
+```
+
+**Output:**
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+Authentication successful
+
+Asset newserver99 created (type: SERVER, owner: CLI-IMPORT)
++ Asset newserver99 created. Vulnerability CVE-2024-9999 added.
+
+============================================================
+Summary
+============================================================
+Asset: newserver99 (auto-created)
+Operation: CREATED
+```
+
+**Auto-created asset defaults:**
+- **Type**: `SERVER`
+- **Owner**: `CLI-IMPORT`
+- **Last Seen**: Current timestamp
+
+### Update Existing Vulnerability (Upsert)
+
+If the same CVE already exists for the asset, the command updates the existing record instead of creating a duplicate.
+
+```bash
+# First add
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 30 \
+  --username admin \
+  --password secret'
+
+# Update the same CVE with new days-open
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 45 \
+  --username admin \
+  --password secret'
+```
+
+**Output (second run):**
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+Authentication successful
+
+~ Vulnerability CVE-2024-1234 updated on asset webserver01
+
+============================================================
+Summary
+============================================================
+Asset: webserver01
+Operation: UPDATED (existing vulnerability)
+```
+
+### Verbose Mode
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 30 \
+  --username admin \
+  --password secret \
+  --verbose'
+```
+
+**Output:**
+```
+============================================================
+Add Vulnerability
+============================================================
+
+Authenticating with backend...
+Authentication successful
+
+Processing vulnerability...
+Hostname: webserver01
+CVE: CVE-2024-1234
+Criticality: HIGH
+Days Open: 30
+
++ Vulnerability CVE-2024-1234 added to asset webserver01
+
+============================================================
+Summary
+============================================================
+Asset: webserver01
+Operation: CREATED
+```
+
+### Custom Backend URL
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --backend-url https://api.example.com:8080 \
+  --username admin \
+  --password secret'
+```
+
+---
+
+## Validation Rules
+
+### Criticality Values
+
+Valid values (case-insensitive):
+- `CRITICAL`
+- `HIGH`
+- `MEDIUM`
+- `LOW`
+
+**Invalid value error:**
+```
+Error: Criticality must be CRITICAL, HIGH, MEDIUM, or LOW
+   Received: IMPORTANT
+```
+
+### Days Open
+
+- Must be a non-negative integer (>= 0)
+- Default: `0` (vulnerability discovered today)
+
+**Invalid value error:**
+```
+Error: Days open must be a positive number or zero
+   Received: -5
+```
+
+### CVE Format
+
+- Any string format is accepted
+- Allows non-standard identifiers for manual entries
+- Examples: `CVE-2024-1234`, `VULN-001`, `INTERNAL-SEC-2024-05`
+
+### Hostname
+
+- Required, non-blank
+- Case-insensitive lookup in database
+- If not found, auto-creates asset
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success - vulnerability added or updated |
+| `1` | Validation error, authentication failure, or API error |
+| `2` | Backend connection error (cannot reach server) |
+
+**Example script using exit codes:**
+```bash
+#!/bin/bash
+
+./gradlew cli:run --args='add-vulnerability \
+  --hostname server01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --username admin \
+  --password secret'
+
+case $? in
+  0) echo "Vulnerability added successfully" ;;
+  1) echo "Error: Check parameters or authentication" ;;
+  2) echo "Error: Cannot connect to backend" ;;
+esac
+```
+
+---
+
+## Data Model
+
+### Vulnerability Record
+
+When a vulnerability is added, the following fields are set:
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `vulnerabilityId` | `--cve` parameter | `CVE-2024-1234` |
+| `cvssSeverity` | `--criticality` (title case) | `High` |
+| `daysOpen` | `--days-open` as text | `30 days` |
+| `scanTimestamp` | Calculated: now - days-open | `2024-10-08T10:30:00` |
+| `importTimestamp` | Current time | `2024-11-07T10:30:00` |
+| `asset` | Found or created by hostname | webserver01 |
+
+### Criticality Mapping
+
+| CLI Input | Database Value |
+|-----------|----------------|
+| `CRITICAL` | `Critical` |
+| `HIGH` | `High` |
+| `MEDIUM` | `Medium` |
+| `LOW` | `Low` |
+
+---
+
+## Common Workflows
+
+### 1. Record Penetration Test Findings
+
+After a penetration test, manually add discovered vulnerabilities:
+
+```bash
+# Add multiple findings from pen test report
+./gradlew cli:run --args='add-vulnerability \
+  --hostname app-server-01 \
+  --cve CVE-2024-1234 \
+  --criticality CRITICAL \
+  --days-open 0 \
+  --username admin \
+  --password secret'
+
+./gradlew cli:run --args='add-vulnerability \
+  --hostname app-server-01 \
+  --cve CVE-2024-5678 \
+  --criticality HIGH \
+  --days-open 0 \
+  --username admin \
+  --password secret'
+
+./gradlew cli:run --args='add-vulnerability \
+  --hostname db-server-01 \
+  --cve CVE-2024-9999 \
+  --criticality MEDIUM \
+  --days-open 0 \
+  --username admin \
+  --password secret'
+```
+
+### 2. Batch Import from Script
+
+Create a script to import multiple vulnerabilities:
+
+```bash
+#!/bin/bash
+# import-vulns.sh
+
+BACKEND_URL="http://localhost:8080"
+USERNAME="admin"
+PASSWORD="secret"
+
+while IFS=',' read -r hostname cve criticality days_open; do
+  echo "Adding: $hostname - $cve ($criticality)"
+
+  ./gradlew cli:run --args="add-vulnerability \
+    --hostname $hostname \
+    --cve $cve \
+    --criticality $criticality \
+    --days-open ${days_open:-0} \
+    --backend-url $BACKEND_URL \
+    --username $USERNAME \
+    --password $PASSWORD"
+
+  if [ $? -ne 0 ]; then
+    echo "Failed to add: $hostname - $cve"
+  fi
+done < vulnerabilities.csv
+```
+
+**vulnerabilities.csv:**
+```csv
+webserver01,CVE-2024-1234,HIGH,30
+webserver01,CVE-2024-5678,CRITICAL,15
+dbserver02,CVE-2024-9999,MEDIUM,45
+newserver99,CVE-2024-0001,LOW,0
+```
+
+### 3. Update Vulnerability Age
+
+Update the days-open for an existing vulnerability:
+
+```bash
+# Original entry with 30 days
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 30 \
+  --username admin \
+  --password secret'
+
+# After 15 more days, update to 45 days
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --days-open 45 \
+  --username admin \
+  --password secret'
+```
+
+### 4. Track Non-CVE Vulnerabilities
+
+Use custom identifiers for internal findings:
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname internal-app \
+  --cve INTERNAL-SEC-2024-001 \
+  --criticality HIGH \
+  --days-open 10 \
+  --username admin \
+  --password secret'
+```
+
+---
+
+## Troubleshooting
+
+### Issue: "Username required via --username or SECMAN_USERNAME env var"
+
+**Cause**: No username provided
+**Solution**:
+- Set `SECMAN_USERNAME` environment variable, OR
+- Pass `--username` flag
+
+```bash
+# Option 1: Set environment variable
+export SECMAN_USERNAME=admin
+
+# Option 2: Pass via command line
+./gradlew cli:run --args='add-vulnerability ... --username admin'
+```
+
+### Issue: "Password required via --password or SECMAN_PASSWORD env var"
+
+**Cause**: No password provided
+**Solution**:
+- Set `SECMAN_PASSWORD` environment variable (recommended), OR
+- Pass `--password` flag
+
+```bash
+# Option 1: Set environment variable (recommended)
+export SECMAN_PASSWORD=secret
+
+# Option 2: Pass via command line (less secure)
+./gradlew cli:run --args='add-vulnerability ... --password secret'
+```
+
+### Issue: "Authentication failed"
+
+**Cause**: Invalid username or password
+**Solution**:
+- Verify credentials are correct
+- Ensure user has ADMIN or VULN role
+
+```bash
+# Test authentication
+curl -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"secret"}'
+```
+
+### Issue: "Cannot connect to backend"
+
+**Cause**: Backend server unreachable
+**Solution**:
+- Verify backend is running
+- Check `--backend-url` is correct
+- Test network connectivity
+
+```bash
+# Test connectivity
+curl http://localhost:8080/health
+```
+
+### Issue: "Insufficient permissions"
+
+**Cause**: User lacks required role
+**Solution**: Ensure user has ADMIN or VULN role
+
+### Issue: "Criticality must be CRITICAL, HIGH, MEDIUM, or LOW"
+
+**Cause**: Invalid criticality value
+**Solution**: Use one of the valid values (case-insensitive)
+
+### Issue: Vulnerability not appearing in UI
+
+**Cause**: Various
+**Solution**:
+1. Verify the asset exists (check if auto-created)
+2. Check user has access to the asset's workgroup
+3. Refresh the vulnerabilities view
+
+---
+
+## Security Considerations
+
+1. **Role-Based Access**: Only ADMIN and VULN roles can add vulnerabilities
+2. **Audit Logging**: All additions/updates are logged with user identity
+3. **Input Validation**: All parameters validated before database operations
+4. **Credential Handling**: Supports environment variables to avoid exposing credentials in process listings
+5. **HTTPS Recommended**: Use `--backend-url https://...` in production
+
+### Authentication Methods
+
+**Method 1 - Environment Variables (Recommended):**
+
+Environment variables keep credentials out of process listings and shell history:
+
+```bash
+# Set credentials once
+export SECMAN_USERNAME=admin
+export SECMAN_PASSWORD=secret
+
+# Run commands without exposing credentials
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH'
+```
+
+**Method 2 - Command Line Arguments:**
+
+For quick testing or single-user environments:
+
+```bash
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --username admin \
+  --password secret'
+```
+
+⚠️ **Warning**: Command line arguments are visible in:
+- Process listings (`ps aux`)
+- Shell history (`~/.bash_history`, `~/.zsh_history`)
+- System logs
+
+**Method 3 - Mixed (Override Environment):**
+
+Command line arguments take precedence over environment variables:
+
+```bash
+export SECMAN_USERNAME=default_user
+export SECMAN_PASSWORD=default_pass
+
+# Override username for this command only
+./gradlew cli:run --args='add-vulnerability \
+  --hostname webserver01 \
+  --cve CVE-2024-1234 \
+  --criticality HIGH \
+  --username different_user'
+```
+
+### Environment Variables Reference
+
+| Variable | Description |
+|----------|-------------|
+| `SECMAN_USERNAME` | Backend username for authentication |
+| `SECMAN_PASSWORD` | Backend password for authentication |
+
+---
+
+## API Endpoint
+
+The CLI calls the following backend endpoint:
+
+**Endpoint**: `POST /api/vulnerabilities/cli-add`
+**Auth**: Bearer JWT token (obtained via `/api/auth/login`)
+**Roles**: ADMIN, VULN
+
+**Request Body:**
+```json
+{
+  "hostname": "webserver01",
+  "cve": "CVE-2024-1234",
+  "criticality": "HIGH",
+  "daysOpen": 30
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Vulnerability CVE-2024-1234 added to asset webserver01",
+  "assetName": "webserver01",
+  "assetCreated": false,
+  "vulnerabilityId": "CVE-2024-1234",
+  "operation": "CREATED"
+}
+```
+
+---
+
+## Related Documentation
+
+- **Feature Spec**: `specs/052-cli-add-vulnerability/spec.md`
+- **Implementation Plan**: `specs/052-cli-add-vulnerability/plan.md`
+- **Task Breakdown**: `specs/052-cli-add-vulnerability/tasks.md`
+- **Quickstart Guide**: `specs/052-cli-add-vulnerability/quickstart.md`
+- **API Contract**: `specs/052-cli-add-vulnerability/contracts/api.yaml`
+- **CLI Reference**: `docs/CLI.md`
+
+---
+
+## Support
+
+For issues or questions:
+1. Check troubleshooting guide above
+2. Verify backend logs: `./gradlew backendng:run`
+3. Enable verbose mode: `--verbose`
+4. Report bugs: https://github.com/schmalle/secman/issues
+
+---
+
+**End of Add Vulnerability Command Documentation**

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
@@ -131,6 +131,9 @@ open class CrowdStrikeApiClientImpl(
 
                 // For now, return single page (pagination requires CrowdStrike cursor/offset support)
                 hasMore = false
+            } catch (e: CrowdStrikeException) {
+                // Don't log stack trace for known CrowdStrike exceptions - just rethrow
+                throw e
             } catch (e: Exception) {
                 log.error("Error during pagination: offset={}", offset, e)
                 throw e


### PR DESCRIPTION
Implements the `add-vulnerability` CLI command allowing users to manually add or update vulnerabilities for a given hostname, including CVE, criticality, and days open. Automatically creates the asset if the hostname does not exist, uses upsert logic to prevent duplicates, and adds backend/controller/service/repository support with new DTOs and documentation updates.