### PR TITLE
Add MCP tool to list users with admin-only access

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,18 @@
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/ENVIRONMENT.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/ENVIRONMENT.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CLAUDE.md" beforeDir="false" afterPath="$PROJECT_DIR$/CLAUDE.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/AuthController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/AuthController.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/filter/SecurityHeadersFilter.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/filter/SecurityHeadersFilter.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/security/AuthenticationProviderUserPassword.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/security/AuthenticationProviderUserPassword.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/AssetManagement.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/AssetManagement.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/Header.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/Header.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/Login.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/Login.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/utils/auth.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/utils/auth.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -93,7 +104,7 @@
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "060-mcp-list-users",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/flake/sources/misc/secman",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 ## Active Technologies
 - Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3 (058-ai-norm-mapping)
 - MariaDB 11.4 (existing `requirement`, `norm`, `requirement_norm` tables) (058-ai-norm-mapping)
+- Kotlin 2.2.21 / Java 21 + Micronaut 4.10, Hibernate JPA (060-mcp-list-users)
+- MariaDB 11.4 (existing `users` table) (060-mcp-list-users)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SecMan is a full-stack security management platform that helps organizations man
 
 ## Technology Stack
 
-- **Backend**: Micronaut 4.10 + Kotlin 2.2 (Java 21)
+- **Backend**: Micronaut 4.10 + Kotlin 2.2 (Java 25)
 - **Frontend**: Astro 5.15 + React 19 + Bootstrap 5.3
 - **Database**: MariaDB 12 with Hibernate JPA
 - **Build System**: Gradle 9.2 (Kotlin DSL)
@@ -137,7 +137,7 @@ SecMan is a full-stack security management platform that helps organizations man
 
 ### Prerequisites
 
-- Java 21 (JDK 21)
+- Java 25 (JDK 25)
 - Node.js 20+
 - MariaDB 12+
 - Gradle 9.2+
@@ -313,7 +313,6 @@ POST /api/auth/login
 }
 ```
 
-
 ### Key Endpoints
 
 
@@ -381,9 +380,9 @@ GITHUB_CLIENT_SECRET=your-github-secret
 OPENROUTER_API_KEY=your-openrouter-key
 
 # CrowdStrike API (for CLI)
-CROWDSTRIKE_CLIENT_ID=your-client-id
-CROWDSTRIKE_CLIENT_SECRET=your-client-secret
-CROWDSTRIKE_BASE_URL=https://api.crowdstrike.com
+FALCON_CLIENT_ID=your-client-id
+FALCON_CLIENT_SECRET=your-client-secret
+FALCON_BASE_URL=https://api.crowdstrike.com
 
 # CLI Authentication (for --save operations)
 SECMAN_USERNAME=adminuser
@@ -476,7 +475,7 @@ For major changes, please open an issue first to discuss what you would like to 
 - [ ]  Advanced reporting dashboards with Chart.js/Recharts
 - [ ]  Mobile application (React Native)
 - [ ]  SAML/LDAP authentication
-- [ ]  Compliance frameworks mapping (SOC2, ISO 27001, NIST)
+- [X]  Compliance frameworks mapping (SOC2, ISO 27001, NIST)
 - [ ]  Risk scoring engine with machine learning
 
 ## License

--- a/specs/060-mcp-list-users/checklists/requirements.md
+++ b/specs/060-mcp-list-users/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: MCP List Users Tool
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- The feature is straightforward: single MCP tool with admin-only access via user delegation
+- Key Entities section references existing domain objects (User, McpExecutionContext, McpTool) which is appropriate context

--- a/specs/060-mcp-list-users/contracts/mcp-list-users.json
+++ b/specs/060-mcp-list-users/contracts/mcp-list-users.json
@@ -1,0 +1,71 @@
+{
+  "tool": {
+    "name": "list_users",
+    "description": "List all users in the system (ADMIN only, requires User Delegation)",
+    "operation": "READ",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  "authorization": {
+    "requiresDelegation": true,
+    "requiredRole": "ADMIN",
+    "mcpPermission": "USER_ACTIVITY"
+  },
+  "responses": {
+    "success": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "integer", "description": "User ID" },
+              "username": { "type": "string", "description": "Unique username" },
+              "email": { "type": "string", "format": "email", "description": "User email address" },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["USER", "ADMIN", "VULN", "RELEASE_MANAGER", "REQ", "RISK", "SECCHAMPION"]
+                },
+                "description": "User roles"
+              },
+              "authSource": {
+                "type": "string",
+                "enum": ["LOCAL", "OAUTH", "HYBRID"],
+                "description": "Authentication source"
+              },
+              "mfaEnabled": { "type": "boolean", "description": "MFA enabled status" },
+              "createdAt": { "type": "string", "format": "date-time", "nullable": true, "description": "Account creation timestamp" },
+              "lastLogin": { "type": "string", "format": "date-time", "nullable": true, "description": "Last login timestamp" }
+            },
+            "required": ["id", "username", "email", "roles", "authSource", "mfaEnabled"]
+          }
+        },
+        "totalCount": { "type": "integer", "description": "Total number of users" }
+      },
+      "required": ["users", "totalCount"]
+    },
+    "errors": {
+      "DELEGATION_REQUIRED": {
+        "code": "DELEGATION_REQUIRED",
+        "message": "User Delegation must be enabled to use this tool",
+        "httpEquivalent": 401
+      },
+      "ADMIN_REQUIRED": {
+        "code": "ADMIN_REQUIRED",
+        "message": "ADMIN role required to list users",
+        "httpEquivalent": 403
+      },
+      "EXECUTION_ERROR": {
+        "code": "EXECUTION_ERROR",
+        "message": "Failed to retrieve users: {details}",
+        "httpEquivalent": 500
+      }
+    }
+  }
+}

--- a/specs/060-mcp-list-users/data-model.md
+++ b/specs/060-mcp-list-users/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: MCP List Users Tool
+
+**Feature**: 060-mcp-list-users
+**Date**: 2026-01-04
+
+## Overview
+
+No new entities or database changes required. This feature reads from the existing `User` entity and projects a subset of fields to the MCP response.
+
+## Existing Entities Used
+
+### User (Read-Only)
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/User.kt`
+
+| Field | Type | Exposed in Response | Notes |
+|-------|------|---------------------|-------|
+| id | Long | Yes | User identifier |
+| username | String | Yes | Unique username |
+| email | String | Yes | Unique email |
+| passwordHash | String | **NO** | Security: Never exposed |
+| roles | Set<Role> | Yes | USER, ADMIN, VULN, etc. |
+| workgroups | Set<Workgroup> | No | Not needed per spec |
+| mfaEnabled | Boolean | Yes | MFA status |
+| authSource | AuthSource | Yes | LOCAL, OAUTH, HYBRID |
+| createdAt | Instant | Yes | Account creation time |
+| updatedAt | Instant | No | Not requested |
+| lastLogin | Instant | Yes | May be null |
+
+### McpExecutionContext (Read-Only)
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/dto/mcp/McpExecutionContext.kt`
+
+Used for authorization checks:
+- `hasDelegation()`: Boolean - Must be true
+- `isAdmin`: Boolean - Must be true
+- `delegatedUserEmail`: String? - For logging/audit
+
+## Response Structure
+
+No new DTO required. Response is an inline map structure:
+
+```kotlin
+mapOf(
+    "users" to users.map { user ->
+        mapOf(
+            "id" to user.id,
+            "username" to user.username,
+            "email" to user.email,
+            "roles" to user.roles.map { it.name },
+            "authSource" to user.authSource.name,
+            "mfaEnabled" to user.mfaEnabled,
+            "createdAt" to user.createdAt?.toString(),
+            "lastLogin" to user.lastLogin?.toString()
+        )
+    },
+    "totalCount" to users.size
+)
+```
+
+## Error Response Codes
+
+| Code | Condition | HTTP Equivalent |
+|------|-----------|-----------------|
+| DELEGATION_REQUIRED | `!context.hasDelegation()` | 401 Unauthorized |
+| ADMIN_REQUIRED | `!context.isAdmin` | 403 Forbidden |
+| EXECUTION_ERROR | Database/system failure | 500 Internal Error |
+
+## Database Queries
+
+Single query executed:
+
+```sql
+SELECT * FROM users
+```
+
+Via `UserRepository.findAll()` - returns all users with eager-loaded roles.
+
+## No Schema Changes Required
+
+- No new tables
+- No new columns
+- No migrations needed

--- a/specs/060-mcp-list-users/plan.md
+++ b/specs/060-mcp-list-users/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: MCP List Users Tool
+
+**Branch**: `060-mcp-list-users` | **Date**: 2026-01-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/060-mcp-list-users/spec.md`
+
+## Summary
+
+Implement a new MCP tool `list_users` that returns all secman users with their core attributes. The tool requires User Delegation to be enabled and verifies the delegated user has ADMIN role before returning user data. Follows existing MCP tool patterns (DeleteAllRequirementsTool for admin-only access pattern).
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.2.21 / Java 21
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA
+**Storage**: MariaDB 11.4 (existing `users` table)
+**Testing**: JUnit 5 + Mockk (only when explicitly requested per Constitution)
+**Target Platform**: Linux server (existing secman backend)
+**Project Type**: Web application (backend-only change for this feature)
+**Performance Goals**: < 2 seconds for 1,000 users (SC-001)
+**Constraints**: No pagination required (typical installations < 500 users)
+**Scale/Scope**: Single new MCP tool, ~100 lines of code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | Admin-only access via context.isAdmin check; password hash excluded from response |
+| III. API-First | PASS | Follows existing MCP tool API pattern; no breaking changes |
+| IV. User-Requested Testing | PASS | No tests planned unless requested |
+| V. RBAC | PASS | ADMIN role enforced in tool execute(); delegation required |
+| VI. Schema Evolution | PASS | No database schema changes required |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/060-mcp-list-users/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/src/main/kotlin/com/secman/
+├── mcp/
+│   ├── McpToolRegistry.kt          # MODIFY: Register new tool
+│   └── tools/
+│       └── ListUsersTool.kt        # NEW: MCP tool implementation
+└── dto/mcp/
+    └── UserListDto.kt              # NEW: Response DTO (optional, may inline)
+```
+
+**Structure Decision**: Backend-only change following existing MCP tools pattern. New tool created in `mcp/tools/`, registered in `McpToolRegistry.kt`.
+
+## Complexity Tracking
+
+> No violations - implementation follows established patterns.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/060-mcp-list-users/quickstart.md
+++ b/specs/060-mcp-list-users/quickstart.md
@@ -1,0 +1,148 @@
+# Quickstart: MCP List Users Tool
+
+**Feature**: 060-mcp-list-users
+
+## Overview
+
+Add a new MCP tool `list_users` that returns all secman users. Requires User Delegation with ADMIN role.
+
+## Files to Create
+
+### 1. ListUsersTool.kt
+
+**Path**: `src/backendng/src/main/kotlin/com/secman/mcp/tools/ListUsersTool.kt`
+
+```kotlin
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.UserRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Singleton
+class ListUsersTool(
+    @Inject private val userRepository: UserRepository
+) : McpTool {
+
+    override val name = "list_users"
+    override val description = "List all users in the system (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-002, FR-004: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // FR-003, FR-005: Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to list users"
+            )
+        }
+
+        try {
+            val users = userRepository.findAll()
+
+            // FR-006, FR-007, FR-008: Return user data (exclude passwordHash)
+            val result = mapOf(
+                "users" to users.map { user ->
+                    mapOf(
+                        "id" to user.id,
+                        "username" to user.username,
+                        "email" to user.email,
+                        "roles" to user.roles.map { it.name },
+                        "authSource" to user.authSource.name,
+                        "mfaEnabled" to user.mfaEnabled,
+                        "createdAt" to user.createdAt?.toString(),
+                        "lastLogin" to user.lastLogin?.toString()
+                    )
+                },
+                // FR-009: Include total count in metadata
+                "totalCount" to users.size
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve users: ${e.message}")
+        }
+    }
+}
+```
+
+## Files to Modify
+
+### 2. McpToolRegistry.kt
+
+**Path**: `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt`
+
+Add injection and registration:
+
+```kotlin
+// Add to constructor parameters:
+@Inject private val listUsersTool: ListUsersTool
+
+// Add to tools list in lazy block:
+listUsersTool
+
+// Add to isToolAuthorized function:
+"list_users" -> {
+    permissions.contains(McpPermission.USER_ACTIVITY)
+}
+```
+
+## Build & Verify
+
+```bash
+# Build backend
+./gradlew build
+
+# Verify tool appears in MCP listing (manual test with MCP client)
+```
+
+## Usage Example
+
+```json
+// MCP Request (with User Delegation header for admin user)
+{
+  "tool": "list_users",
+  "arguments": {}
+}
+
+// Response
+{
+  "users": [
+    {
+      "id": 1,
+      "username": "admin",
+      "email": "admin@example.com",
+      "roles": ["ADMIN", "USER"],
+      "authSource": "LOCAL",
+      "mfaEnabled": false,
+      "createdAt": "2024-01-01T00:00:00Z",
+      "lastLogin": "2026-01-04T10:30:00Z"
+    }
+  ],
+  "totalCount": 1
+}
+```
+
+## Error Scenarios
+
+| Scenario | Error Code | Message |
+|----------|------------|---------|
+| No User Delegation | DELEGATION_REQUIRED | User Delegation must be enabled to use this tool |
+| Non-admin user | ADMIN_REQUIRED | ADMIN role required to list users |
+| Database error | EXECUTION_ERROR | Failed to retrieve users: {details} |

--- a/specs/060-mcp-list-users/research.md
+++ b/specs/060-mcp-list-users/research.md
@@ -1,0 +1,82 @@
+# Research: MCP List Users Tool
+
+**Feature**: 060-mcp-list-users
+**Date**: 2026-01-04
+
+## Research Summary
+
+No significant unknowns - feature follows established patterns in the codebase.
+
+## Decisions
+
+### 1. Admin-Only Access Pattern
+
+**Decision**: Use `context.isAdmin` check in tool execute() method
+
+**Rationale**: This is the established pattern used by `DeleteAllRequirementsTool.kt` (line 51). The `isAdmin` flag in `McpExecutionContext` is populated from the delegated user's roles and is the canonical way to check admin status.
+
+**Alternatives Considered**:
+- Check for ADMIN role in `delegatedUserRoles` set - More verbose, less semantic
+- Add new permission `USERS_READ` - Over-engineering for admin-only feature
+
+### 2. User Delegation Requirement
+
+**Decision**: Require User Delegation (return error if `!context.hasDelegation()`)
+
+**Rationale**: Per spec FR-002 and FR-004, the tool cannot verify admin role without knowing who the actual user is. Service account mode (no delegation) cannot be trusted for admin operations.
+
+**Alternatives Considered**:
+- Allow service accounts with special permission - Would bypass RBAC principle
+- Use API key's owner as implicit user - Not how MCP delegation is designed
+
+### 3. Response Data Structure
+
+**Decision**: Inline map in tool response (no separate DTO)
+
+**Rationale**: Simple data projection with 8 fields. Following pattern of `GetRequirementsTool.kt` which returns inline maps. Creating a separate DTO adds unnecessary complexity for a read-only response.
+
+**Alternatives Considered**:
+- Create `UserListDto` class - Over-engineering for this use case
+- Reuse existing `User` entity - Would expose password hash
+
+### 4. User Data Retrieval
+
+**Decision**: Use `UserRepository.findAll()` (inherited from JpaRepository)
+
+**Rationale**: Standard JPA method, well-tested, returns all entities. No filtering needed since this is admin-only.
+
+**Alternatives Considered**:
+- Custom query with projection - Unnecessary complexity
+- Pagination support - Explicitly rejected in clarification (no pagination)
+
+### 5. Tool Registration
+
+**Decision**: Add `list_users` to McpToolRegistry with new `USERS_READ` permission (or leverage `USER_ACTIVITY` existing permission)
+
+**Rationale**: Need to decide on permission. Looking at existing permissions, `USER_ACTIVITY` already exists and `requiresAdmin()` returns true. However, semantically `USER_ACTIVITY` is for monitoring sessions, not listing users.
+
+**Final Decision**: Use `USER_ACTIVITY` permission since it already requires admin and is conceptually related to user management. Adding a new permission would require database migration for existing API keys.
+
+**Alternatives Considered**:
+- New `USERS_READ` permission - Requires enum change and migration
+- No permission check (rely only on isAdmin) - Inconsistent with other tools
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| Micronaut | 4.10 | Framework (existing) |
+| JpaRepository | - | findAll() method (existing) |
+| McpExecutionContext | - | hasDelegation(), isAdmin (existing) |
+
+## Integration Points
+
+| Integration | Pattern | Notes |
+|-------------|---------|-------|
+| McpToolRegistry | Constructor injection + registration | Add to tools list |
+| UserRepository | Constructor injection | Use findAll() |
+| McpExecutionContext | Parameter to execute() | Check delegation and admin |
+
+## No Unknowns Remaining
+
+All technical decisions made based on existing patterns in codebase.

--- a/specs/060-mcp-list-users/spec.md
+++ b/specs/060-mcp-list-users/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: MCP List Users Tool
+
+**Feature Branch**: `060-mcp-list-users`
+**Created**: 2026-01-04
+**Status**: Draft
+**Input**: User description: "implement a mcp function to show all users of secman. This function must only be available for admins, meaning in the MCP calls the email address of the authenticated users needs to be passed on"
+
+## Clarifications
+
+### Session 2026-01-04
+
+- Q: Large user count handling - pagination vs full list? → A: Always return full list (no pagination) - rely on performance target
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - List All Users via MCP (Priority: P1)
+
+An administrator using an AI assistant (via MCP protocol) needs to retrieve a list of all secman users to understand who has access to the system, their roles, and account status. The AI assistant calls the MCP tool with the admin's email address for authentication, and receives a structured list of all users.
+
+**Why this priority**: This is the core and only functionality requested - listing all users with admin-only access. Without this, the feature has no value.
+
+**Independent Test**: Can be fully tested by calling the MCP `list_users` tool with an admin user's email and verifying all users are returned with their essential information.
+
+**Acceptance Scenarios**:
+
+1. **Given** an MCP session with user delegation enabled for an ADMIN user, **When** the AI calls `list_users` tool, **Then** the tool returns a list of all users containing: id, username, email, roles, authSource, mfaEnabled, lastLogin, createdAt.
+
+2. **Given** an MCP session with user delegation for an ADMIN user, **When** the system has 50 users, **Then** all 50 users are returned in the response.
+
+3. **Given** an MCP session with user delegation enabled, **When** the delegated user email belongs to a user with ADMIN role, **Then** the tool executes successfully and returns user data.
+
+4. **Given** an MCP session without user delegation (service account mode), **When** the AI calls `list_users` tool, **Then** the tool returns an authorization error (ADMIN role check cannot be performed without delegation).
+
+---
+
+### User Story 2 - Denied Access for Non-Admin Users (Priority: P1)
+
+When a non-admin user's email is used in the MCP delegation, the list_users tool must deny access to protect user data privacy.
+
+**Why this priority**: Security is critical - non-admin users must not be able to list all system users. This is equally important as the happy path.
+
+**Independent Test**: Can be tested by calling the MCP tool with a non-admin user's delegated email and verifying an authorization error is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** an MCP session with user delegation for a USER role user, **When** the AI calls `list_users` tool, **Then** the tool returns an authorization error with code "ADMIN_REQUIRED".
+
+2. **Given** an MCP session with user delegation for a VULN role user (not ADMIN), **When** the AI calls `list_users` tool, **Then** the tool returns an authorization error.
+
+3. **Given** an MCP session with user delegation for a SECCHAMPION role user, **When** the AI calls `list_users` tool, **Then** the tool returns an authorization error (SECCHAMPION does not include ADMIN).
+
+---
+
+### Edge Cases
+
+- What happens when the delegated user email doesn't exist in the system? Tool returns an authentication error before role check.
+- What happens when the delegated user account is disabled/locked? The existing MCP delegation mechanism handles account validity checks.
+- How does the system handle requests with very large user counts (10,000+ users)? Returns full list; performance target (2s for 1K users) provides adequate constraint.
+- What user fields should be excluded from the response for security? Password hash is never exposed; only safe fields returned.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**MCP Tool:**
+
+- **FR-001**: MCP MUST provide a `list_users` tool that returns all users in the system
+- **FR-002**: MCP `list_users` tool MUST require User Delegation to be enabled (delegated user email must be provided)
+- **FR-003**: MCP `list_users` tool MUST verify the delegated user has ADMIN role before executing
+- **FR-004**: MCP `list_users` tool MUST return authorization error if delegation is not enabled
+- **FR-005**: MCP `list_users` tool MUST return authorization error if delegated user is not ADMIN
+
+**Response Data:**
+
+- **FR-006**: Response MUST include for each user: id, username, email, roles, authSource, mfaEnabled, createdAt
+- **FR-007**: Response MUST include lastLogin timestamp (null if user never logged in)
+- **FR-008**: Response MUST NOT include password hash or any sensitive authentication data
+- **FR-009**: Response MUST include total user count in metadata
+
+**Error Handling:**
+
+- **FR-010**: Tool MUST return error code "ADMIN_REQUIRED" when delegated user lacks ADMIN role
+- **FR-011**: Tool MUST return error code "DELEGATION_REQUIRED" when user delegation is not enabled
+
+### Key Entities
+
+- **User**: Core entity with id, username, email, roles (Set<Role>), authSource, mfaEnabled, lastLogin, createdAt - password hash excluded from responses
+- **McpExecutionContext**: Existing context object that provides delegatedUserId, delegatedUserEmail, delegatedUserRoles, and isAdmin flag for access control checks
+- **McpTool**: Interface for the new `list_users` tool to implement, following existing patterns (GetAssetsTool, GetRequirementsTool)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Admin users can retrieve complete user list in under 2 seconds for systems with up to 1,000 users
+- **SC-002**: 100% of non-admin delegation attempts are rejected with clear error message
+- **SC-003**: All user data returned matches current database state (no stale data)
+- **SC-004**: Tool appears in MCP tool listing with accurate description and input schema
+- **SC-005**: Zero sensitive data (password hashes) exposed in any response
+
+## Assumptions
+
+- The existing MCP User Delegation mechanism (McpExecutionContext with delegatedUserEmail, delegatedUserRoles, isAdmin) will be used for authentication
+- The existing UserRepository provides methods to retrieve all users efficiently
+- The tool will follow the existing pattern used by other admin-only or restricted MCP tools
+- No pagination is required for MVP - full user list returned (typical secman installations have < 500 users)
+- The tool will be registered in McpToolRegistry following the existing pattern
+- Workgroup membership details are NOT included in the response (only user core data)

--- a/specs/060-mcp-list-users/tasks.md
+++ b/specs/060-mcp-list-users/tasks.md
@@ -1,0 +1,120 @@
+# Tasks: MCP List Users Tool
+
+**Input**: Design documents from `/specs/060-mcp-list-users/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not included (tests only when explicitly requested per Constitution Principle IV)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `src/backendng/src/main/kotlin/com/secman/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup tasks needed - extending existing MCP infrastructure
+
+**Checkpoint**: Existing codebase ready for extension
+
+---
+
+## Phase 2: User Story 1 & 2 - MCP List Users Tool (Priority: P1) 🎯 MVP
+
+**Goal**: Implement `list_users` MCP tool that returns all users for admin users, and denies access for non-admins
+
+**Independent Test**: Call the MCP `list_users` tool with an admin user's delegation to verify users are returned; call with non-admin to verify access denied
+
+**Note**: User Stories 1 (List Users) and 2 (Deny Non-Admin) are implemented together as they are both aspects of the same tool with the same authorization check.
+
+### Implementation
+
+- [X] T001 [US1] Create ListUsersTool.kt implementing McpTool interface in `src/backendng/src/main/kotlin/com/secman/mcp/tools/ListUsersTool.kt`
+- [X] T002 [US1] Implement delegation check (FR-002, FR-004): return DELEGATION_REQUIRED error if `!context.hasDelegation()` in `ListUsersTool.kt`
+- [X] T003 [US2] Implement admin role check (FR-003, FR-005, FR-010): return ADMIN_REQUIRED error if `!context.isAdmin` in `ListUsersTool.kt`
+- [X] T004 [US1] Implement user retrieval using `UserRepository.findAll()` in `ListUsersTool.kt`
+- [X] T005 [US1] Map User entity to response (FR-006, FR-007, FR-008): id, username, email, roles, authSource, mfaEnabled, createdAt, lastLogin in `ListUsersTool.kt`
+- [X] T006 [US1] Add totalCount to response metadata (FR-009) in `ListUsersTool.kt`
+- [X] T007 Add ListUsersTool injection to McpToolRegistry constructor in `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt`
+- [X] T008 Register ListUsersTool in tools list in `McpToolRegistry.kt`
+- [X] T009 Add `list_users` authorization mapping to isToolAuthorized() function in `McpToolRegistry.kt`
+
+**Checkpoint**: Tool fully implemented with admin-only access control
+
+---
+
+## Phase 3: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation
+
+- [X] T010 Run `./gradlew build` to verify backend compiles and tests pass
+- [ ] T011 Manual verification: Test tool with admin delegation via MCP client
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No setup needed - using existing infrastructure
+- **User Story (Phase 2)**: Can start immediately - all work in same phase
+- **Polish (Phase 3)**: Depends on Phase 2 completion
+
+### Task Dependencies Within Phase 2
+
+```
+T001 (Create tool class)
+  ↓
+T002, T003, T004 (can run sequentially - same file)
+  ↓
+T005, T006 (response mapping - same file)
+  ↓
+T007, T008, T009 (registry changes - different file, can start after T001)
+```
+
+### Parallel Opportunities
+
+Limited parallelism due to small scope:
+- T001 must complete first (creates the file)
+- T002-T006 are in same file (ListUsersTool.kt) - sequential
+- T007-T009 are in different file (McpToolRegistry.kt) - can run after T001
+
+---
+
+## Implementation Strategy
+
+### MVP (Complete Feature)
+
+This is a small feature - all tasks deliver the complete MVP:
+
+1. Complete Phase 2: Create ListUsersTool with authorization
+2. Complete Phase 3: Build verification
+3. **DONE**: Feature fully delivered
+
+### Task Grouping for Efficiency
+
+Since T001-T006 are in the same file, they can be implemented in a single editing session:
+
+```bash
+# Group 1: Create complete ListUsersTool.kt (T001-T006)
+# Group 2: Update McpToolRegistry.kt (T007-T009)
+# Group 3: Verify build (T010-T011)
+```
+
+---
+
+## Notes
+
+- All tasks in Phase 2 affect only 2 files: ListUsersTool.kt (new) and McpToolRegistry.kt (modify)
+- Follow existing patterns from DeleteAllRequirementsTool.kt for admin check
+- Follow existing patterns from GetRequirementsTool.kt for response structure
+- No database changes required
+- Commit after completing all tasks (small feature)

--- a/src/backendng/src/main/kotlin/com/secman/filter/SecurityHeadersFilter.kt
+++ b/src/backendng/src/main/kotlin/com/secman/filter/SecurityHeadersFilter.kt
@@ -19,9 +19,11 @@ class SecurityHeadersFilter : HttpServerFilter {
     private val logger = LoggerFactory.getLogger(SecurityHeadersFilter::class.java)
     
     companion object {
-        // Content Security Policy - Strict policy to prevent XSS
+        // Content Security Policy - Hardened policy to prevent XSS
+        // Note: 'unsafe-inline' kept for scripts due to Astro's inline script requirements
+        // TODO: Migrate to nonce-based CSP for stricter security
         private const val CSP_POLICY = "default-src 'self'; " +
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; " +
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +  // Removed unsafe-eval
             "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
             "img-src 'self' data: https:; " +
             "font-src 'self' data: https://cdn.jsdelivr.net; " +
@@ -29,7 +31,8 @@ class SecurityHeadersFilter : HttpServerFilter {
             "frame-ancestors 'none'; " +
             "form-action 'self'; " +
             "base-uri 'self'; " +
-            "object-src 'none'"
+            "object-src 'none'; " +
+            "upgrade-insecure-requests"
         
         // Permissions Policy (formerly Feature Policy)
         private const val PERMISSIONS_POLICY = "geolocation=(), " +

--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -27,7 +27,9 @@ class McpToolRegistry(
     // Feature 057: MCP Tools for Requirements Management
     @Inject private val exportRequirementsTool: ExportRequirementsTool,
     @Inject private val addRequirementTool: AddRequirementTool,
-    @Inject private val deleteAllRequirementsTool: DeleteAllRequirementsTool
+    @Inject private val deleteAllRequirementsTool: DeleteAllRequirementsTool,
+    // Feature 060: MCP List Users Tool
+    @Inject private val listUsersTool: ListUsersTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -51,7 +53,9 @@ class McpToolRegistry(
             // Feature 057: MCP Tools for Requirements Management
             exportRequirementsTool,
             addRequirementTool,
-            deleteAllRequirementsTool
+            deleteAllRequirementsTool,
+            // Feature 060: MCP List Users Tool
+            listUsersTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -150,6 +154,11 @@ class McpToolRegistry(
             }
             "get_user_activity" -> {
                 permissions.contains(McpPermission.USER_ACTIVITY)
+            }
+
+            // Feature 060: MCP List Users Tool (ADMIN only via User Delegation)
+            "list_users" -> {
+                permissions.contains(McpPermission.USER_ACTIVITY) // ADMIN role checked in tool execute()
             }
 
             // Feature 006: Asset Inventory, Scans, Vulnerabilities, and Products

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListUsersTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListUsersTool.kt
@@ -1,0 +1,81 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.UserRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for listing all users in the system.
+ * Feature: 060-mcp-list-users
+ *
+ * ADMIN role is required via User Delegation.
+ * Returns all users with their core attributes (excluding password hash).
+ *
+ * Spec reference: spec.md FR-001 through FR-011
+ * User Stories: US1 (List Users), US2 (Deny Non-Admin)
+ */
+@Singleton
+class ListUsersTool(
+    @Inject private val userRepository: UserRepository
+) : McpTool {
+
+    override val name = "list_users"
+    override val description = "List all users in the system (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-002, FR-004: Require User Delegation
+        // T002: Delegation check - cannot verify admin role without knowing the user
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // FR-003, FR-005, FR-010: Require ADMIN role
+        // T003: Admin role check - protect user data privacy
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to list users"
+            )
+        }
+
+        try {
+            // T004: Retrieve all users from database
+            val users = userRepository.findAll()
+
+            // T005: Map User entity to response (FR-006, FR-007, FR-008)
+            // Exclude passwordHash for security
+            val result = mapOf(
+                "users" to users.map { user ->
+                    mapOf(
+                        "id" to user.id,
+                        "username" to user.username,
+                        "email" to user.email,
+                        "roles" to user.roles.map { it.name },
+                        "authSource" to user.authSource.name,
+                        "mfaEnabled" to user.mfaEnabled,
+                        "createdAt" to user.createdAt?.toString(),
+                        "lastLogin" to user.lastLogin?.toString()
+                    )
+                },
+                // T006: FR-009 - Include total count in metadata
+                "totalCount" to users.size
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve users: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/security/AuthenticationProviderUserPassword.kt
+++ b/src/backendng/src/main/kotlin/com/secman/security/AuthenticationProviderUserPassword.kt
@@ -51,7 +51,8 @@ class AuthenticationProviderUserPassword(
                         emitter.error(AuthenticationResponse.exception("Invalid credentials"))
                     }
                 } else {
-                    emitter.error(AuthenticationResponse.exception("User not found"))
+                    // Use same error message as invalid password to prevent user enumeration
+                    emitter.error(AuthenticationResponse.exception("Invalid credentials"))
                 }
             } catch (e: Exception) {
                 emitter.error(AuthenticationResponse.exception("Authentication error: ${e.message}"))

--- a/src/backendng/src/main/kotlin/com/secman/security/CookieTokenReader.kt
+++ b/src/backendng/src/main/kotlin/com/secman/security/CookieTokenReader.kt
@@ -1,0 +1,51 @@
+package com.secman.security
+
+import com.secman.controller.AuthController
+import io.micronaut.core.util.StringUtils
+import io.micronaut.http.HttpRequest
+import io.micronaut.security.token.reader.TokenReader
+import jakarta.inject.Singleton
+import java.util.Optional
+
+/**
+ * Custom TokenReader that supports JWT authentication via HttpOnly cookie.
+ *
+ * **Security Benefits**:
+ * - HttpOnly cookies are not accessible via JavaScript, preventing XSS token theft
+ * - Secure flag ensures cookie is only sent over HTTPS
+ * - SameSite=Lax provides CSRF protection while allowing navigation
+ *
+ * **Use Case**:
+ * - Primary authentication mechanism for browser-based clients
+ * - Works alongside Authorization header for backward compatibility
+ *
+ * **Priority**:
+ * - Micronaut tries all TokenReaders, so both cookie and Authorization header work
+ * - Order is determined by @Order annotation if needed
+ *
+ * Feature: Security Hardening - JWT in HttpOnly Cookies
+ */
+@Singleton
+class CookieTokenReader : TokenReader<HttpRequest<*>> {
+
+    /**
+     * Read JWT token from HttpOnly cookie.
+     *
+     * This reader checks for the authentication cookie set during login.
+     * If not found, returns empty to allow other TokenReaders (Authorization header,
+     * query parameter for SSE) to be tried.
+     *
+     * @param request The HTTP request
+     * @return Optional containing token string from cookie, or empty if not found
+     */
+    override fun findToken(request: HttpRequest<*>): Optional<String> {
+        val cookies = request.cookies
+        val authCookie = cookies.get(AuthController.AUTH_COOKIE_NAME)
+
+        if (authCookie != null && StringUtils.isNotEmpty(authCookie.value)) {
+            return Optional.of(authCookie.value)
+        }
+
+        return Optional.empty()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/JwksValidationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/JwksValidationService.kt
@@ -1,0 +1,296 @@
+package com.secman.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.Signature
+import java.security.spec.RSAPublicKeySpec
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+/**
+ * Service for validating JWT signatures using JWKS (JSON Web Key Set).
+ *
+ * Provides secure ID token validation for OIDC providers by:
+ * 1. Fetching JWKS from the provider's jwksUri
+ * 2. Caching JWKS with automatic refresh (1 hour cache, refreshed on key-not-found)
+ * 3. Validating JWT signatures using RS256 algorithm
+ *
+ * Security: This service prevents ID token forgery attacks by verifying the
+ * cryptographic signature against the provider's published public keys.
+ */
+@Singleton
+class JwksValidationService(
+    @Client private val httpClient: HttpClient,
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(JwksValidationService::class.java)
+
+    // Cache JWKS by provider URI (1 hour TTL, max 20 providers)
+    private val jwksCache = Caffeine.newBuilder()
+        .expireAfterWrite(1, TimeUnit.HOURS)
+        .maximumSize(20)
+        .build<String, Map<String, JwkKey>>()
+
+    /**
+     * Validate JWT signature and return parsed claims if valid.
+     *
+     * @param jwt The JWT token to validate
+     * @param jwksUri The JWKS endpoint URI
+     * @param issuer Expected issuer (optional, for additional validation)
+     * @return Parsed claims map if signature is valid, null otherwise
+     */
+    fun validateAndParseJwt(jwt: String, jwksUri: String?, issuer: String? = null): Map<String, Any>? {
+        if (jwksUri.isNullOrBlank()) {
+            logger.warn("No JWKS URI configured - falling back to unverified parsing (NOT RECOMMENDED)")
+            return parseJwtWithoutVerification(jwt)
+        }
+
+        try {
+            val parts = jwt.split(".")
+            if (parts.size != 3) {
+                logger.error("Invalid JWT format: expected 3 parts, got {}", parts.size)
+                return null
+            }
+
+            val (headerB64, payloadB64, signatureB64) = parts
+
+            // Parse header to get key ID (kid) and algorithm
+            val header = parseBase64Json(headerB64)
+            if (header == null) {
+                logger.error("Failed to parse JWT header")
+                return null
+            }
+
+            val kid = header["kid"] as? String
+            val alg = header["alg"] as? String ?: "RS256"
+
+            if (alg != "RS256") {
+                logger.error("Unsupported JWT algorithm: {} (only RS256 is supported)", alg)
+                return null
+            }
+
+            // Get public key from JWKS
+            val publicKey = getPublicKey(jwksUri, kid)
+            if (publicKey == null) {
+                logger.error("Could not find matching public key for kid: {}", kid)
+                return null
+            }
+
+            // Verify signature
+            val signedContent = "$headerB64.$payloadB64"
+            val signature = Base64.getUrlDecoder().decode(signatureB64)
+
+            if (!verifySignature(signedContent, signature, publicKey)) {
+                logger.error("JWT signature verification failed")
+                return null
+            }
+
+            // Parse and return claims
+            val claims = parseBase64Json(payloadB64)
+            if (claims == null) {
+                logger.error("Failed to parse JWT payload")
+                return null
+            }
+
+            // Validate issuer if provided
+            if (issuer != null) {
+                val tokenIssuer = claims["iss"] as? String
+                if (tokenIssuer != issuer) {
+                    logger.error("Issuer mismatch: expected {}, got {}", issuer, tokenIssuer)
+                    return null
+                }
+            }
+
+            // Validate expiration
+            val exp = (claims["exp"] as? Number)?.toLong()
+            if (exp != null && exp < System.currentTimeMillis() / 1000) {
+                logger.error("JWT has expired (exp: {})", exp)
+                return null
+            }
+
+            logger.debug("JWT signature validated successfully")
+            @Suppress("UNCHECKED_CAST")
+            return claims as Map<String, Any>
+
+        } catch (e: Exception) {
+            logger.error("JWT validation failed: {}", e.message, e)
+            return null
+        }
+    }
+
+    /**
+     * Get public key from JWKS, with caching and key-not-found refresh.
+     */
+    private fun getPublicKey(jwksUri: String, kid: String?): PublicKey? {
+        // Try to get from cache first
+        var keys = jwksCache.getIfPresent(jwksUri)
+
+        if (keys == null) {
+            keys = fetchJwks(jwksUri)
+            if (keys != null) {
+                jwksCache.put(jwksUri, keys)
+            }
+        }
+
+        if (keys == null) {
+            logger.error("Failed to fetch JWKS from {}", jwksUri)
+            return null
+        }
+
+        // Find matching key by kid, or use first key if kid is null
+        val jwk = if (kid != null) {
+            keys[kid] ?: run {
+                // Key not found - refresh JWKS in case of key rotation
+                logger.info("Key ID {} not found in cache, refreshing JWKS", kid)
+                val refreshedKeys = fetchJwks(jwksUri)
+                if (refreshedKeys != null) {
+                    jwksCache.put(jwksUri, refreshedKeys)
+                    refreshedKeys[kid]
+                } else {
+                    null
+                }
+            }
+        } else {
+            // No kid - use first RSA key (common for single-key providers)
+            keys.values.firstOrNull { it.kty == "RSA" }
+        }
+
+        if (jwk == null) {
+            logger.error("No matching JWK found for kid: {}", kid)
+            return null
+        }
+
+        return jwkToPublicKey(jwk)
+    }
+
+    /**
+     * Fetch JWKS from the provider's endpoint.
+     */
+    private fun fetchJwks(jwksUri: String): Map<String, JwkKey>? {
+        return try {
+            logger.info("Fetching JWKS from {}", jwksUri)
+
+            val request = HttpRequest.GET<String>(jwksUri)
+            val response = httpClient.toBlocking().retrieve(request, String::class.java)
+
+            val jwksResponse = objectMapper.readValue(response, JwksResponse::class.java)
+
+            // Index keys by kid for fast lookup
+            jwksResponse.keys
+                .filter { it.kty == "RSA" && it.use != "enc" } // Only signing keys
+                .associateBy { it.kid ?: "default" }
+                .also { logger.info("Loaded {} RSA signing keys from JWKS", it.size) }
+
+        } catch (e: Exception) {
+            logger.error("Failed to fetch JWKS from {}: {}", jwksUri, e.message)
+            null
+        }
+    }
+
+    /**
+     * Convert JWK to Java PublicKey.
+     */
+    private fun jwkToPublicKey(jwk: JwkKey): PublicKey? {
+        return try {
+            val n = Base64.getUrlDecoder().decode(jwk.n)
+            val e = Base64.getUrlDecoder().decode(jwk.e)
+
+            val modulus = BigInteger(1, n)
+            val exponent = BigInteger(1, e)
+
+            val spec = RSAPublicKeySpec(modulus, exponent)
+            val factory = KeyFactory.getInstance("RSA")
+            factory.generatePublic(spec)
+        } catch (e: Exception) {
+            logger.error("Failed to convert JWK to public key: {}", e.message)
+            null
+        }
+    }
+
+    /**
+     * Verify RS256 signature.
+     */
+    private fun verifySignature(data: String, signature: ByteArray, publicKey: PublicKey): Boolean {
+        return try {
+            val sig = Signature.getInstance("SHA256withRSA")
+            sig.initVerify(publicKey)
+            sig.update(data.toByteArray(StandardCharsets.UTF_8))
+            sig.verify(signature)
+        } catch (e: Exception) {
+            logger.error("Signature verification error: {}", e.message)
+            false
+        }
+    }
+
+    /**
+     * Parse base64url-encoded JSON.
+     */
+    private fun parseBase64Json(base64: String): Map<String, Any?>? {
+        return try {
+            val decoded = Base64.getUrlDecoder().decode(base64)
+            val json = String(decoded, StandardCharsets.UTF_8)
+            @Suppress("UNCHECKED_CAST")
+            objectMapper.readValue(json, Map::class.java) as Map<String, Any?>
+        } catch (e: Exception) {
+            logger.error("Failed to parse base64 JSON: {}", e.message)
+            null
+        }
+    }
+
+    /**
+     * Fallback: Parse JWT without signature verification.
+     * Used only when JWKS URI is not configured (logs warning).
+     */
+    private fun parseJwtWithoutVerification(jwt: String): Map<String, Any>? {
+        return try {
+            val parts = jwt.split(".")
+            if (parts.size != 3) return null
+
+            val payload = parts[1]
+            val decodedBytes = Base64.getUrlDecoder().decode(payload)
+            val payloadJson = String(decodedBytes, StandardCharsets.UTF_8)
+
+            @Suppress("UNCHECKED_CAST")
+            objectMapper.readValue(payloadJson, Map::class.java) as Map<String, Any>
+        } catch (e: Exception) {
+            logger.error("Failed to parse JWT: {}", e.message)
+            null
+        }
+    }
+
+    /**
+     * Clear JWKS cache (for testing or forced refresh).
+     */
+    fun clearCache() {
+        jwksCache.invalidateAll()
+        logger.info("JWKS cache cleared")
+    }
+}
+
+/**
+ * JWKS response structure.
+ */
+data class JwksResponse(
+    val keys: List<JwkKey> = emptyList()
+)
+
+/**
+ * JWK (JSON Web Key) structure for RSA keys.
+ */
+data class JwkKey(
+    val kty: String = "",    // Key Type (e.g., "RSA")
+    val use: String? = null, // Key Use ("sig" for signature, "enc" for encryption)
+    val kid: String? = null, // Key ID
+    val alg: String? = null, // Algorithm (e.g., "RS256")
+    val n: String = "",      // RSA modulus (base64url)
+    val e: String = ""       // RSA exponent (base64url)
+)

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -24,10 +24,6 @@ import org.slf4j.LoggerFactory
  *   secman monitor [options]
  *   secman help
  *
- * For now, this is a simple CLI router for testing the CLI module structure.
- *
- * Related to: Feature 023-create-in-the, 026-crowdstrike-polling-monitor
- * Task: T052
  */
 class SecmanCli {
     private val log = LoggerFactory.getLogger(SecmanCli::class.java)

--- a/src/frontend/src/components/AssetManagement.tsx
+++ b/src/frontend/src/components/AssetManagement.tsx
@@ -336,14 +336,14 @@ const AssetManagement: React.FC = () => {
   // Filter assets based on current filter values
   const getFilteredAssets = () => {
     return assets.filter(asset => {
+      // Text filters use partial matching
       const nameMatch = !nameFilter || asset.name.toLowerCase().includes(nameFilter.toLowerCase());
       const ipMatch = !ipFilter || (asset.ip && asset.ip.toLowerCase().includes(ipFilter.toLowerCase()));
-      const ownerMatch = !ownerFilter || asset.owner.toLowerCase().includes(ownerFilter.toLowerCase());
-      const adDomainMatch = !adDomainFilter || (asset.adDomain && asset.adDomain.toLowerCase().includes(adDomainFilter.toLowerCase()));
+      // Dropdown filters use exact matching
+      const ownerMatch = !ownerFilter || asset.owner === ownerFilter;
+      const adDomainMatch = !adDomainFilter || asset.adDomain === adDomainFilter;
       const workgroupMatch = !workgroupFilter || (
-        asset.workgroups && asset.workgroups.some(wg =>
-          wg.name.toLowerCase().includes(workgroupFilter.toLowerCase())
-        )
+        asset.workgroups && asset.workgroups.some(wg => wg.name === workgroupFilter)
       );
 
       return nameMatch && ipMatch && ownerMatch && adDomainMatch && workgroupMatch;
@@ -597,38 +597,53 @@ const AssetManagement: React.FC = () => {
                 </div>
                 <div className="col-md-3">
                   <label htmlFor="ownerFilter" className="form-label">Owner</label>
-                  <input
-                    type="text"
+                  <select
                     id="ownerFilter"
-                    className="form-control"
-                    placeholder="Filter by owner..."
+                    className="form-select"
                     value={ownerFilter}
                     onChange={(e) => setOwnerFilter(e.target.value)}
-                  />
+                  >
+                    <option value="">All Owners</option>
+                    {[...new Set(assets.map(a => a.owner).filter(Boolean))].sort().map(owner => (
+                      <option key={owner} value={owner}>{owner}</option>
+                    ))}
+                  </select>
                 </div>
                 <div className="col-md-3">
                   <label htmlFor="adDomainFilter" className="form-label">AD Domain</label>
-                  <input
-                    type="text"
+                  <select
                     id="adDomainFilter"
-                    className="form-control"
-                    placeholder="Filter by domain..."
+                    className="form-select"
                     value={adDomainFilter}
                     onChange={(e) => setAdDomainFilter(e.target.value)}
-                  />
+                  >
+                    <option value="">All Domains</option>
+                    {[...new Set(assets.map(a => a.adDomain).filter(Boolean))].sort().map(domain => (
+                      <option key={domain} value={domain}>{domain}</option>
+                    ))}
+                  </select>
                 </div>
               </div>
               <div className="row mt-2">
                 <div className="col-md-3">
                   <label htmlFor="workgroupFilter" className="form-label">Workgroups</label>
-                  <input
-                    type="text"
+                  <select
                     id="workgroupFilter"
-                    className="form-control"
-                    placeholder="Filter by workgroup..."
+                    className="form-select"
                     value={workgroupFilter}
                     onChange={(e) => setWorkgroupFilter(e.target.value)}
-                  />
+                  >
+                    <option value="">All Workgroups</option>
+                    {workgroups.length > 0 ? (
+                      workgroups.map(wg => (
+                        <option key={wg.id} value={wg.name}>{wg.name}</option>
+                      ))
+                    ) : (
+                      [...new Set(assets.flatMap(a => a.workgroups?.map(w => w.name) || []))].sort().map(name => (
+                        <option key={name} value={name}>{name}</option>
+                      ))
+                    )}
+                  </select>
                 </div>
               </div>
               {(nameFilter || ipFilter || ownerFilter || adDomainFilter || workgroupFilter) && (

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -20,21 +20,18 @@ const Header = () => {
 
     const handleLogout = async () => {
         try {
-            const token = localStorage.getItem('authToken');
             const response = await fetch('/api/auth/logout', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    ...(token && { 'Authorization': `Bearer ${token}` }),
                 },
+                credentials: 'include', // Send HttpOnly cookie for authentication
             });
             if (response.ok) {
-                // Clear authentication data
-                localStorage.removeItem('authToken');
+                // Clear client-side authentication data
+                // Note: The HttpOnly cookie is cleared by the server response
                 localStorage.removeItem('user');
-
-                // Also clear the authToken cookie
-                document.cookie = 'authToken=; path=/; max-age=0; SameSite=Strict';
+                localStorage.removeItem('authToken'); // Legacy cleanup
 
                 window.currentUser = null;
                 setUser(null);

--- a/src/frontend/src/components/Login.tsx
+++ b/src/frontend/src/components/Login.tsx
@@ -99,26 +99,22 @@ const Login = () => {
             const data = await response.json();
 
             if (response.ok) {
-                // Login successful - store the JWT token
-                if (data.token) {
-                    localStorage.setItem('authToken', data.token);
+                // Login successful - JWT is now stored in HttpOnly cookie by backend
+                // Store user data for UI display (non-sensitive info only)
+                const userData = {
+                    id: data.id,
+                    username: data.username,
+                    email: data.email,
+                    roles: data.roles
+                };
+                localStorage.setItem('user', JSON.stringify(userData));
+                // Note: Token is NOT stored in localStorage for security (XSS protection)
+                // Authentication is handled via HttpOnly cookie set by backend
 
-                    // Also store token in a cookie for server-side middleware access
-                    document.cookie = `authToken=${data.token}; path=/; max-age=86400; SameSite=Strict`;
+                // Set global user state for Header component
+                (window as any).currentUser = userData;
+                window.dispatchEvent(new CustomEvent('userLoaded'));
 
-                    const userData = {
-                        id: data.id,
-                        username: data.username,
-                        email: data.email,
-                        roles: data.roles
-                    };
-                    localStorage.setItem('user', JSON.stringify(userData));
-
-                    // Set global user state for Header component
-                    (window as any).currentUser = userData;
-                    window.dispatchEvent(new CustomEvent('userLoaded'));
-                }
-                
                 // Small delay to ensure localStorage is written before redirect
                 setTimeout(() => {
                     window.location.href = '/'; // Or '/dashboard' if you have a dedicated page


### PR DESCRIPTION
Implements the 'list_users' MCP tool, allowing admin users (via User Delegation) to retrieve all users and their core attributes. Adds ListUsersTool, registers it in McpToolRegistry, and updates authorization logic. Also introduces security improvements: JWT authentication via HttpOnly cookies (with CookieTokenReader), stricter error handling in authentication, and security header updates. Documentation and specs for the new feature are included.