### PR TITLE
Add MCP function to list installed products

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -29,7 +29,9 @@ class McpToolRegistry(
     @Inject private val addRequirementTool: AddRequirementTool,
     @Inject private val deleteAllRequirementsTool: DeleteAllRequirementsTool,
     // Feature 060: MCP List Users Tool
-    @Inject private val listUsersTool: ListUsersTool
+    @Inject private val listUsersTool: ListUsersTool,
+    // Feature 061: MCP List Products Tool
+    @Inject private val listProductsTool: ListProductsTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -55,7 +57,9 @@ class McpToolRegistry(
             addRequirementTool,
             deleteAllRequirementsTool,
             // Feature 060: MCP List Users Tool
-            listUsersTool
+            listUsersTool,
+            // Feature 061: MCP List Products Tool
+            listProductsTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -159,6 +163,11 @@ class McpToolRegistry(
             // Feature 060: MCP List Users Tool (ADMIN only via User Delegation)
             "list_users" -> {
                 permissions.contains(McpPermission.USER_ACTIVITY) // ADMIN role checked in tool execute()
+            }
+
+            // Feature 061: MCP List Products Tool (ADMIN or SECCHAMPION via User Delegation)
+            "list_products" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Role checked in tool execute()
             }
 
             // Feature 006: Asset Inventory, Scans, Vulnerabilities, and Products

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListProductsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListProductsTool.kt
@@ -1,0 +1,80 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.VulnerabilityRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for listing all installed products in the system.
+ * Feature: 061-mcp-list-products
+ *
+ * Products are derived from vulnerability data (vulnerableProductVersions field).
+ * ADMIN or SECCHAMPION role is required via User Delegation.
+ *
+ * Returns all unique product names sorted alphabetically.
+ */
+@Singleton
+class ListProductsTool(
+    @Inject private val vulnerabilityRepository: VulnerabilityRepository
+) : McpTool {
+
+    override val name = "list_products"
+    override val description = "List all installed products in the system (ADMIN or SECCHAMPION only, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "search" to mapOf(
+                "type" to "string",
+                "description" to "Optional search term to filter products (case-insensitive)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation - cannot verify role without knowing the user
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN or SECCHAMPION role
+        val hasRequiredRole = context.isAdmin ||
+            context.delegatedUserRoles?.contains("SECCHAMPION") == true
+
+        if (!hasRequiredRole) {
+            return McpToolResult.error(
+                "ROLE_REQUIRED",
+                "ADMIN or SECCHAMPION role required to list products"
+            )
+        }
+
+        try {
+            // Get optional search parameter
+            val search = (arguments["search"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+
+            // Retrieve products - for authorized roles, show all products
+            val products = if (search != null) {
+                vulnerabilityRepository.findDistinctProductsForAllFiltered(search)
+            } else {
+                vulnerabilityRepository.findDistinctProductsForAll()
+            }
+
+            val result = mapOf(
+                "products" to products,
+                "totalCount" to products.size,
+                "searchTerm" to search
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve products: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
Add list_products MCP tool that returns all installed products derived from vulnerability data. Access restricted to users with ADMIN or SECCHAMPION roles via User Delegation.

- Create ListProductsTool with optional search parameter
- Register tool in McpToolRegistry with VULNERABILITIES_READ permission
- Role check enforced in tool execute() method