### PR TITLE
Add device type filtering to CLI CrowdStrike queries

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,17 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change" />
+    <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CLAUDE.md" beforeDir="false" afterPath="$PROJECT_DIR$/CLAUDE.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/gradle.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/gradle.properties" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/shared/gradle.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/gradle.properties" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -90,7 +100,7 @@
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
-    "git-widget-placeholder": "054-products-overview",
+    "git-widget-placeholder": "055-cli-query-clients",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/flake/sources/misc/secman",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 12 (existing Asset, Vulnerability entities) (052-cli-add-vulnerability)
 - Kotlin 2.2.21 / Java 21 (backend), TypeScript (frontend) + Micronaut 4.10, Hibernate JPA (backend); Astro 5.14, React 19, Bootstrap 5.3 (frontend) (054-products-overview)
 - MariaDB 11.4 (existing Vulnerability and Asset entities) (054-products-overview)
+- Kotlin 2.2.21 / Java 21 + Micronaut 4.10, Picocli 4.7 (CLI framework) (055-cli-query-clients)
+- MariaDB 11.4 (existing Asset/Vulnerability entities - no changes required) (055-cli-query-clients)
 
 ## Recent Changes
 - 048-prevent-duplicate-vulnerabilities: Fixed critical 99% data loss bug by removing JPA cascade from Asset.vulnerabilities; added transactional replace pattern for duplicate prevention, comprehensive documentation

--- a/specs/055-cli-query-clients/checklists/requirements.md
+++ b/specs/055-cli-query-clients/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: CLI Query Clients/Workstations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The feature scope is well-defined: extend existing CLI command with new device type option
+- CrowdStrike FQL filter patterns are mentioned as technical context for clarity but the spec remains user-focused

--- a/specs/055-cli-query-clients/data-model.md
+++ b/specs/055-cli-query-clients/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: CLI Query Clients/Workstations
+
+**Feature**: 055-cli-query-clients
+**Date**: 2025-12-16
+
+## Overview
+
+This feature introduces no new database entities. It adds a single enum type for device classification in the CLI/shared modules.
+
+## New Types
+
+### DeviceType Enum
+
+**Location**: `src/shared/src/main/kotlin/com/secman/crowdstrike/dto/DeviceType.kt`
+
+```kotlin
+enum class DeviceType(val fqlValue: String) {
+    SERVER("Server"),
+    WORKSTATION("Workstation"),
+    ALL("");  // Special case: queries both types
+
+    /**
+     * Generate FQL filter string for CrowdStrike API
+     * Returns null for ALL (requires special handling)
+     */
+    fun toFqlFilter(): String? = when (this) {
+        SERVER -> "product_type_desc:'Server'"
+        WORKSTATION -> "product_type_desc:'Workstation'"
+        ALL -> null
+    }
+
+    companion object {
+        /**
+         * Parse from string (case-insensitive)
+         * @throws IllegalArgumentException if invalid value
+         */
+        fun fromString(value: String): DeviceType =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException(
+                    "Invalid device type: '$value'. Valid values: ${entries.joinToString { it.name }}"
+                )
+    }
+}
+```
+
+**Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| fqlValue | String | CrowdStrike FQL filter value |
+
+**Validation Rules**:
+- Case-insensitive parsing from CLI input
+- Invalid values throw `IllegalArgumentException` with helpful message
+
+## Existing Entities (Unchanged)
+
+### Asset
+
+The existing Asset entity remains unchanged. Both servers and workstations are stored as Asset records with no device type distinction. This is intentional - the vulnerability management system treats all devices equally.
+
+### Vulnerability
+
+The existing Vulnerability entity remains unchanged. Vulnerabilities are associated with Assets regardless of whether the underlying device is a server or workstation.
+
+## Data Flow
+
+```
+CLI Input (--device-type WORKSTATION)
+    ↓
+DeviceType.fromString("WORKSTATION")
+    ↓
+DeviceType.WORKSTATION.toFqlFilter()
+    ↓
+"product_type_desc:'Workstation'"
+    ↓
+CrowdStrike API Query
+    ↓
+CrowdStrikeVulnerabilityDto (existing)
+    ↓
+Backend Import (existing endpoint)
+    ↓
+Asset + Vulnerability records (existing)
+```
+
+## Migration
+
+**No migration required** - This feature adds no database schema changes.

--- a/specs/055-cli-query-clients/plan.md
+++ b/specs/055-cli-query-clients/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: CLI Query Clients/Workstations
+
+**Branch**: `055-cli-query-clients` | **Date**: 2025-12-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/055-cli-query-clients/spec.md`
+
+## Summary
+
+Extend the existing `query servers` CLI command to support querying CrowdStrike for workstation/client devices in addition to servers. Add a `--device-type` option accepting SERVER (default), WORKSTATION, or ALL values. The implementation follows existing patterns with minimal changes to the shared CrowdStrike API client.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.2.21 / Java 21
+**Primary Dependencies**: Micronaut 4.10, Picocli 4.7 (CLI framework)
+**Storage**: MariaDB 11.4 (existing Asset/Vulnerability entities - no changes required)
+**Testing**: N/A (per constitution - testing only when requested)
+**Target Platform**: CLI tool (JVM)
+**Project Type**: Multi-module (cli, shared, backendng)
+**Performance Goals**: Match existing server query performance (batching, parallelism)
+**Constraints**: Backward compatible - default behavior unchanged
+**Scale/Scope**: Workstation counts potentially 5-10x higher than servers (~50,000+ devices)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | ✅ PASS | No new input vectors; reuses existing auth patterns |
+| III. API-First | ✅ PASS | No backend API changes; CLI-only feature |
+| IV. User-Requested Testing | ✅ PASS | No test planning included |
+| V. RBAC | ✅ PASS | No authorization changes; CLI uses existing backend auth |
+| VI. Schema Evolution | ✅ PASS | No database schema changes |
+
+**Gate Status**: PASSED - No violations requiring justification
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/055-cli-query-clients/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (files to modify)
+
+```text
+src/cli/src/main/kotlin/com/secman/cli/
+├── commands/
+│   └── ServersCommand.kt          # Add --device-type option parsing
+└── SecmanCli.kt                   # (if needed) Add option wiring
+
+src/shared/src/main/kotlin/com/secman/crowdstrike/
+├── client/
+│   ├── CrowdStrikeApiClient.kt    # No changes needed (deviceType already accepted)
+│   └── CrowdStrikeApiClientImpl.kt # Add getDeviceIdsFiltered() with deviceType param
+└── dto/
+    └── DeviceType.kt              # NEW: Enum for SERVER, WORKSTATION, ALL
+```
+
+**Structure Decision**: Existing multi-module structure maintained. Changes isolated to CLI command layer and shared CrowdStrike client.
+
+## Implementation Approach
+
+### Key Changes
+
+1. **ServersCommand.kt** (CLI layer)
+   - Already has `deviceType: String = "SERVER"` property (line 42)
+   - Need to: validate input, support case-insensitive matching, add error for invalid values
+   - Log output should reflect actual device type being queried
+
+2. **CrowdStrikeApiClientImpl.kt** (API client)
+   - `getServerDeviceIdsFiltered()` hardcodes `product_type_desc:'Server'` (line 594)
+   - Refactor to accept `deviceType` parameter
+   - For `ALL`: Query both device types and combine results
+   - Rename method to `getDeviceIdsFiltered(deviceType: DeviceType)`
+
+3. **DeviceType.kt** (new enum)
+   - Values: SERVER, WORKSTATION, ALL
+   - Method: `toFqlFilter()` returns appropriate filter string
+
+### CrowdStrike FQL Filters
+
+| Device Type | FQL Filter |
+|-------------|------------|
+| SERVER | `product_type_desc:'Server'+last_seen:>'now-1d'` |
+| WORKSTATION | `product_type_desc:'Workstation'+last_seen:>'now-1d'` |
+| ALL | Query both filters separately, combine device IDs |
+
+## Complexity Tracking
+
+> No Constitution Check violations - this section is empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | - | - |

--- a/specs/055-cli-query-clients/quickstart.md
+++ b/specs/055-cli-query-clients/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: CLI Query Clients/Workstations
+
+**Feature**: 055-cli-query-clients
+
+## Usage
+
+### Query Workstations
+
+```bash
+./gradlew cli:run --args='query servers --device-type WORKSTATION severity CRITICAL,HIGH --min-days-open 1'
+```
+
+### Query Servers (default, unchanged)
+
+```bash
+./gradlew cli:run --args='query servers severity CRITICAL,HIGH --min-days-open 1'
+```
+
+### Query All Devices
+
+```bash
+./gradlew cli:run --args='query servers --device-type ALL severity CRITICAL,HIGH --min-days-open 1'
+```
+
+### Import Workstation Vulnerabilities
+
+```bash
+./gradlew cli:run --args='query servers --device-type WORKSTATION severity CRITICAL,HIGH --min-days-open 1 --save --username admin --password secret --backend-url http://localhost:8080'
+```
+
+## New Option
+
+| Option | Values | Default | Description |
+|--------|--------|---------|-------------|
+| `--device-type` | SERVER, WORKSTATION, ALL | SERVER | Filter by CrowdStrike device classification |
+
+## Verification
+
+1. **Dry run workstation query**:
+   ```bash
+   ./gradlew cli:run --args='query servers --device-type WORKSTATION --dry-run --verbose'
+   ```
+
+2. **Check output includes workstation count**:
+   ```
+   Querying CrowdStrike for workstations...
+   Found X vulnerabilities across workstations
+   ```
+
+3. **Verify server default unchanged**:
+   ```bash
+   ./gradlew cli:run --args='query servers --verbose'
+   ```
+   Should show "device type=SERVER" in filters.
+
+## Build
+
+```bash
+./gradlew build
+```
+
+No additional dependencies or configuration required.

--- a/specs/055-cli-query-clients/research.md
+++ b/specs/055-cli-query-clients/research.md
@@ -1,0 +1,95 @@
+# Research: CLI Query Clients/Workstations
+
+**Feature**: 055-cli-query-clients
+**Date**: 2025-12-16
+
+## Overview
+
+This feature extends existing CLI functionality with minimal research required. The codebase already has a working implementation for server queries that can be parameterized.
+
+## Research Topics
+
+### 1. CrowdStrike Device Type Filtering
+
+**Question**: What FQL filter values does CrowdStrike use to distinguish servers from workstations?
+
+**Decision**: Use `product_type_desc` field with values `'Server'` and `'Workstation'`
+
+**Rationale**:
+- Existing implementation at `CrowdStrikeApiClientImpl.kt:594` uses `product_type_desc:'Server'`
+- CrowdStrike Falcon API documentation confirms `product_type_desc` field supports: Server, Workstation, Domain Controller
+- The implementation already filters by this field, just needs parameterization
+
+**Alternatives Considered**:
+- `platform_name` field: Less specific, indicates OS rather than device role
+- `system_product_name` field: Hardware model, not device classification
+- `device_type` field: Does not exist in CrowdStrike schema
+
+### 2. Performance for Large Workstation Counts
+
+**Question**: How will performance scale with potentially 50,000+ workstations?
+
+**Decision**: Reuse existing batching and parallelism patterns
+
+**Rationale**:
+- Existing server implementation handles ~3,000 devices efficiently
+- Batching (configurable via `secman.crowdstrike.batch-size`, default 20)
+- Parallelism (configurable via `secman.crowdstrike.max-parallel-batches`, default up to 12)
+- Rate limit handling with exponential backoff already implemented
+- No architectural changes needed
+
+**Alternatives Considered**:
+- Increase default batch size for workstations: Rejected - let user configure via existing settings
+- Add workstation-specific caching: Rejected - over-engineering for initial implementation
+
+### 3. Backend Import Compatibility
+
+**Question**: Can the existing backend import endpoint handle workstation data?
+
+**Decision**: Yes, no changes required
+
+**Rationale**:
+- Backend endpoint `/api/crowdstrike/servers/import` processes `CrowdStrikeVulnerabilityBatchDto`
+- The DTO is device-type agnostic - contains hostname, vulnerabilities, metadata
+- Asset entity has no device type field; servers and workstations are just Assets
+- Import logic creates/updates Asset records without distinguishing device type
+
+**Alternatives Considered**:
+- Add device type field to Asset: Rejected - scope creep, not in requirements
+- Create separate workstation import endpoint: Rejected - unnecessary duplication
+
+### 4. CLI Option Design
+
+**Question**: Should `--device-type` be a string or use an enum?
+
+**Decision**: Accept string input, validate against enum values internally
+
+**Rationale**:
+- Existing `deviceType: String = "SERVER"` property in ServersCommand.kt
+- Case-insensitive parsing for user convenience
+- Clear error message listing valid options on invalid input
+- Enum provides type safety in API client layer
+
+**Alternatives Considered**:
+- Add new subcommands (`query workstations`, `query all`): Rejected - inconsistent with existing CLI structure
+- Add `--include-workstations` flag: Rejected - less flexible than enum approach
+
+## Dependencies
+
+| Dependency | Version | Purpose | Verified |
+|------------|---------|---------|----------|
+| CrowdStrike Falcon API | v2 | Device and vulnerability queries | ✅ Existing |
+| Picocli | 4.7 | CLI framework | ✅ Existing |
+| Micronaut HTTP Client | 4.10 | API calls | ✅ Existing |
+
+## Unknowns Resolved
+
+All technical unknowns have been resolved. The implementation can proceed with the approach outlined in plan.md.
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Large workstation count causes timeout | Low | Medium | Existing batching/parallelism handles this |
+| CrowdStrike API rate limits | Low | Low | Existing retry with exponential backoff |
+| Workstation filter returns unexpected results | Low | Low | Test with `--dry-run` before import |

--- a/specs/055-cli-query-clients/spec.md
+++ b/specs/055-cli-query-clients/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: CLI Query Clients/Workstations
+
+**Feature Branch**: `055-cli-query-clients`
+**Created**: 2025-12-16
+**Status**: Draft
+**Input**: User description: "in the CLI functionality i can use a 'query servers' command, please add a command line option to also query clients instead of servers, extend the Crowdstrike query logic accordingly"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Workstation Vulnerabilities (Priority: P1)
+
+As a security administrator, I want to query CrowdStrike for vulnerabilities on client workstations (laptops, desktops) so that I can assess endpoint security posture across my organization's end-user devices.
+
+**Why this priority**: End-user devices are a significant attack surface and need vulnerability tracking alongside servers. This is the core functionality being requested.
+
+**Independent Test**: Can be fully tested by running the CLI command with the new client/workstation option and verifying vulnerabilities are retrieved for workstation-type devices only.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI is configured with valid CrowdStrike credentials, **When** I run `./gradlew cli:run --args='query servers --device-type WORKSTATION ...'`, **Then** the system queries CrowdStrike for devices with product type "Workstation" and returns their vulnerabilities.
+
+2. **Given** the CLI is configured with valid CrowdStrike credentials, **When** I run the query with `--device-type WORKSTATION`, **Then** only workstation/client devices are included (no servers).
+
+3. **Given** I want to query workstations with specific filters, **When** I run the query with `--device-type WORKSTATION --severity CRITICAL,HIGH --min-days-open 30`, **Then** the system applies both the device type filter and the severity/days-open filters correctly.
+
+---
+
+### User Story 2 - Default Behavior Preserved (Priority: P1)
+
+As a security administrator using the existing workflow, I want the default behavior of the `query servers` command to remain unchanged so that my existing scripts and processes continue to work.
+
+**Why this priority**: Backward compatibility is critical to avoid breaking existing automation.
+
+**Independent Test**: Run existing server query command without the new option and verify behavior is identical to before.
+
+**Acceptance Scenarios**:
+
+1. **Given** no `--device-type` option is specified, **When** I run `./gradlew cli:run --args='query servers ...'`, **Then** the system queries only SERVER devices (current default behavior).
+
+2. **Given** I explicitly specify `--device-type SERVER`, **When** I run the query, **Then** the behavior is identical to omitting the option.
+
+---
+
+### User Story 3 - Query All Device Types (Priority: P2)
+
+As a security administrator, I want to query vulnerabilities across all device types (servers and workstations) in a single command so that I can get a complete picture of my organization's vulnerability landscape.
+
+**Why this priority**: Convenient for comprehensive reporting but not essential for the core use case.
+
+**Independent Test**: Run the query with `--device-type ALL` and verify both servers and workstations are included.
+
+**Acceptance Scenarios**:
+
+1. **Given** I specify `--device-type ALL`, **When** I run the query, **Then** the system queries both SERVER and WORKSTATION devices from CrowdStrike.
+
+2. **Given** I query with `--device-type ALL`, **When** results are returned, **Then** I can distinguish servers from workstations in the output.
+
+---
+
+### Edge Cases
+
+- What happens when no workstations are found in CrowdStrike? System should return gracefully with "No vulnerabilities found matching criteria" message.
+- What happens when an invalid device type is specified? System should display an error listing valid options (SERVER, WORKSTATION, ALL).
+- What happens when workstation count is very large (e.g., 50,000+ devices)? System should use the same pagination and batching optimizations as the server query.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept a `--device-type` command-line option with values: SERVER (default), WORKSTATION, ALL
+- **FR-002**: System MUST query CrowdStrike with FQL filter `product_type_desc:'Workstation'` when device type is WORKSTATION
+- **FR-003**: System MUST query CrowdStrike with FQL filter `product_type_desc:'Server'` when device type is SERVER (existing behavior)
+- **FR-004**: System MUST query both device types when device type is ALL
+- **FR-005**: System MUST apply the same severity and days-open filters to workstation queries as server queries
+- **FR-006**: System MUST apply the same "last seen within 24 hours" optimization to workstation queries
+- **FR-007**: System MUST use the same batching and parallelism strategy for workstation queries to handle large device counts
+- **FR-008**: System MUST display helpful error message when invalid device type is specified
+- **FR-009**: System MUST default to SERVER device type when `--device-type` is not specified (backward compatibility)
+- **FR-010**: System MUST support importing workstation vulnerabilities to the backend when `--save` is specified
+
+### Key Entities
+
+- **Device Type**: Enum representing CrowdStrike device classification (SERVER, WORKSTATION, ALL)
+- **CrowdStrike Product Type**: The `product_type_desc` field from CrowdStrike API that distinguishes servers from workstations
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can query workstation vulnerabilities using the same CLI workflow as server queries
+- **SC-002**: Default behavior remains unchanged - existing server query commands work identically
+- **SC-003**: Query performance for workstations is comparable to server queries (same pagination/batching optimizations)
+- **SC-004**: Users can query all device types in a single command for comprehensive vulnerability reporting
+- **SC-005**: Error messages clearly guide users when invalid options are provided
+
+## Assumptions
+
+- CrowdStrike API uses `product_type_desc:'Workstation'` FQL filter for workstations/clients (industry standard for Falcon API)
+- Workstation device counts may be higher than server counts (typical enterprise has more endpoints than servers)
+- The existing backend import endpoint (`/api/crowdstrike/servers/import`) can accept workstation data - the endpoint processes Assets generically regardless of device type

--- a/specs/055-cli-query-clients/tasks.md
+++ b/specs/055-cli-query-clients/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: CLI Query Clients/Workstations
+
+**Input**: Design documents from `/specs/055-cli-query-clients/`
+**Prerequisites**: plan.md (required), spec.md (required), data-model.md, research.md, quickstart.md
+
+**Tests**: Not requested in feature specification (per constitution principle IV)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+This is a multi-module project:
+- **CLI module**: `src/cli/src/main/kotlin/com/secman/cli/`
+- **Shared module**: `src/shared/src/main/kotlin/com/secman/crowdstrike/`
+- **Backend module**: `src/backendng/` (no changes needed)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the new DeviceType enum that all user stories depend on
+
+- [x] T001 [P] Create DeviceType enum in src/shared/src/main/kotlin/com/secman/crowdstrike/dto/DeviceType.kt
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core API client changes that enable all device type queries
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T002 Refactor getServerDeviceIdsFiltered() to accept DeviceType parameter in src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+- [x] T003 Add getDeviceIdsFiltered(deviceType: DeviceType) method that generates appropriate FQL filter in src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+- [x] T004 Update queryServersWithFilters() to use DeviceType enum instead of String parameter in src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Query Workstation Vulnerabilities (Priority: P1) 🎯 MVP
+
+**Goal**: Enable querying CrowdStrike for workstation/client device vulnerabilities
+
+**Independent Test**: Run `./gradlew cli:run --args='query servers --device-type WORKSTATION --dry-run --verbose'` and verify workstation devices are queried
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Add --device-type option validation in ServersCommand.execute() in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+- [x] T006 [US1] Convert deviceType String to DeviceType enum with case-insensitive parsing in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+- [x] T007 [US1] Update console output to reflect actual device type being queried (e.g., "Querying CrowdStrike for workstations...") in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+- [x] T008 [US1] Add error handling for invalid device type values with helpful message in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+
+**Checkpoint**: User Story 1 complete - can query WORKSTATION devices via CLI
+
+---
+
+## Phase 4: User Story 2 - Default Behavior Preserved (Priority: P1)
+
+**Goal**: Ensure backward compatibility - existing server queries work identically
+
+**Independent Test**: Run existing `./gradlew cli:run --args='query servers --dry-run'` without --device-type and verify SERVER behavior unchanged
+
+### Implementation for User Story 2
+
+- [x] T009 [US2] Verify deviceType property default remains "SERVER" in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+- [x] T010 [US2] Ensure queryServersWithFilters() defaults to SERVER when no deviceType specified in src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+
+**Checkpoint**: User Story 2 complete - backward compatibility verified
+
+---
+
+## Phase 5: User Story 3 - Query All Device Types (Priority: P2)
+
+**Goal**: Enable querying both servers and workstations in a single command
+
+**Independent Test**: Run `./gradlew cli:run --args='query servers --device-type ALL --dry-run --verbose'` and verify both device types are queried
+
+### Implementation for User Story 3
+
+- [x] T011 [US3] Implement ALL device type handling in getDeviceIdsFiltered() - query both SERVER and WORKSTATION, combine results in src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+- [x] T012 [US3] Update verbose output to show device type breakdown when querying ALL in src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+
+**Checkpoint**: User Story 3 complete - can query all device types in single command
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and build validation
+
+- [x] T013 Run ./gradlew build to verify compilation succeeds
+- [x] T014 Run quickstart.md validation scenarios to verify all device types work correctly
+- [x] T015 Update CLI documentation/help text if needed in src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 completion - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 priority and can proceed in parallel
+  - US3 depends on foundational work but is independent of US1/US2
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on T001-T004 (Foundational) - No dependencies on other stories
+- **User Story 2 (P1)**: Depends on T001-T004 (Foundational) - Shares T010 with US1 but tests different behavior
+- **User Story 3 (P2)**: Depends on T001-T004 (Foundational) - No dependencies on US1/US2
+
+### Task Dependencies Within Phases
+
+```
+Phase 1:  T001 (DeviceType enum)
+              ↓
+Phase 2:  T002 → T003 → T004 (sequential - same file modifications)
+              ↓
+Phase 3:  T005 → T006 → T007 → T008 (sequential - same file modifications)
+              ↓
+Phase 4:  T009, T010 (verification tasks, can run after US1)
+              ↓
+Phase 5:  T011 → T012 (sequential - T011 API, T012 CLI)
+              ↓
+Phase 6:  T013 → T014 → T015 (sequential - build first, test, then docs)
+```
+
+### Parallel Opportunities
+
+Within this feature, most tasks modify the same files (ServersCommand.kt, CrowdStrikeApiClientImpl.kt) so parallelism is limited. However:
+
+- T001 (DeviceType.kt) is a new file and can be created independently
+- User Stories 1, 2, and 3 are conceptually independent (different behaviors)
+- T013, T014, T015 in Polish phase are independent activities
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + User Story 2)
+
+1. Complete Phase 1: Create DeviceType enum
+2. Complete Phase 2: Refactor API client
+3. Complete Phase 3: User Story 1 (WORKSTATION queries)
+4. Complete Phase 4: User Story 2 (backward compatibility)
+5. **STOP and VALIDATE**: Test both WORKSTATION and default SERVER queries
+6. Build passes → MVP complete
+
+### Full Implementation
+
+1. Complete MVP (above)
+2. Complete Phase 5: User Story 3 (ALL device types)
+3. Complete Phase 6: Polish
+4. Final build validation
+
+### Incremental Delivery
+
+Each user story delivers independent value:
+- **After US1**: Can query workstation vulnerabilities
+- **After US2**: Existing server queries still work (confidence)
+- **After US3**: Can query comprehensive vulnerability landscape
+
+---
+
+## Notes
+
+- All tasks modify existing files except T001 (new DeviceType.kt)
+- No test tasks included (per constitution principle IV - testing only when requested)
+- US1 and US2 are both P1 priority because backward compatibility is critical
+- Commit after each completed phase
+- The existing `deviceType: String = "SERVER"` property in ServersCommand.kt already exists; we're enhancing its validation and usage

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -59,8 +59,8 @@ dependencies {
     implementation("org.eclipse.angus:angus-mail:2.0.5")
 
     // Amazon SES
-    implementation("software.amazon.awssdk:ses:2.40.8")
-    implementation("software.amazon.awssdk:auth:2.40.8")
+    implementation("software.amazon.awssdk:ses:2.40.9")
+    implementation("software.amazon.awssdk:auth:2.40.9")
 
     // Email templates (Thymeleaf) - Feature 035
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
@@ -95,7 +95,7 @@ dependencies {
     runtimeOnly("org.yaml:snakeyaml:2.5")
     
     // Password encoding
-    implementation("org.springframework.security:spring-security-crypto:7.0.0")
+    implementation("org.springframework.security:spring-security-crypto:7.0.2")
     implementation("commons-logging:commons-logging:1.3.5")
     
     // Document generation (Apache POI)

--- a/src/backendng/gradle.properties
+++ b/src/backendng/gradle.properties
@@ -1,5 +1,5 @@
 micronautVersion=4.10.1
-kotlinVersion=2.2.21
+kotlinVersion=2.3.0
 
 # Gradle daemon heap
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError

--- a/src/cli/build.gradle.kts
+++ b/src/cli/build.gradle.kts
@@ -44,8 +44,8 @@ dependencies {
     implementation("org.apache.commons:commons-csv:1.11.0")
     
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.3.0")
     
     // Logging
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -42,9 +42,16 @@ class SecmanCli {
                             serversCommand.hostnames = args[i + 1].split(",").map { it.trim() }
                             i++
                         }
-                        args[i] == "--device-type" && i + 1 < args.size -> {
-                            serversCommand.deviceType = args[i + 1]
-                            i++
+                        args[i] == "--device-type" -> {
+                            // Check if next arg exists and is not another flag
+                            if (i + 1 < args.size && !args[i + 1].startsWith("--")) {
+                                serversCommand.deviceType = args[i + 1]
+                                i++
+                            } else {
+                                // No value provided, default to SERVER
+                                serversCommand.deviceType = "SERVER"
+                                System.out.println("Info: No device type specified, defaulting to SERVER")
+                            }
                         }
                         args[i] == "--severity" && i + 1 < args.size -> {
                             serversCommand.severity = args[i + 1]
@@ -228,9 +235,9 @@ class SecmanCli {
               add-vulnerability      Add or update a vulnerability for an asset (Feature 052)
               help                   Show this help message
 
-            Query Servers Options (Feature 032):
-              --hostnames <list>       Comma-separated list of hostnames (optional, default: all servers)
-              --device-type <type>     Device type filter (default: SERVER)
+            Query Servers Options (Feature 032, 055):
+              --hostnames <list>       Comma-separated list of hostnames (optional, default: all devices)
+              --device-type <type>     Device type: SERVER, WORKSTATION, or ALL (default: SERVER)
               --severity <levels>      Severity filter (default: HIGH,CRITICAL)
               --min-days-open <num>    Minimum days open filter (default: 30)
               --limit <num>            Page size for pagination (default: 800)
@@ -313,6 +320,14 @@ class SecmanCli {
 
               # Query specific servers and save to database
               secman query servers --hostnames server01,server02 --save --username admin --password secret
+
+              # Query workstations/clients (Feature 055)
+              secman query servers --device-type WORKSTATION --dry-run --verbose
+              secman query servers --device-type WORKSTATION --severity CRITICAL,HIGH --save --username admin --password secret
+
+              # Query all device types (servers + workstations)
+              secman query servers --device-type ALL --dry-run --verbose
+              secman query servers --device-type ALL --save --username admin --password secret
 
               # Monitor continuously
               secman monitor --interval 10 --hostnames server01,server02,server03

--- a/src/shared/gradle.properties
+++ b/src/shared/gradle.properties
@@ -1,4 +1,4 @@
 micronautVersion=4.10.0
-kotlinVersion=2.2.21
+kotlinVersion=2.3.0
 
 org.gradle.configuration-cache=true

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/DeviceType.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/DeviceType.kt
@@ -1,0 +1,44 @@
+package com.secman.crowdstrike.dto
+
+/**
+ * Device type classification for CrowdStrike queries
+ *
+ * Feature: 055-cli-query-clients
+ * Maps to CrowdStrike's product_type_desc field values
+ */
+enum class DeviceType(val fqlValue: String) {
+    SERVER("Server"),
+    WORKSTATION("Workstation"),
+    ALL("");  // Special case: queries both types
+
+    /**
+     * Generate FQL filter string for CrowdStrike API
+     * Returns null for ALL (requires special handling - query both types)
+     */
+    fun toFqlFilter(): String? = when (this) {
+        SERVER -> "product_type_desc:'Server'"
+        WORKSTATION -> "product_type_desc:'Workstation'"
+        ALL -> null
+    }
+
+    /**
+     * Get display name for user-facing output
+     */
+    fun displayName(): String = when (this) {
+        SERVER -> "servers"
+        WORKSTATION -> "workstations"
+        ALL -> "all devices"
+    }
+
+    companion object {
+        /**
+         * Parse from string (case-insensitive)
+         * @throws IllegalArgumentException if invalid value
+         */
+        fun fromString(value: String): DeviceType =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException(
+                    "Invalid device type: '$value'. Valid values: ${entries.joinToString { it.name }}"
+                )
+    }
+}


### PR DESCRIPTION
Implements the 055-cli-query-clients feature, allowing the CLI 'query servers' command to filter by device type (SERVER, WORKSTATION, or ALL) using a new --device-type option. Adds a DeviceType enum, updates the shared CrowdStrike API client to support device type filtering, and enhances CLI output and validation. Updates documentation, build files, and specifications accordingly. Dependency versions for Kotlin and some libraries are also updated.