### PR TITLE
Add MCP tools for overdue vulnerabilities and exceptions

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="temurin-21 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="temurin-25 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/MCP_INTEGRATION.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/MCP_INTEGRATION.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/McpConnectionType.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/McpConnectionType.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/build.gradle.kts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,37 +84,37 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_MARK_IGNORED_FILES_AS_EXCLUDED&quot;: &quot;true&quot;,
-    &quot;Gradle.OAuthServiceTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.backendng [build].executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;SHELLCHECK.PATH&quot;: &quot;/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/flake/sources/misc/secman&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.12135923&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.409894&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/flake/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_MARK_IGNORED_FILES_AS_EXCLUDED": "true",
+    "Gradle.OAuthServiceTest.executor": "Run",
+    "Gradle.backendng [build].executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
+    "git-widget-placeholder": "062-mcp-vuln-exceptions",
+    "junie.onboarding.icon.badge.shown": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/flake/sources/misc/secman",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Global Libraries",
+    "project.structure.proportion": "0.12135923",
+    "project.structure.side.proportion": "0.409894",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "ts.external.directory.path": "/Users/flake/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;mariadb&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "mariadb"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scripts/install/db" />

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -35,6 +35,7 @@ All features MUST implement security as a primary concern, not an afterthought.
 - RBAC MUST be enforced at both API endpoint level (@Secured annotations) and UI level (role checks)
 - Sensitive data MUST NOT be logged or exposed in error messages
 - Authentication tokens MUST be stored securely (sessionStorage for JWT)
+- A secutity review must be done before finalizing the implementation
 
 **Rationale**: Security vulnerabilities in a security requirements management tool are unacceptable and undermine the entire purpose of the system.
 
@@ -90,13 +91,14 @@ Database schema changes MUST be managed through automated migration with appropr
 - Migration MUST be testable in development before production deployment
 - Schema changes MUST NOT cause data loss without explicit approval
 - flyway migration scripts must be created
+- all functionality must be referenced in the corresponding documentation (where needed for end users)
 
 **Rationale**: Automated migration reduces deployment errors and ensures schema-code consistency.
 
 ## Technology Stack
 
 **Backend**:
-- Language: Kotlin 2.2.21 / Java 21
+- Language: Kotlin 2.3.0 / Java 25
 - Framework: Micronaut 4.10
 - ORM: Hibernate JPA
 - Database: MariaDB 11.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing `requirement`, `norm`, `requirement_norm` tables) (058-ai-norm-mapping)
 - Kotlin 2.2.21 / Java 21 + Micronaut 4.10, Hibernate JPA (060-mcp-list-users)
 - MariaDB 11.4 (existing `users` table) (060-mcp-list-users)
+- MariaDB 11.4 (existing tables: `vulnerability_exception_request`, `vulnerability_exception`, `outdated_asset_materialized_view`) (062-mcp-vuln-exceptions)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.2.21" apply false
-    id("org.jetbrains.kotlin.plugin.allopen") version "2.2.21" apply false
-    id("org.jetbrains.kotlin.plugin.jpa") version "2.2.21" apply false
-    id("com.google.devtools.ksp") version "2.2.21-2.0.4" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.3.0" apply false
+    id("org.jetbrains.kotlin.plugin.allopen") version "2.3.0" apply false
+    id("org.jetbrains.kotlin.plugin.jpa") version "2.3.0" apply false
+    id("com.google.devtools.ksp") version "2.3.0" apply false
     id("io.micronaut.application") version "4.6.0" apply false
     id("io.micronaut.library") version "4.6.0" apply false
     id("io.micronaut.aot") version "4.6.0" apply false
@@ -20,8 +20,8 @@ subprojects {
 
 // Common dependency versions
 ext {
-    set("kotlinVersion", "2.2.21")
+    set("kotlinVersion", "2.3.0")
     set("micronautVersion", "4.10.1")
-    set("jvmTarget", "21")
+    set("jvmTarget", "25")
     set("picocliVersion", "4.7.5")
 }

--- a/specs/062-mcp-vuln-exceptions/checklists/requirements.md
+++ b/specs/062-mcp-vuln-exceptions/checklists/requirements.md
@@ -1,0 +1,57 @@
+# Specification Quality Checklist: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass validation. The specification is ready for `/speckit.clarify` or `/speckit.plan`.
+
+### Validation Details
+
+**Content Quality:**
+- Spec uses tool names like `get_overdue_assets` but does not specify implementation language or framework
+- All requirements focus on what users can do, not how it's built
+- Written in accessible language about security workflows
+
+**Requirements:**
+- 25 functional requirements covering all user stories
+- Each requirement uses MUST/SHOULD language for testability
+- Specific character limits and validation rules included (50-2048 chars for reason, 10-1024 for comments)
+
+**Success Criteria:**
+- All 7 criteria are measurable (time limits, behavior expectations)
+- No technology references in success criteria
+- Focus on user-facing outcomes
+
+**Edge Cases:**
+- Concurrent approval handling documented
+- Invalid state transitions documented
+- Access control violations documented
+- Disabled user delegation documented

--- a/specs/062-mcp-vuln-exceptions/contracts/01-get-overdue-assets.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/01-get-overdue-assets.md
@@ -1,0 +1,87 @@
+# MCP Tool Contract: get_overdue_assets
+
+**Tool Name**: `get_overdue_assets`
+**Operation**: READ
+**Spec Reference**: FR-001 through FR-005
+
+## Description
+
+Get assets with overdue vulnerabilities. Respects workgroup-based access control.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: ADMIN, VULN
+- **Access Scope**:
+  - ADMIN sees all overdue assets
+  - VULN sees only assets from assigned workgroups
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "number",
+      "description": "Page number (0-indexed, default: 0)"
+    },
+    "size": {
+      "type": "number",
+      "description": "Page size (default: 20, max: 100)"
+    },
+    "minSeverity": {
+      "type": "string",
+      "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+      "description": "Minimum severity filter"
+    },
+    "searchTerm": {
+      "type": "string",
+      "description": "Search by asset name (case-insensitive)"
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "assets": [
+    {
+      "id": 123,
+      "assetId": 456,
+      "name": "server-prod-01",
+      "ip": "192.168.1.100",
+      "type": "SERVER",
+      "totalVulnerabilities": 25,
+      "criticalCount": 3,
+      "highCount": 8,
+      "mediumCount": 10,
+      "lowCount": 4,
+      "oldestVulnDays": 45,
+      "maxSeverity": "CRITICAL"
+    }
+  ],
+  "totalElements": 150,
+  "totalPages": 8,
+  "page": 0,
+  "size": 20
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `ROLE_REQUIRED` | "ADMIN or VULN role required to view overdue assets" |
+| `EXECUTION_ERROR` | "Failed to retrieve overdue assets: {message}" |
+
+## Implementation Notes
+
+- Delegates to `OutdatedAssetService.getOutdatedAssets()`
+- Creates minimal `Authentication` adapter from `McpExecutionContext`
+- Returns paginated results from `OutdatedAssetMaterializedView`

--- a/specs/062-mcp-vuln-exceptions/contracts/02-create-exception-request.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/02-create-exception-request.md
@@ -1,0 +1,105 @@
+# MCP Tool Contract: create_exception_request
+
+**Tool Name**: `create_exception_request`
+**Operation**: WRITE
+**Spec Reference**: FR-006 through FR-010
+
+## Description
+
+Create a new vulnerability exception request. Auto-approves for ADMIN/SECCHAMPION users.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: Any authenticated user
+- **Auto-Approval**: ADMIN and SECCHAMPION roles get immediate approval
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["vulnerabilityId", "reason", "expirationDate"],
+  "properties": {
+    "vulnerabilityId": {
+      "type": "number",
+      "description": "ID of the vulnerability to request exception for"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Business justification (50-2048 characters)",
+      "minLength": 50,
+      "maxLength": 2048
+    },
+    "expirationDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the exception should expire (ISO-8601, must be future date)"
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["SINGLE_VULNERABILITY", "CVE_PATTERN"],
+      "default": "SINGLE_VULNERABILITY",
+      "description": "Exception scope (default: SINGLE_VULNERABILITY)"
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "request": {
+    "id": 789,
+    "vulnerabilityId": 456,
+    "vulnerabilityCve": "CVE-2024-1234",
+    "assetName": "server-prod-01",
+    "assetIp": "192.168.1.100",
+    "requestedByUsername": "user@example.com",
+    "scope": "SINGLE_VULNERABILITY",
+    "reason": "Compensating controls in place. Patch scheduled for next maintenance window...",
+    "expirationDate": "2026-04-11T00:00:00",
+    "status": "PENDING",
+    "autoApproved": false,
+    "createdAt": "2026-01-11T15:30:00",
+    "updatedAt": "2026-01-11T15:30:00"
+  },
+  "message": "Exception request created successfully. Status: PENDING"
+}
+```
+
+### Auto-Approved Response
+
+```json
+{
+  "request": {
+    "id": 790,
+    "status": "APPROVED",
+    "autoApproved": true,
+    "reviewedByUsername": "admin@example.com",
+    "reviewDate": "2026-01-11T15:30:00"
+  },
+  "message": "Exception request auto-approved (ADMIN/SECCHAMPION role)"
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `NOT_FOUND` | "Vulnerability with ID {id} not found" |
+| `VALIDATION_ERROR` | "Reason must be at least 50 characters" |
+| `VALIDATION_ERROR` | "Expiration date must be in the future" |
+| `CONFLICT` | "Active exception request already exists for this vulnerability" |
+| `EXECUTION_ERROR` | "Failed to create exception request: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.createRequest()`
+- Parses `expirationDate` as ISO-8601 datetime
+- Default scope is `SINGLE_VULNERABILITY` per clarification session
+- Auto-approval determined by user roles in context

--- a/specs/062-mcp-vuln-exceptions/contracts/03-get-my-exception-requests.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/03-get-my-exception-requests.md
@@ -1,0 +1,96 @@
+# MCP Tool Contract: get_my_exception_requests
+
+**Tool Name**: `get_my_exception_requests`
+**Operation**: READ
+**Spec Reference**: FR-011 through FR-013
+
+## Description
+
+Get the current user's own exception requests with optional status filtering and pagination.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: Any authenticated user
+- **Access Scope**: Only returns requests created by the delegated user
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["PENDING", "APPROVED", "REJECTED", "EXPIRED", "CANCELLED"],
+      "description": "Filter by request status"
+    },
+    "page": {
+      "type": "number",
+      "description": "Page number (0-indexed, default: 0)"
+    },
+    "size": {
+      "type": "number",
+      "description": "Page size (default: 20, max: 100)"
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "requests": [
+    {
+      "id": 789,
+      "vulnerabilityId": 456,
+      "vulnerabilityCve": "CVE-2024-1234",
+      "assetName": "server-prod-01",
+      "assetIp": "192.168.1.100",
+      "requestedByUsername": "user@example.com",
+      "scope": "SINGLE_VULNERABILITY",
+      "reason": "Compensating controls in place...",
+      "expirationDate": "2026-04-11T00:00:00",
+      "status": "PENDING",
+      "autoApproved": false,
+      "reviewedByUsername": null,
+      "reviewDate": null,
+      "reviewComment": null,
+      "createdAt": "2026-01-11T15:30:00",
+      "updatedAt": "2026-01-11T15:30:00"
+    }
+  ],
+  "totalElements": 5,
+  "totalPages": 1,
+  "page": 0,
+  "size": 20
+}
+```
+
+### Empty Response
+
+```json
+{
+  "requests": [],
+  "totalElements": 0,
+  "totalPages": 0,
+  "page": 0,
+  "size": 20
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `EXECUTION_ERROR` | "Failed to retrieve exception requests: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.getUserRequests()`
+- Uses `context.delegatedUserId` to filter requests
+- Sorted by `createdAt` descending (newest first)

--- a/specs/062-mcp-vuln-exceptions/contracts/04-get-pending-exception-requests.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/04-get-pending-exception-requests.md
@@ -1,0 +1,78 @@
+# MCP Tool Contract: get_pending_exception_requests
+
+**Tool Name**: `get_pending_exception_requests`
+**Operation**: READ
+**Spec Reference**: FR-014 through FR-016
+
+## Description
+
+Get all pending exception requests awaiting approval. For use by approvers (ADMIN/SECCHAMPION).
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: ADMIN, SECCHAMPION
+- **Access Scope**: All pending requests system-wide
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "number",
+      "description": "Page number (0-indexed, default: 0)"
+    },
+    "size": {
+      "type": "number",
+      "description": "Page size (default: 20, max: 100)"
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "requests": [
+    {
+      "id": 789,
+      "vulnerabilityId": 456,
+      "vulnerabilityCve": "CVE-2024-1234",
+      "assetName": "server-prod-01",
+      "assetIp": "192.168.1.100",
+      "requestedByUsername": "user@example.com",
+      "scope": "SINGLE_VULNERABILITY",
+      "reason": "Compensating controls in place. Patch scheduled for next maintenance window...",
+      "expirationDate": "2026-04-11T00:00:00",
+      "status": "PENDING",
+      "autoApproved": false,
+      "createdAt": "2026-01-10T10:00:00",
+      "updatedAt": "2026-01-10T10:00:00"
+    }
+  ],
+  "totalElements": 15,
+  "totalPages": 1,
+  "page": 0,
+  "size": 20,
+  "pendingCount": 15
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `APPROVAL_ROLE_REQUIRED` | "ADMIN or SECCHAMPION role required to view pending requests" |
+| `EXECUTION_ERROR` | "Failed to retrieve pending requests: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.getPendingRequests()`
+- Sorted by `createdAt` ascending (oldest first) for fair FIFO processing
+- Includes `pendingCount` in response for badge display

--- a/specs/062-mcp-vuln-exceptions/contracts/05-approve-exception-request.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/05-approve-exception-request.md
@@ -1,0 +1,81 @@
+# MCP Tool Contract: approve_exception_request
+
+**Tool Name**: `approve_exception_request`
+**Operation**: WRITE
+**Spec Reference**: FR-017, FR-020, FR-021
+
+## Description
+
+Approve a pending exception request. Creates a corresponding VulnerabilityException on success.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: ADMIN, SECCHAMPION
+- **Concurrency**: First-approver-wins with optimistic locking
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["requestId"],
+  "properties": {
+    "requestId": {
+      "type": "number",
+      "description": "ID of the exception request to approve"
+    },
+    "comment": {
+      "type": "string",
+      "description": "Optional approval comment (max 1024 characters)",
+      "maxLength": 1024
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "request": {
+    "id": 789,
+    "vulnerabilityId": 456,
+    "vulnerabilityCve": "CVE-2024-1234",
+    "assetName": "server-prod-01",
+    "assetIp": "192.168.1.100",
+    "requestedByUsername": "user@example.com",
+    "scope": "SINGLE_VULNERABILITY",
+    "reason": "Compensating controls in place...",
+    "expirationDate": "2026-04-11T00:00:00",
+    "status": "APPROVED",
+    "autoApproved": false,
+    "reviewedByUsername": "admin@example.com",
+    "reviewDate": "2026-01-11T16:00:00",
+    "reviewComment": "Approved - controls verified",
+    "createdAt": "2026-01-10T10:00:00",
+    "updatedAt": "2026-01-11T16:00:00"
+  },
+  "message": "Exception request approved successfully"
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `APPROVAL_ROLE_REQUIRED` | "ADMIN or SECCHAMPION role required to approve requests" |
+| `NOT_FOUND` | "Exception request with ID {id} not found" |
+| `INVALID_STATE` | "Cannot approve request in {status} status. Only PENDING requests can be approved." |
+| `CONCURRENT_MODIFICATION` | "Request was already reviewed by {username} at {timestamp}" |
+| `EXECUTION_ERROR` | "Failed to approve request: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.approveRequest()`
+- Automatically creates `VulnerabilityException` on approval
+- Uses optimistic locking to prevent race conditions
+- Reviewer is the delegated user from context

--- a/specs/062-mcp-vuln-exceptions/contracts/06-reject-exception-request.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/06-reject-exception-request.md
@@ -1,0 +1,84 @@
+# MCP Tool Contract: reject_exception_request
+
+**Tool Name**: `reject_exception_request`
+**Operation**: WRITE
+**Spec Reference**: FR-018, FR-019, FR-020
+
+## Description
+
+Reject a pending exception request. Requires a justification comment.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: ADMIN, SECCHAMPION
+- **Concurrency**: First-approver-wins with optimistic locking
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["requestId", "comment"],
+  "properties": {
+    "requestId": {
+      "type": "number",
+      "description": "ID of the exception request to reject"
+    },
+    "comment": {
+      "type": "string",
+      "description": "Required rejection reason (10-1024 characters)",
+      "minLength": 10,
+      "maxLength": 1024
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "request": {
+    "id": 789,
+    "vulnerabilityId": 456,
+    "vulnerabilityCve": "CVE-2024-1234",
+    "assetName": "server-prod-01",
+    "assetIp": "192.168.1.100",
+    "requestedByUsername": "user@example.com",
+    "scope": "SINGLE_VULNERABILITY",
+    "reason": "Compensating controls in place...",
+    "expirationDate": "2026-04-11T00:00:00",
+    "status": "REJECTED",
+    "autoApproved": false,
+    "reviewedByUsername": "secchampion@example.com",
+    "reviewDate": "2026-01-11T16:00:00",
+    "reviewComment": "Vulnerability too critical to accept. Immediate remediation required.",
+    "createdAt": "2026-01-10T10:00:00",
+    "updatedAt": "2026-01-11T16:00:00"
+  },
+  "message": "Exception request rejected"
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `APPROVAL_ROLE_REQUIRED` | "ADMIN or SECCHAMPION role required to reject requests" |
+| `VALIDATION_ERROR` | "Rejection comment is required" |
+| `VALIDATION_ERROR` | "Rejection comment must be at least 10 characters" |
+| `NOT_FOUND` | "Exception request with ID {id} not found" |
+| `INVALID_STATE` | "Cannot reject request in {status} status. Only PENDING requests can be rejected." |
+| `CONCURRENT_MODIFICATION` | "Request was already reviewed by {username} at {timestamp}" |
+| `EXECUTION_ERROR` | "Failed to reject request: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.rejectRequest()`
+- Comment is REQUIRED (unlike approval where it's optional)
+- Minimum 10 characters enforced for meaningful feedback
+- No `VulnerabilityException` is created on rejection

--- a/specs/062-mcp-vuln-exceptions/contracts/07-cancel-exception-request.md
+++ b/specs/062-mcp-vuln-exceptions/contracts/07-cancel-exception-request.md
@@ -1,0 +1,72 @@
+# MCP Tool Contract: cancel_exception_request
+
+**Tool Name**: `cancel_exception_request`
+**Operation**: WRITE
+**Spec Reference**: FR-022 through FR-024
+
+## Description
+
+Cancel the user's own pending exception request.
+
+## Access Control
+
+- **Requires User Delegation**: Yes
+- **Allowed Roles**: Any authenticated user (original requester only)
+- **Ownership Check**: Only the user who created the request can cancel it
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "required": ["requestId"],
+  "properties": {
+    "requestId": {
+      "type": "number",
+      "description": "ID of the exception request to cancel"
+    }
+  }
+}
+```
+
+## Response Format
+
+### Success Response
+
+```json
+{
+  "request": {
+    "id": 789,
+    "vulnerabilityId": 456,
+    "vulnerabilityCve": "CVE-2024-1234",
+    "assetName": "server-prod-01",
+    "assetIp": "192.168.1.100",
+    "requestedByUsername": "user@example.com",
+    "scope": "SINGLE_VULNERABILITY",
+    "reason": "Compensating controls in place...",
+    "expirationDate": "2026-04-11T00:00:00",
+    "status": "CANCELLED",
+    "autoApproved": false,
+    "createdAt": "2026-01-10T10:00:00",
+    "updatedAt": "2026-01-11T16:30:00"
+  },
+  "message": "Exception request cancelled successfully"
+}
+```
+
+### Error Responses
+
+| Code | Message |
+|------|---------|
+| `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| `NOT_FOUND` | "Exception request with ID {id} not found" |
+| `FORBIDDEN` | "Only the original requester can cancel this request" |
+| `INVALID_STATE` | "Cannot cancel request in {status} status. Only PENDING requests can be cancelled." |
+| `EXECUTION_ERROR` | "Failed to cancel request: {message}" |
+
+## Implementation Notes
+
+- Delegates to `VulnerabilityExceptionRequestService.cancelRequest()`
+- Ownership verified by comparing `context.delegatedUserId` with `request.requestedByUser.id`
+- Only PENDING status requests can be cancelled
+- Auto-approved requests that were later auto-approved can also be cancelled (will delete the exception)

--- a/specs/062-mcp-vuln-exceptions/data-model.md
+++ b/specs/062-mcp-vuln-exceptions/data-model.md
@@ -1,0 +1,173 @@
+# Data Model: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Feature**: 062-mcp-vuln-exceptions
+**Date**: 2026-01-11
+
+## Overview
+
+This feature uses **existing entities only**. No new database tables or schema changes are required.
+
+## Existing Entities Used
+
+### VulnerabilityExceptionRequest
+
+**Table**: `vulnerability_exception_request`
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/VulnerabilityExceptionRequest.kt`
+
+Represents a user's request to create an exception for a vulnerability.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | Long | Primary key |
+| `vulnerability` | Vulnerability (FK) | The vulnerability this exception applies to |
+| `requestedByUser` | User (FK) | User who created the request |
+| `requestedByUsername` | String | Username (preserved for audit) |
+| `scope` | ExceptionScope | SINGLE_VULNERABILITY or CVE_PATTERN |
+| `reason` | String | Business justification (50-2048 chars) |
+| `expirationDate` | LocalDateTime | When exception should expire |
+| `status` | ExceptionRequestStatus | PENDING, APPROVED, REJECTED, EXPIRED, CANCELLED |
+| `autoApproved` | Boolean | True if auto-approved (ADMIN/SECCHAMPION) |
+| `reviewedByUser` | User (FK) | Reviewer who approved/rejected |
+| `reviewedByUsername` | String | Reviewer username (preserved for audit) |
+| `reviewDate` | LocalDateTime | When reviewed |
+| `reviewComment` | String | Reviewer notes (10-1024 chars for rejection) |
+| `createdAt` | LocalDateTime | Creation timestamp |
+| `updatedAt` | LocalDateTime | Last modification timestamp |
+| `version` | Long | Optimistic locking version |
+
+**State Machine**:
+```
+PENDING → APPROVED, REJECTED, CANCELLED
+APPROVED → EXPIRED (via scheduler)
+REJECTED → (terminal)
+CANCELLED → (terminal)
+EXPIRED → (terminal)
+```
+
+---
+
+### VulnerabilityException
+
+**Table**: `vulnerability_exception`
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/VulnerabilityException.kt`
+
+The actual exception rule created upon approval.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | Long | Primary key |
+| `exceptionType` | ExceptionType | IP, PRODUCT, or ASSET |
+| `targetValue` | String | IP address, product pattern, or asset name |
+| `assetId` | Long? | Asset ID for ASSET-type exceptions |
+| `expirationDate` | LocalDateTime? | When exception expires |
+| `reason` | String | Justification |
+| `createdBy` | String | Creator username |
+| `createdAt` | LocalDateTime | Creation timestamp |
+| `updatedAt` | LocalDateTime | Last modification timestamp |
+
+---
+
+### OutdatedAssetMaterializedView
+
+**Table**: `outdated_asset_materialized_view`
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/OutdatedAssetMaterializedView.kt`
+
+Pre-computed view of assets with overdue vulnerabilities.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | Long | Primary key (view-specific) |
+| `assetId` | Long | Actual asset ID |
+| `assetName` | String | Asset name |
+| `assetIp` | String? | Asset IP address |
+| `assetType` | String | Asset type |
+| `workgroupIds` | String? | Comma-separated workgroup IDs |
+| `totalVulnerabilities` | Int | Total vulnerability count |
+| `criticalCount` | Int | Critical severity count |
+| `highCount` | Int | High severity count |
+| `mediumCount` | Int | Medium severity count |
+| `lowCount` | Int | Low severity count |
+| `oldestVulnDays` | Int | Days since oldest overdue vulnerability |
+| `maxSeverity` | String | Highest severity level |
+| `calculatedAt` | LocalDateTime | When view was refreshed |
+
+---
+
+## Supporting Enums
+
+### ExceptionScope
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/ExceptionScope.kt`
+
+```kotlin
+enum class ExceptionScope {
+    SINGLE_VULNERABILITY,  // Exception applies to one specific vulnerability
+    CVE_PATTERN           // Exception applies to all instances of a CVE
+}
+```
+
+### ExceptionRequestStatus
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/ExceptionRequestStatus.kt`
+
+```kotlin
+enum class ExceptionRequestStatus {
+    PENDING,    // Awaiting approval
+    APPROVED,   // Approved - exception created
+    REJECTED,   // Rejected by reviewer
+    EXPIRED,    // Past expiration date
+    CANCELLED   // Cancelled by requester
+}
+```
+
+---
+
+## DTOs for MCP Response
+
+### VulnerabilityExceptionRequestDto
+**Location**: `src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityExceptionRequestDto.kt`
+
+Used for all exception request responses via MCP.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | Long | Request ID |
+| `vulnerabilityId` | Long? | Vulnerability ID |
+| `vulnerabilityCve` | String? | CVE identifier |
+| `assetName` | String? | Asset name |
+| `assetIp` | String? | Asset IP |
+| `requestedByUsername` | String | Requester |
+| `scope` | ExceptionScope | Request scope |
+| `reason` | String | Justification |
+| `expirationDate` | LocalDateTime | Expiration date |
+| `status` | ExceptionRequestStatus | Current status |
+| `autoApproved` | Boolean | Auto-approval flag |
+| `reviewedByUsername` | String? | Reviewer |
+| `reviewDate` | LocalDateTime? | Review timestamp |
+| `reviewComment` | String? | Review notes |
+| `createdAt` | LocalDateTime | Creation timestamp |
+| `updatedAt` | LocalDateTime | Update timestamp |
+
+### OutdatedAssetDto
+**Location**: `src/backendng/src/main/kotlin/com/secman/dto/OutdatedAssetDto.kt`
+
+Used for overdue asset responses via MCP.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | Long | Materialized view ID |
+| `assetId` | Long | Actual asset ID |
+| `name` | String | Asset name |
+| `ip` | String? | Asset IP |
+| `type` | String | Asset type |
+| `totalVulnerabilities` | Int | Total count |
+| `criticalCount` | Int | Critical count |
+| `highCount` | Int | High count |
+| `mediumCount` | Int | Medium count |
+| `lowCount` | Int | Low count |
+| `oldestVulnDays` | Int | Days overdue |
+| `maxSeverity` | String | Highest severity |
+
+---
+
+## No Schema Changes Required
+
+This feature operates entirely on existing database tables. The MCP tools are thin wrappers around existing service layer functionality.

--- a/specs/062-mcp-vuln-exceptions/plan.md
+++ b/specs/062-mcp-vuln-exceptions/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Branch**: `062-mcp-vuln-exceptions` | **Date**: 2026-01-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/062-mcp-vuln-exceptions/spec.md`
+
+## Summary
+
+Implement 7 new MCP tools to expose overdue asset querying and vulnerability exception handling functionality via the Model Context Protocol. These tools wrap existing service layer functionality (`OutdatedAssetService`, `VulnerabilityExceptionRequestService`) with proper access control using `McpExecutionContext` for User Delegation.
+
+**Tools to implement:**
+1. `get_overdue_assets` - List assets with overdue vulnerabilities (ADMIN/VULN)
+2. `create_exception_request` - Create new exception request (all authenticated users)
+3. `get_my_exception_requests` - View own exception requests (all authenticated users)
+4. `get_pending_exception_requests` - View all pending requests (ADMIN/SECCHAMPION)
+5. `approve_exception_request` - Approve pending request (ADMIN/SECCHAMPION)
+6. `reject_exception_request` - Reject pending request (ADMIN/SECCHAMPION)
+7. `cancel_exception_request` - Cancel own pending request (original requester)
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.2.21 / Java 21
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA
+**Storage**: MariaDB 11.4 (existing tables: `vulnerability_exception_request`, `vulnerability_exception`, `outdated_asset_materialized_view`)
+**Testing**: JUnit 5, Mockk (per constitution Principle IV - test preparation only when explicitly requested)
+**Target Platform**: Linux server (Docker/VM deployment)
+**Project Type**: Web application (backend MCP server)
+**Performance Goals**: <3s for overdue assets retrieval, <2s for exception request operations
+**Constraints**: Must respect existing RBAC, User Delegation required for role checks
+**Scale/Scope**: 7 new MCP tools, ~7 Kotlin files, MCP documentation update
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | All tools use `McpExecutionContext` for access control; role checks via `context.isAdmin`, `context.delegatedUserRoles`; input sanitization delegated to existing service layer |
+| III. API-First | PASS | MCP tools follow existing patterns; JSON-RPC 2.0 protocol maintained |
+| IV. User-Requested Testing | PASS | No test preparation included unless explicitly requested |
+| V. RBAC | PASS | All tools enforce role requirements matching REST API; ADMIN/VULN for overdue assets, ADMIN/SECCHAMPION for exception approval |
+| VI. Schema Evolution | PASS | No schema changes required; using existing entities |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/062-mcp-vuln-exceptions/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (MCP tool schemas)
+│   ├── get-overdue-assets.md
+│   ├── create-exception-request.md
+│   ├── get-my-exception-requests.md
+│   ├── get-pending-exception-requests.md
+│   ├── approve-exception-request.md
+│   ├── reject-exception-request.md
+│   └── cancel-exception-request.md
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/src/main/kotlin/com/secman/
+├── mcp/
+│   ├── McpToolRegistry.kt                    # MODIFY - register new tools
+│   └── tools/
+│       ├── GetOverdueAssetsTool.kt          # NEW
+│       ├── CreateExceptionRequestTool.kt    # NEW
+│       ├── GetMyExceptionRequestsTool.kt    # NEW
+│       ├── GetPendingExceptionRequestsTool.kt # NEW
+│       ├── ApproveExceptionRequestTool.kt   # NEW
+│       ├── RejectExceptionRequestTool.kt    # NEW
+│       └── CancelExceptionRequestTool.kt    # NEW
+├── domain/
+│   └── McpPermission.kt                      # MODIFY - add EXCEPTIONS_READ, EXCEPTIONS_WRITE if needed
+└── dto/mcp/
+    └── McpExecutionContext.kt                # READ ONLY - use existing context pattern
+
+docs/
+└── MCP.md                                    # MODIFY - document new tools
+```
+
+**Structure Decision**: Web application structure using existing `src/backendng/` layout. All new files placed in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` following established MCP tool patterns (e.g., `ListUsersTool.kt`, `GetAssetMostVulnerabilitiesTool.kt`).
+
+## Complexity Tracking
+
+> No constitution violations to justify. Implementation uses existing service layer and patterns.
+
+| Aspect | Decision | Justification |
+|--------|----------|---------------|
+| Service reuse | Delegate to existing services | `OutdatedAssetService` and `VulnerabilityExceptionRequestService` contain all business logic |
+| No new entities | Use existing domain model | `VulnerabilityExceptionRequest`, `VulnerabilityException`, `OutdatedAssetMaterializedView` already exist |
+| No new permissions | Reuse existing McpPermission | `VULNERABILITIES_READ`, `ASSETS_READ`, `USER_ACTIVITY` sufficient for authorization mapping |

--- a/specs/062-mcp-vuln-exceptions/quickstart.md
+++ b/specs/062-mcp-vuln-exceptions/quickstart.md
@@ -1,0 +1,208 @@
+# Quickstart Guide: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Feature**: 062-mcp-vuln-exceptions
+**Date**: 2026-01-11
+
+## Overview
+
+This guide provides the implementation approach for adding 7 MCP tools that expose overdue asset querying and vulnerability exception handling.
+
+## Prerequisites
+
+- Existing services: `OutdatedAssetService`, `VulnerabilityExceptionRequestService`
+- Existing entities: `VulnerabilityExceptionRequest`, `VulnerabilityException`, `OutdatedAssetMaterializedView`
+- Existing DTOs: `VulnerabilityExceptionRequestDto`, `OutdatedAssetDto`, `CreateExceptionRequestDto`, `ReviewExceptionRequestDto`
+
+## Implementation Sequence
+
+### Phase 1: GetOverdueAssetsTool (US1 - P1)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt`
+
+```kotlin
+@Singleton
+class GetOverdueAssetsTool(
+    @Inject private val outdatedAssetService: OutdatedAssetService
+) : McpTool {
+    override val name = "get_overdue_assets"
+    override val description = "Get assets with overdue vulnerabilities (ADMIN/VULN only)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "page" to mapOf("type" to "number", "description" to "Page number (default: 0)"),
+            "size" to mapOf("type" to "number", "description" to "Page size (default: 20, max: 100)"),
+            "minSeverity" to mapOf("type" to "string", "enum" to listOf("CRITICAL", "HIGH", "MEDIUM", "LOW")),
+            "searchTerm" to mapOf("type" to "string", "description" to "Search by asset name")
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // 1. Check delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled")
+        }
+
+        // 2. Check role (ADMIN or VULN)
+        val hasRole = context.isAdmin || context.delegatedUserRoles?.contains("VULN") == true
+        if (!hasRole) {
+            return McpToolResult.error("ROLE_REQUIRED", "ADMIN or VULN role required")
+        }
+
+        // 3. Create Authentication adapter from context
+        val authentication = createAuthenticationFromContext(context)
+
+        // 4. Parse parameters and call service
+        val page = (arguments["page"] as? Number)?.toInt() ?: 0
+        val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+        val minSeverity = arguments["minSeverity"] as? String
+        val searchTerm = arguments["searchTerm"] as? String
+
+        val pageable = Pageable.from(page, size)
+        val result = outdatedAssetService.getOutdatedAssets(authentication, searchTerm, minSeverity, pageable)
+
+        // 5. Return success with mapped DTOs
+        return McpToolResult.success(mapOf(
+            "assets" to result.content.map { OutdatedAssetDto.from(it) },
+            "totalElements" to result.totalSize,
+            "totalPages" to result.totalPages,
+            "page" to page,
+            "size" to size
+        ))
+    }
+
+    private fun createAuthenticationFromContext(context: McpExecutionContext): Authentication {
+        return object : Authentication {
+            override fun getName() = context.delegatedUserEmail ?: "mcp-user"
+            override fun getRoles() = context.delegatedUserRoles ?: emptySet()
+            override fun getAttributes() = mapOf<String, Any>(
+                "userId" to (context.delegatedUserId ?: 0L),
+                "workgroupIds" to (context.accessibleWorkgroupIds?.toList() ?: emptyList<Long>())
+            )
+        }
+    }
+}
+```
+
+### Phase 2: CreateExceptionRequestTool (US2 - P1)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateExceptionRequestTool.kt`
+
+```kotlin
+@Singleton
+class CreateExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+    override val name = "create_exception_request"
+    override val description = "Create a vulnerability exception request"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("vulnerabilityId", "reason", "expirationDate"),
+        "properties" to mapOf(
+            "vulnerabilityId" to mapOf("type" to "number"),
+            "reason" to mapOf("type" to "string", "minLength" to 50, "maxLength" to 2048),
+            "expirationDate" to mapOf("type" to "string", "format" to "date-time"),
+            "scope" to mapOf("type" to "string", "enum" to listOf("SINGLE_VULNERABILITY", "CVE_PATTERN"))
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled")
+        }
+
+        try {
+            val dto = CreateExceptionRequestDto(
+                vulnerabilityId = (arguments["vulnerabilityId"] as Number).toLong(),
+                scope = ExceptionScope.valueOf(arguments["scope"] as? String ?: "SINGLE_VULNERABILITY"),
+                reason = arguments["reason"] as String,
+                expirationDate = LocalDateTime.parse(arguments["expirationDate"] as String)
+            )
+
+            val result = exceptionRequestService.createRequest(dto, context.delegatedUserId!!, null)
+
+            val message = if (result.autoApproved) {
+                "Exception request auto-approved (ADMIN/SECCHAMPION role)"
+            } else {
+                "Exception request created successfully. Status: PENDING"
+            }
+
+            return McpToolResult.success(mapOf("request" to result, "message" to message))
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("VALIDATION_ERROR", e.message ?: "Validation failed")
+        }
+    }
+}
+```
+
+### Phase 3-7: Remaining Tools
+
+Follow the same pattern for:
+
+3. **GetMyExceptionRequestsTool** → `exceptionRequestService.getUserRequests(userId, status, pageable)`
+4. **GetPendingExceptionRequestsTool** → `exceptionRequestService.getPendingRequests(pageable)` (requires ADMIN/SECCHAMPION)
+5. **ApproveExceptionRequestTool** → `exceptionRequestService.approveRequest(id, reviewerId, dto, clientIp)` (requires ADMIN/SECCHAMPION)
+6. **RejectExceptionRequestTool** → `exceptionRequestService.rejectRequest(id, reviewerId, dto, clientIp)` (requires ADMIN/SECCHAMPION)
+7. **CancelExceptionRequestTool** → `exceptionRequestService.cancelRequest(id, userId, clientIp)` (ownership check)
+
+### Phase 8: Register Tools in McpToolRegistry
+
+**File**: `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt`
+
+Add constructor injections:
+```kotlin
+@Inject private val getOverdueAssetsTool: GetOverdueAssetsTool,
+@Inject private val createExceptionRequestTool: CreateExceptionRequestTool,
+@Inject private val getMyExceptionRequestsTool: GetMyExceptionRequestsTool,
+@Inject private val getPendingExceptionRequestsTool: GetPendingExceptionRequestsTool,
+@Inject private val approveExceptionRequestTool: ApproveExceptionRequestTool,
+@Inject private val rejectExceptionRequestTool: RejectExceptionRequestTool,
+@Inject private val cancelExceptionRequestTool: CancelExceptionRequestTool,
+```
+
+Register in tools list and add authorization mappings in `isToolAuthorized()`.
+
+### Phase 9: Update Documentation
+
+**File**: `docs/MCP.md`
+
+Add new tools to:
+1. Permission Types table
+2. Available MCP Tools section under "Vulnerability Management"
+3. Usage Examples section
+
+## Verification
+
+```bash
+# Build
+./gradlew build
+
+# Test via curl
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: sk-your-key" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/call",
+    "params": {
+      "name": "get_overdue_assets",
+      "arguments": {}
+    }
+  }'
+```
+
+## Error Handling Checklist
+
+- [ ] DELEGATION_REQUIRED for all tools
+- [ ] Role checks for admin-only tools
+- [ ] NOT_FOUND for missing entities
+- [ ] VALIDATION_ERROR for invalid input
+- [ ] CONFLICT for duplicate requests
+- [ ] INVALID_STATE for wrong status transitions
+- [ ] CONCURRENT_MODIFICATION for optimistic lock failures
+- [ ] FORBIDDEN for ownership violations

--- a/specs/062-mcp-vuln-exceptions/research.md
+++ b/specs/062-mcp-vuln-exceptions/research.md
@@ -1,0 +1,194 @@
+# Research: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Feature**: 062-mcp-vuln-exceptions
+**Date**: 2026-01-11
+
+## Research Tasks
+
+### 1. MCP Tool Implementation Pattern
+
+**Decision**: Follow established `McpTool` interface pattern
+
+**Rationale**: Existing MCP tools (`ListUsersTool`, `GetAssetMostVulnerabilitiesTool`, etc.) demonstrate a consistent pattern that should be followed.
+
+**Pattern Analysis**:
+```kotlin
+@Singleton
+class MyTool(
+    @Inject private val myService: MyService
+) : McpTool {
+    override val name = "tool_name"
+    override val description = "Human-readable description"
+    override val operation = McpOperation.READ  // or WRITE
+    override val inputSchema = mapOf(...)
+
+    override suspend fun execute(
+        arguments: Map<String, Any>,
+        context: McpExecutionContext
+    ): McpToolResult {
+        // 1. Check delegation if required
+        // 2. Check roles if required
+        // 3. Call service layer
+        // 4. Return McpToolResult.success() or McpToolResult.error()
+    }
+}
+```
+
+**Alternatives Considered**: None - pattern is well-established in codebase.
+
+---
+
+### 2. Access Control Approach for MCP Tools
+
+**Decision**: Use `McpExecutionContext` properties for all authorization checks
+
+**Rationale**: `McpExecutionContext` provides:
+- `hasDelegation()` - Check if User Delegation is active
+- `isAdmin` - Quick check for ADMIN role
+- `delegatedUserRoles` - Set of role names for detailed checks
+- `delegatedUserId` - User ID for ownership checks
+- `delegatedUserEmail` - Email for audit logging
+
+**Role Check Patterns**:
+```kotlin
+// ADMIN-only tool
+if (!context.isAdmin) {
+    return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required")
+}
+
+// ADMIN or SECCHAMPION
+val hasApprovalRole = context.delegatedUserRoles?.any {
+    it == "ADMIN" || it == "SECCHAMPION"
+} == true
+if (!hasApprovalRole) {
+    return McpToolResult.error("APPROVAL_ROLE_REQUIRED", "ADMIN or SECCHAMPION role required")
+}
+
+// ADMIN or VULN
+val hasVulnRole = context.isAdmin || context.delegatedUserRoles?.contains("VULN") == true
+```
+
+**Alternatives Considered**:
+- Creating Micronaut `Authentication` objects to pass to services - rejected due to complexity and service methods already having userId parameters.
+
+---
+
+### 3. Service Layer Integration
+
+**Decision**: Delegate to existing services, adapting parameters from MCP context
+
+**Services to use**:
+
+| Tool | Service | Method(s) |
+|------|---------|-----------|
+| `get_overdue_assets` | `OutdatedAssetService` | `getOutdatedAssets()`, Need to adapt context to Authentication |
+| `create_exception_request` | `VulnerabilityExceptionRequestService` | `createRequest(dto, userId, clientIp)` |
+| `get_my_exception_requests` | `VulnerabilityExceptionRequestService` | `getUserRequests(userId, status, pageable)` |
+| `get_pending_exception_requests` | `VulnerabilityExceptionRequestService` | `getPendingRequests(pageable)` |
+| `approve_exception_request` | `VulnerabilityExceptionRequestService` | `approveRequest(id, reviewerId, dto, clientIp)` |
+| `reject_exception_request` | `VulnerabilityExceptionRequestService` | `rejectRequest(id, reviewerId, dto, clientIp)` |
+| `cancel_exception_request` | `VulnerabilityExceptionRequestService` | `cancelRequest(id, userId, clientIp)` |
+
+**Rationale**: Services contain all business logic, validation, and audit logging. MCP tools should be thin wrappers.
+
+**Challenge**: `OutdatedAssetService.getOutdatedAssets()` expects `Authentication` object, but MCP provides `McpExecutionContext`.
+
+**Solution**: Create an adapter method or use repository directly with workgroup filtering from context. The service uses `authentication.roles` and `authentication.attributes["workgroupIds"]` - we can query the repository directly with the same filtering logic.
+
+---
+
+### 4. OutdatedAssetService Authentication Adaptation
+
+**Decision**: Create a simple `Authentication` implementation within the MCP tool for `OutdatedAssetService` calls
+
+**Rationale**: `OutdatedAssetService.getOutdatedAssets()` requires:
+- `authentication.roles` - Set of role names
+- `authentication.attributes["workgroupIds"]` - List of accessible workgroup IDs
+
+**Implementation Approach**:
+```kotlin
+// Create minimal Authentication from McpExecutionContext
+val authentication = object : io.micronaut.security.authentication.Authentication {
+    override fun getName(): String = context.delegatedUserEmail ?: "mcp-user"
+    override fun getRoles(): Collection<String> = context.delegatedUserRoles ?: emptySet()
+    override fun getAttributes(): Map<String, Any> = mapOf(
+        "userId" to (context.delegatedUserId ?: 0L),
+        "workgroupIds" to (context.accessibleWorkgroupIds?.toList() ?: emptyList<Long>())
+    )
+}
+```
+
+**Alternatives Considered**:
+- Duplicating the service logic in the MCP tool - rejected to maintain single source of truth
+- Modifying `OutdatedAssetService` to accept alternative parameters - rejected to avoid changes to working code
+
+---
+
+### 5. Error Handling Patterns
+
+**Decision**: Use consistent error codes matching existing MCP tools
+
+**Error Code Mapping**:
+| Scenario | Code | Message Pattern |
+|----------|------|-----------------|
+| Missing User Delegation | `DELEGATION_REQUIRED` | "User Delegation must be enabled to use this tool" |
+| Missing required role | `{ROLE}_REQUIRED` | "{ROLE} role required to [action]" |
+| Entity not found | `NOT_FOUND` | "{Entity} with ID {id} not found" |
+| Validation failure | `VALIDATION_ERROR` | "{Field}: {message}" |
+| Duplicate/conflict | `CONFLICT` | "Already exists: {details}" |
+| Invalid state transition | `INVALID_STATE` | "Cannot {action} request in {status} status" |
+| Concurrent modification | `CONCURRENT_MODIFICATION` | "Request was already reviewed by {username}" |
+| Execution error | `EXECUTION_ERROR` | "Failed to {action}: {message}" |
+
+**Rationale**: Consistent error codes enable AI assistants to provide meaningful feedback to users.
+
+---
+
+### 6. MCP Permission Mapping
+
+**Decision**: Use existing permissions where possible, adding new ones only if necessary
+
+**Mapping Analysis**:
+
+| Tool | Required Role | MCP Permission | Existing? |
+|------|---------------|----------------|-----------|
+| `get_overdue_assets` | ADMIN or VULN | `VULNERABILITIES_READ` | Yes |
+| `create_exception_request` | Any authenticated | `VULNERABILITIES_READ` | Yes |
+| `get_my_exception_requests` | Any authenticated | `VULNERABILITIES_READ` | Yes |
+| `get_pending_exception_requests` | ADMIN or SECCHAMPION | `VULNERABILITIES_READ` | Yes |
+| `approve_exception_request` | ADMIN or SECCHAMPION | `VULNERABILITIES_READ` | Yes (write check done in execute) |
+| `reject_exception_request` | ADMIN or SECCHAMPION | `VULNERABILITIES_READ` | Yes (write check done in execute) |
+| `cancel_exception_request` | Original requester | `VULNERABILITIES_READ` | Yes |
+
+**Rationale**: All exception handling relates to vulnerabilities, so `VULNERABILITIES_READ` permission is appropriate. Role-based authorization is enforced within each tool's `execute()` method using `McpExecutionContext`, not at the permission level. This matches the pattern used by `list_users` tool (requires `USER_ACTIVITY` permission but checks `isAdmin` in execute).
+
+---
+
+### 7. Pagination Support
+
+**Decision**: Support pagination via `page` and `size` parameters for list operations
+
+**Pattern**:
+```kotlin
+val page = (arguments["page"] as? Number)?.toInt() ?: 0
+val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+val pageable = Pageable.from(page, size)
+```
+
+**Applied to**:
+- `get_overdue_assets`
+- `get_my_exception_requests`
+- `get_pending_exception_requests`
+
+**Rationale**: Pagination prevents large result sets from overwhelming AI context windows.
+
+---
+
+## Summary
+
+All research items resolved. Implementation can proceed with:
+1. Thin MCP tool wrappers delegating to existing services
+2. `McpExecutionContext` for all authorization checks
+3. Consistent error handling with defined codes
+4. Pagination support for list operations
+5. Authentication adapter for `OutdatedAssetService` integration

--- a/specs/062-mcp-vuln-exceptions/spec.md
+++ b/specs/062-mcp-vuln-exceptions/spec.md
@@ -1,0 +1,222 @@
+# Feature Specification: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Feature Branch**: `062-mcp-vuln-exceptions`
+**Created**: 2026-01-11
+**Status**: Draft
+**Input**: User description: "add a functionality to show all assets with overdue vulnerabilities for the current user via MCP, add also functionality via MCP to exception handling (request, show, approve, decline), respect here existing RBAC implementations. Add newly create functionality to documentation."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View My Overdue Assets via MCP (Priority: P1)
+
+A security analyst or administrator wants to use an AI assistant to ask "What assets do I have with overdue vulnerabilities?" and receive a list of assets with vulnerabilities that have exceeded their remediation deadline, filtered based on their workgroup access and roles.
+
+**Why this priority**: This provides immediate visibility into the most critical security posture issue - vulnerabilities that have exceeded their allowed remediation time. Direct value for security operations and compliance.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying that assets with overdue vulnerabilities are returned, filtered by the user's access rights.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with ADMIN role connected via MCP with user delegation, **When** they invoke the `get_overdue_assets` tool, **Then** they receive a list of all assets with overdue vulnerabilities in the system.
+
+2. **Given** a user with VULN role connected via MCP with user delegation, **When** they invoke the `get_overdue_assets` tool, **Then** they receive only assets from their assigned workgroups that have overdue vulnerabilities.
+
+3. **Given** a user with no ADMIN or VULN role connected via MCP, **When** they invoke the `get_overdue_assets` tool, **Then** they receive an authorization error.
+
+4. **Given** a user connected via MCP, **When** they invoke `get_overdue_assets` with a severity filter, **Then** only assets with overdue vulnerabilities at or above that severity are returned.
+
+---
+
+### User Story 2 - Request Vulnerability Exception via MCP (Priority: P1)
+
+A user wants to use an AI assistant to create an exception request for a vulnerability they cannot immediately remediate, providing justification and an expiration date. The request should follow the existing approval workflow.
+
+**Why this priority**: Exception requests are critical for managing vulnerabilities that cannot be immediately fixed due to business constraints. This enables security workflows via AI assistants.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying an exception request is created in PENDING status (or auto-approved for ADMIN/SECCHAMPION).
+
+**Acceptance Scenarios**:
+
+1. **Given** a regular user connected via MCP with user delegation, **When** they invoke `create_exception_request` with vulnerability ID, reason (50+ characters), and expiration date, **Then** a new exception request is created with PENDING status.
+
+2. **Given** a user with ADMIN or SECCHAMPION role connected via MCP, **When** they invoke `create_exception_request`, **Then** the exception request is auto-approved (status APPROVED immediately).
+
+3. **Given** a user connected via MCP, **When** they invoke `create_exception_request` with a reason less than 50 characters, **Then** they receive a validation error.
+
+4. **Given** a user connected via MCP, **When** they invoke `create_exception_request` with an expiration date in the past, **Then** they receive a validation error.
+
+---
+
+### User Story 3 - View My Exception Requests via MCP (Priority: P2)
+
+A user wants to use an AI assistant to ask "Show me my exception requests" to see the status of their pending and past exception requests.
+
+**Why this priority**: Users need visibility into their own requests to track approval status and manage their workflow.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying the user receives only their own exception requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user connected via MCP with user delegation, **When** they invoke `get_my_exception_requests`, **Then** they receive a list of their own exception requests.
+
+2. **Given** a user connected via MCP with user delegation, **When** they invoke `get_my_exception_requests` with status filter `PENDING`, **Then** they receive only their pending requests.
+
+3. **Given** a user who has never created exception requests, **When** they invoke `get_my_exception_requests`, **Then** they receive an empty list with count 0.
+
+---
+
+### User Story 4 - View Pending Exception Requests for Approval via MCP (Priority: P2)
+
+An ADMIN or SECCHAMPION wants to use an AI assistant to ask "Show me pending exception requests that need approval" to review and take action on requests awaiting their decision.
+
+**Why this priority**: Approvers need to see the queue of pending requests to perform their approval duties.
+
+**Independent Test**: Can be tested by invoking the MCP tool with an ADMIN/SECCHAMPION user and verifying all pending requests system-wide are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with ADMIN role connected via MCP, **When** they invoke `get_pending_exception_requests`, **Then** they receive all pending exception requests in the system, sorted oldest first.
+
+2. **Given** a user with SECCHAMPION role connected via MCP, **When** they invoke `get_pending_exception_requests`, **Then** they receive all pending exception requests in the system.
+
+3. **Given** a regular user connected via MCP (without ADMIN or SECCHAMPION role), **When** they invoke `get_pending_exception_requests`, **Then** they receive an authorization error.
+
+---
+
+### User Story 5 - Approve Exception Request via MCP (Priority: P2)
+
+An ADMIN or SECCHAMPION wants to use an AI assistant to approve a pending exception request, optionally adding a review comment.
+
+**Why this priority**: Core approval workflow capability needed to process the exception queue.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying the request status changes to APPROVED.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with ADMIN role connected via MCP and a pending exception request exists, **When** they invoke `approve_exception_request` with the request ID, **Then** the request status changes to APPROVED and a VulnerabilityException is created.
+
+2. **Given** a user with SECCHAMPION role connected via MCP, **When** they invoke `approve_exception_request` with an optional comment, **Then** the comment is recorded with the approval.
+
+3. **Given** a regular user connected via MCP, **When** they invoke `approve_exception_request`, **Then** they receive an authorization error.
+
+4. **Given** an ADMIN connected via MCP and a request that is already APPROVED, **When** they invoke `approve_exception_request`, **Then** they receive an error indicating the request cannot be approved (invalid status transition).
+
+---
+
+### User Story 6 - Reject Exception Request via MCP (Priority: P2)
+
+An ADMIN or SECCHAMPION wants to use an AI assistant to reject a pending exception request, providing a mandatory rejection reason.
+
+**Why this priority**: Core approval workflow capability needed to process the exception queue.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying the request status changes to REJECTED.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with ADMIN role connected via MCP and a pending exception request exists, **When** they invoke `reject_exception_request` with the request ID and a comment (10+ characters), **Then** the request status changes to REJECTED.
+
+2. **Given** a user with SECCHAMPION role connected via MCP, **When** they invoke `reject_exception_request` without a comment, **Then** they receive a validation error (comment is required for rejection).
+
+3. **Given** a regular user connected via MCP, **When** they invoke `reject_exception_request`, **Then** they receive an authorization error.
+
+---
+
+### User Story 7 - Cancel My Exception Request via MCP (Priority: P3)
+
+A user wants to use an AI assistant to cancel their own pending exception request that they no longer need.
+
+**Why this priority**: Allows users to manage their own requests, but less critical than core create/approve/reject workflow.
+
+**Independent Test**: Can be tested by invoking the MCP tool and verifying the request status changes to CANCELLED.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user connected via MCP who has a PENDING exception request, **When** they invoke `cancel_exception_request` with their request ID, **Then** the request status changes to CANCELLED.
+
+2. **Given** a user connected via MCP, **When** they try to cancel another user's request, **Then** they receive an authorization error.
+
+3. **Given** a user connected via MCP who has an APPROVED exception request, **When** they invoke `cancel_exception_request`, **Then** they receive an error (only PENDING requests can be cancelled).
+
+---
+
+### Edge Cases
+
+- What happens when a user requests an exception for a vulnerability they don't have access to? → Authorization error returned.
+- What happens when two approvers try to approve the same request simultaneously? → First-approver-wins using optimistic locking; second receives conflict error.
+- What happens when the delegated user's account is disabled? → MCP request fails with delegation error.
+- How does the system handle expired exception requests? → Expired requests remain in EXPIRED status; this tool shows current status.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Overdue Assets Tool:**
+- **FR-001**: System MUST provide an MCP tool `get_overdue_assets` that returns assets with overdue vulnerabilities.
+- **FR-002**: System MUST filter overdue assets based on the delegated user's workgroup access (VULN role sees only their workgroups, ADMIN sees all).
+- **FR-003**: System MUST require ADMIN or VULN role to access the `get_overdue_assets` tool.
+- **FR-004**: System MUST support filtering overdue assets by minimum severity level.
+- **FR-005**: System MUST support pagination for the overdue assets results.
+
+**Exception Request Creation:**
+- **FR-006**: System MUST provide an MCP tool `create_exception_request` to create new vulnerability exception requests.
+- **FR-007**: System MUST require vulnerability ID, reason (50-2048 characters), and future expiration date as input. Scope parameter is optional (default: SINGLE_VULNERABILITY; also accepts CVE_PATTERN).
+- **FR-008**: System MUST auto-approve exception requests created by users with ADMIN or SECCHAMPION role.
+- **FR-009**: System MUST create requests in PENDING status for regular users.
+- **FR-010**: System MUST prevent duplicate active exception requests for the same vulnerability by the same user.
+
+**View Exception Requests:**
+- **FR-011**: System MUST provide an MCP tool `get_my_exception_requests` for users to view their own exception requests.
+- **FR-012**: System MUST support filtering by status (PENDING, APPROVED, REJECTED, EXPIRED, CANCELLED).
+- **FR-013**: System MUST support pagination for exception request results.
+
+**Pending Requests for Approval:**
+- **FR-014**: System MUST provide an MCP tool `get_pending_exception_requests` for ADMIN/SECCHAMPION to view all pending requests.
+- **FR-015**: System MUST sort pending requests by creation date (oldest first) for fair processing.
+- **FR-016**: System MUST require ADMIN or SECCHAMPION role to access pending requests.
+
+**Approve/Reject Workflow:**
+- **FR-017**: System MUST provide an MCP tool `approve_exception_request` for ADMIN/SECCHAMPION to approve requests.
+- **FR-018**: System MUST provide an MCP tool `reject_exception_request` for ADMIN/SECCHAMPION to reject requests.
+- **FR-019**: System MUST require a comment (10-1024 characters) for rejection.
+- **FR-020**: System MUST use optimistic locking to handle concurrent approval/rejection (first-approver-wins).
+- **FR-021**: System MUST create a VulnerabilityException entity upon approval.
+
+**Cancel Request:**
+- **FR-022**: System MUST provide an MCP tool `cancel_exception_request` for users to cancel their own PENDING requests.
+- **FR-023**: System MUST only allow the original requester to cancel a request.
+- **FR-024**: System MUST only allow cancellation of PENDING requests.
+
+**Documentation:**
+- **FR-025**: System MUST update MCP documentation to include all new tools with parameters and examples.
+
+### Key Entities
+
+- **VulnerabilityExceptionRequest**: Represents a user's request for an exception, with status workflow (PENDING → APPROVED/REJECTED/CANCELLED, APPROVED → EXPIRED).
+- **VulnerabilityException**: The actual exception rule created upon approval that suppresses vulnerability reporting.
+- **OutdatedAssetMaterializedView**: Pre-computed view of assets with overdue vulnerabilities used for efficient querying.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can retrieve their overdue assets list via MCP in under 3 seconds.
+- **SC-002**: Exception request creation via MCP completes in under 2 seconds.
+- **SC-003**: ADMIN/SECCHAMPION users can process (approve/reject) exception requests via MCP with immediate effect.
+- **SC-004**: All new MCP tools respect the same RBAC rules as the existing REST API endpoints.
+- **SC-005**: Users can successfully create, view, and cancel exception requests entirely via AI assistant interaction.
+- **SC-006**: Approval workflow via MCP maintains audit trail identical to REST API usage.
+- **SC-007**: Documentation includes clear examples for all new MCP tools enabling immediate user adoption.
+
+## Clarifications
+
+### Session 2026-01-11
+
+- Q: Should the `create_exception_request` MCP tool require users to specify an exception scope? → A: Default to SINGLE_VULNERABILITY scope; scope parameter is optional.
+
+## Assumptions
+
+1. **User Delegation Required**: All MCP tools in this feature require User Delegation to be enabled and `X-MCP-User-Email` header to be provided to identify the acting user.
+2. **Existing Materialized View**: The `OutdatedAssetMaterializedView` already exists and is refreshed periodically; no new view creation needed.
+3. **Existing Service Layer**: The `VulnerabilityExceptionRequestService` and `OutdatedAssetService` contain all necessary business logic; MCP tools will delegate to these services.
+4. **McpPermission Extension**: New MCP permissions may be added for exception handling if the existing permission set is insufficient.
+5. **Scope Parameter**: Exception requests support both SINGLE_VULNERABILITY and CVE_PATTERN scopes as per existing implementation.

--- a/specs/062-mcp-vuln-exceptions/tasks.md
+++ b/specs/062-mcp-vuln-exceptions/tasks.md
@@ -1,0 +1,295 @@
+# Tasks: MCP Tools for Overdue Vulnerabilities and Exception Handling
+
+**Input**: Design documents from `/specs/062-mcp-vuln-exceptions/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Not requested for this feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization - using existing project structure
+
+**Note**: No setup tasks required. Project already has:
+- MCP infrastructure in `src/backendng/src/main/kotlin/com/secman/mcp/`
+- Existing services: `OutdatedAssetService`, `VulnerabilityExceptionRequestService`
+- Existing DTOs and entities
+
+**Checkpoint**: Project ready - proceed to implementation
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**Note**: No foundational tasks required. All infrastructure exists:
+- `McpTool` interface and `McpToolResult` classes
+- `McpExecutionContext` for access control
+- `McpToolRegistry` for tool registration
+- Existing services with required methods
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - View Overdue Assets (Priority: P1) MVP
+
+**Goal**: Security analysts can query overdue assets via MCP with filtering options
+
+**Independent Test**: Call `get_overdue_assets` tool with pagination and filtering parameters
+
+### Implementation for User Story 1
+
+- [x] T001 [US1] Create GetOverdueAssetsTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt`
+  - Implement McpTool interface with name `get_overdue_assets`
+  - Add inputSchema for page, size, minSeverity, searchTerm parameters
+  - Check delegation and ADMIN/VULN role requirement
+  - Create Authentication adapter from McpExecutionContext
+  - Call OutdatedAssetService.getOutdatedAssets()
+  - Return paginated response with OutdatedAssetDto mapping
+
+**Checkpoint**: User Story 1 complete - overdue assets queryable via MCP
+
+---
+
+## Phase 4: User Story 2 - Create Exception Request (Priority: P1) MVP
+
+**Goal**: Users can create exception requests via MCP with auto-approval for privileged roles
+
+**Independent Test**: Call `create_exception_request` tool with vulnerability ID, reason, and expiration date
+
+### Implementation for User Story 2
+
+- [x] T002 [US2] Create CreateExceptionRequestTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateExceptionRequestTool.kt`
+  - Implement McpTool interface with name `create_exception_request`
+  - Add inputSchema with required fields: vulnerabilityId, reason, expirationDate
+  - Add optional scope field (defaults to SINGLE_VULNERABILITY)
+  - Check delegation requirement
+  - Validate reason length (50-2048 characters)
+  - Call VulnerabilityExceptionRequestService.createRequest()
+  - Return appropriate message based on autoApproved status
+
+**Checkpoint**: User Story 2 complete - exception requests can be created via MCP
+
+---
+
+## Phase 5: User Story 3 - View My Exception Requests (Priority: P2)
+
+**Goal**: Users can view their own exception requests with status filtering
+
+**Independent Test**: Call `get_my_exception_requests` tool with status filter parameter
+
+### Implementation for User Story 3
+
+- [x] T003 [US3] Create GetMyExceptionRequestsTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestsTool.kt`
+  - Implement McpTool interface with name `get_my_exception_requests`
+  - Add inputSchema for page, size, status filter parameters
+  - Check delegation requirement
+  - Call VulnerabilityExceptionRequestService.getUserRequests() with delegatedUserId
+  - Return paginated response with VulnerabilityExceptionRequestDto mapping
+
+**Checkpoint**: User Story 3 complete - users can view their exception requests via MCP
+
+---
+
+## Phase 6: User Story 4 - View Pending Requests (Priority: P2)
+
+**Goal**: Approvers can see pending exception requests awaiting review
+
+**Independent Test**: Call `get_pending_exception_requests` tool with ADMIN/SECCHAMPION role
+
+### Implementation for User Story 4
+
+- [x] T004 [US4] Create GetPendingExceptionRequestsTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetPendingExceptionRequestsTool.kt`
+  - Implement McpTool interface with name `get_pending_exception_requests`
+  - Add inputSchema for page, size parameters
+  - Check delegation and ADMIN/SECCHAMPION role requirement
+  - Call VulnerabilityExceptionRequestService.getPendingRequests()
+  - Include pendingCount in response for badge display
+  - Sort by createdAt ascending (FIFO processing)
+
+**Checkpoint**: User Story 4 complete - approvers can view pending requests via MCP
+
+---
+
+## Phase 7: User Story 5 - Approve Exception Request (Priority: P2)
+
+**Goal**: Approvers can approve pending requests, creating corresponding VulnerabilityException
+
+**Independent Test**: Call `approve_exception_request` tool with request ID and optional comment
+
+### Implementation for User Story 5
+
+- [x] T005 [US5] Create ApproveExceptionRequestTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/ApproveExceptionRequestTool.kt`
+  - Implement McpTool interface with name `approve_exception_request`
+  - Add inputSchema with required requestId and optional comment (max 1024 chars)
+  - Check delegation and ADMIN/SECCHAMPION role requirement
+  - Call VulnerabilityExceptionRequestService.approveRequest()
+  - Handle NOT_FOUND, INVALID_STATE, CONCURRENT_MODIFICATION errors
+  - Return updated request with success message
+
+**Checkpoint**: User Story 5 complete - approvers can approve requests via MCP
+
+---
+
+## Phase 8: User Story 6 - Reject Exception Request (Priority: P2)
+
+**Goal**: Approvers can reject pending requests with required justification
+
+**Independent Test**: Call `reject_exception_request` tool with request ID and comment
+
+### Implementation for User Story 6
+
+- [x] T006 [US6] Create RejectExceptionRequestTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/RejectExceptionRequestTool.kt`
+  - Implement McpTool interface with name `reject_exception_request`
+  - Add inputSchema with required requestId and comment (10-1024 chars)
+  - Check delegation and ADMIN/SECCHAMPION role requirement
+  - Validate comment minimum length (10 characters required)
+  - Call VulnerabilityExceptionRequestService.rejectRequest()
+  - Handle NOT_FOUND, INVALID_STATE, CONCURRENT_MODIFICATION errors
+  - Return updated request with rejection message
+
+**Checkpoint**: User Story 6 complete - approvers can reject requests via MCP
+
+---
+
+## Phase 9: User Story 7 - Cancel Exception Request (Priority: P3)
+
+**Goal**: Users can cancel their own pending exception requests
+
+**Independent Test**: Call `cancel_exception_request` tool with request ID as original requester
+
+### Implementation for User Story 7
+
+- [x] T007 [US7] Create CancelExceptionRequestTool in `src/backendng/src/main/kotlin/com/secman/mcp/tools/CancelExceptionRequestTool.kt`
+  - Implement McpTool interface with name `cancel_exception_request`
+  - Add inputSchema with required requestId
+  - Check delegation requirement
+  - Call VulnerabilityExceptionRequestService.cancelRequest() with delegatedUserId
+  - Handle NOT_FOUND, FORBIDDEN (ownership), INVALID_STATE errors
+  - Return updated request with cancellation message
+
+**Checkpoint**: User Story 7 complete - users can cancel their own requests via MCP
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration and documentation tasks that affect all user stories
+
+### Tool Registration
+
+- [x] T008 Register all 7 new tools in `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt`
+  - Add constructor injections for all tools
+  - Add tools to the tools list
+  - Add authorization mappings in isToolAuthorized() method
+
+### Documentation
+
+- [x] T009 [P] Update MCP documentation in `docs/MCP.md`
+  - Add new tools to Permission Types table
+  - Add "Vulnerability Management" section with all 7 tools
+  - Document parameters, required roles, and response formats
+  - Add usage examples for common workflows
+
+### Verification
+
+- [x] T010 Run `./gradlew build` to verify compilation and no errors
+- [x] T011 Verify tools appear in MCP tool listing
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No tasks - existing infrastructure
+- **Foundational (Phase 2)**: No tasks - existing infrastructure
+- **User Stories (Phase 3-9)**: Can proceed in parallel - all tools are independent
+- **Polish (Phase 10)**: Depends on all tool implementations being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies - can start immediately
+- **User Story 2 (P1)**: No dependencies - can start immediately
+- **User Story 3 (P2)**: No dependencies - can start immediately
+- **User Story 4 (P2)**: No dependencies - can start immediately
+- **User Story 5 (P2)**: No dependencies - can start immediately
+- **User Story 6 (P2)**: No dependencies - can start immediately
+- **User Story 7 (P3)**: No dependencies - can start immediately
+
+### Within Each User Story
+
+- Single task per story (one tool per story)
+- Tool implementation is self-contained
+
+### Parallel Opportunities
+
+All 7 tool implementations (T001-T007) can run in parallel since they:
+- Create different files
+- Use existing services (no service modifications needed)
+- Have no dependencies on each other
+
+---
+
+## Parallel Example: All Tool Implementations
+
+```bash
+# All tools can be implemented in parallel:
+Task: "Create GetOverdueAssetsTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt"
+Task: "Create CreateExceptionRequestTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateExceptionRequestTool.kt"
+Task: "Create GetMyExceptionRequestsTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestsTool.kt"
+Task: "Create GetPendingExceptionRequestsTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/GetPendingExceptionRequestsTool.kt"
+Task: "Create ApproveExceptionRequestTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/ApproveExceptionRequestTool.kt"
+Task: "Create RejectExceptionRequestTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/RejectExceptionRequestTool.kt"
+Task: "Create CancelExceptionRequestTool in src/backendng/src/main/kotlin/com/secman/mcp/tools/CancelExceptionRequestTool.kt"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2)
+
+1. Implement T001: GetOverdueAssetsTool
+2. Implement T002: CreateExceptionRequestTool
+3. Complete T008: Register tools in McpToolRegistry
+4. Run T010: Build verification
+5. **STOP and VALIDATE**: Test overdue asset query and exception creation
+
+### Incremental Delivery
+
+1. MVP (T001, T002, T008, T010) → Query overdue assets, create requests
+2. Add T003, T004 → Users can track requests, approvers can see queue
+3. Add T005, T006 → Complete approval workflow
+4. Add T007 → Users can cancel pending requests
+5. T009, T011 → Documentation and final verification
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. **Developer A**: T001, T002 (MVP tools)
+2. **Developer B**: T003, T004 (read tools)
+3. **Developer C**: T005, T006, T007 (write tools)
+4. **Any developer**: T008, T009, T010, T011 (integration)
+
+---
+
+## Notes
+
+- All tools follow existing MCP tool pattern (see ListUsersTool, ListProductsTool)
+- Use McpExecutionContext for delegation and role checks
+- Delegate to existing services - no new service methods needed
+- Error codes defined in contracts/ directory
+- No database schema changes required

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -135,12 +135,12 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("21")
-    targetCompatibility = JavaVersion.toVersion("21")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 allOpen {

--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -33,7 +33,15 @@ class McpToolRegistry(
     // Feature 061: MCP List Products Tool
     @Inject private val listProductsTool: ListProductsTool,
     // MCP Tool: Get asset with most vulnerabilities
-    @Inject private val getAssetMostVulnerabilitiesTool: GetAssetMostVulnerabilitiesTool
+    @Inject private val getAssetMostVulnerabilitiesTool: GetAssetMostVulnerabilitiesTool,
+    // Feature 062: MCP Tools for Overdue Vulnerabilities and Exception Handling
+    @Inject private val getOverdueAssetsTool: GetOverdueAssetsTool,
+    @Inject private val createExceptionRequestTool: CreateExceptionRequestTool,
+    @Inject private val getMyExceptionRequestsTool: GetMyExceptionRequestsTool,
+    @Inject private val getPendingExceptionRequestsTool: GetPendingExceptionRequestsTool,
+    @Inject private val approveExceptionRequestTool: ApproveExceptionRequestTool,
+    @Inject private val rejectExceptionRequestTool: RejectExceptionRequestTool,
+    @Inject private val cancelExceptionRequestTool: CancelExceptionRequestTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -63,7 +71,15 @@ class McpToolRegistry(
             // Feature 061: MCP List Products Tool
             listProductsTool,
             // MCP Tool: Get asset with most vulnerabilities
-            getAssetMostVulnerabilitiesTool
+            getAssetMostVulnerabilitiesTool,
+            // Feature 062: MCP Tools for Overdue Vulnerabilities and Exception Handling
+            getOverdueAssetsTool,
+            createExceptionRequestTool,
+            getMyExceptionRequestsTool,
+            getPendingExceptionRequestsTool,
+            approveExceptionRequestTool,
+            rejectExceptionRequestTool,
+            cancelExceptionRequestTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -209,6 +225,30 @@ class McpToolRegistry(
             "get_asset_most_vulnerabilities" -> {
                 permissions.contains(McpPermission.VULNERABILITIES_READ) ||
                 permissions.contains(McpPermission.ASSETS_READ)
+            }
+
+            // Feature 062: MCP Tools for Overdue Vulnerabilities and Exception Handling
+            "get_overdue_assets" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) ||
+                permissions.contains(McpPermission.ASSETS_READ)
+            }
+            "create_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Any authenticated user, role check in tool
+            }
+            "get_my_exception_requests" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Any authenticated user
+            }
+            "get_pending_exception_requests" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Role check in tool
+            }
+            "approve_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Role check in tool
+            }
+            "reject_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Role check in tool
+            }
+            "cancel_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Ownership check in tool
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ApproveExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ApproveExceptionRequestTool.kt
@@ -1,0 +1,131 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.ReviewExceptionRequestDto
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.exception.ConcurrentApprovalException
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for approving pending exception requests.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN or SECCHAMPION role required
+ * - Uses optimistic locking for concurrent approval handling
+ *
+ * Spec reference: spec.md FR-017, FR-020, FR-021
+ * User Story: US5 - Approve Exception Request (P2)
+ */
+@Singleton
+class ApproveExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "approve_exception_request"
+    override val description = "Approve a pending exception request (ADMIN/SECCHAMPION role required, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("requestId"),
+        "properties" to mapOf(
+            "requestId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the exception request to approve"
+            ),
+            "comment" to mapOf(
+                "type" to "string",
+                "description" to "Optional approval comment (max 1024 characters)",
+                "maxLength" to 1024
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-017: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN or SECCHAMPION role
+        val hasApprovalRole = context.isAdmin || context.delegatedUserRoles?.contains("SECCHAMPION") == true
+        if (!hasApprovalRole) {
+            return McpToolResult.error(
+                "APPROVAL_ROLE_REQUIRED",
+                "ADMIN or SECCHAMPION role required to approve requests"
+            )
+        }
+
+        try {
+            // Parse requestId
+            val requestId = (arguments["requestId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "requestId is required")
+
+            // Parse optional comment
+            val comment = arguments["comment"] as? String
+            if (comment != null && comment.length > 1024) {
+                return McpToolResult.error("VALIDATION_ERROR", "Comment must not exceed 1024 characters")
+            }
+
+            // Create review DTO
+            val reviewDto = if (comment != null) ReviewExceptionRequestDto(reviewComment = comment) else null
+
+            // Call service
+            val result = exceptionRequestService.approveRequest(
+                requestId = requestId,
+                reviewerUserId = context.delegatedUserId!!,
+                reviewDto = reviewDto,
+                clientIp = null
+            )
+
+            return McpToolResult.success(
+                mapOf(
+                    "request" to mapOf(
+                        "id" to result.id,
+                        "vulnerabilityId" to result.vulnerabilityId,
+                        "vulnerabilityCve" to result.vulnerabilityCve,
+                        "assetName" to result.assetName,
+                        "assetIp" to result.assetIp,
+                        "requestedByUsername" to result.requestedByUsername,
+                        "scope" to result.scope.name,
+                        "reason" to result.reason,
+                        "expirationDate" to result.expirationDate.toString(),
+                        "status" to result.status.name,
+                        "autoApproved" to result.autoApproved,
+                        "reviewedByUsername" to result.reviewedByUsername,
+                        "reviewDate" to result.reviewDate?.toString(),
+                        "reviewComment" to result.reviewComment,
+                        "createdAt" to result.createdAt.toString(),
+                        "updatedAt" to result.updatedAt.toString()
+                    ),
+                    "message" to "Exception request approved successfully"
+                )
+            )
+
+        } catch (e: ConcurrentApprovalException) {
+            // FR-020: Concurrent approval handling
+            return McpToolResult.error(
+                "CONCURRENT_MODIFICATION",
+                "Request was already reviewed by ${e.reviewedBy} at ${e.reviewedAt}"
+            )
+        } catch (e: IllegalArgumentException) {
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error("NOT_FOUND", message)
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: IllegalStateException) {
+            // FR-021: Invalid state transition
+            return McpToolResult.error("INVALID_STATE", e.message ?: "Invalid state transition")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to approve request: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/CancelExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/CancelExceptionRequestTool.kt
@@ -1,0 +1,104 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for cancelling the user's own pending exception request.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Any authenticated user can cancel their own requests
+ * - Ownership check: only the original requester can cancel
+ * - Only PENDING requests can be cancelled (or auto-approved by same user)
+ *
+ * Spec reference: spec.md FR-022 through FR-024
+ * User Story: US7 - Cancel Exception Request (P3)
+ */
+@Singleton
+class CancelExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "cancel_exception_request"
+    override val description = "Cancel your own pending exception request (requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("requestId"),
+        "properties" to mapOf(
+            "requestId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the exception request to cancel"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            // Parse requestId
+            val requestId = (arguments["requestId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "requestId is required")
+
+            // Call service - ownership check is done inside the service
+            val result = exceptionRequestService.cancelRequest(
+                requestId = requestId,
+                requesterUserId = context.delegatedUserId!!,
+                clientIp = null
+            )
+
+            return McpToolResult.success(
+                mapOf(
+                    "request" to mapOf(
+                        "id" to result.id,
+                        "vulnerabilityId" to result.vulnerabilityId,
+                        "vulnerabilityCve" to result.vulnerabilityCve,
+                        "assetName" to result.assetName,
+                        "assetIp" to result.assetIp,
+                        "requestedByUsername" to result.requestedByUsername,
+                        "scope" to result.scope.name,
+                        "reason" to result.reason,
+                        "expirationDate" to result.expirationDate.toString(),
+                        "status" to result.status.name,
+                        "autoApproved" to result.autoApproved,
+                        "createdAt" to result.createdAt.toString(),
+                        "updatedAt" to result.updatedAt.toString()
+                    ),
+                    "message" to "Exception request cancelled successfully"
+                )
+            )
+
+        } catch (e: IllegalArgumentException) {
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error(
+                    "NOT_FOUND",
+                    "Exception request with ID not found"
+                )
+                message.contains("original requester") -> McpToolResult.error(
+                    "FORBIDDEN",
+                    "Only the original requester can cancel this request"
+                )
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: IllegalStateException) {
+            // Invalid state transition
+            return McpToolResult.error("INVALID_STATE", e.message ?: "Invalid state transition")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to cancel request: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateExceptionRequestTool.kt
@@ -1,0 +1,166 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.ExceptionScope
+import com.secman.domain.McpOperation
+import com.secman.dto.CreateExceptionRequestDto
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.LocalDateTime
+import java.time.format.DateTimeParseException
+
+/**
+ * MCP tool for creating vulnerability exception requests.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Any authenticated user can create requests
+ * - ADMIN/SECCHAMPION requests are auto-approved
+ *
+ * Spec reference: spec.md FR-006 through FR-010
+ * User Story: US2 - Create Exception Request (P1)
+ */
+@Singleton
+class CreateExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "create_exception_request"
+    override val description = "Create a vulnerability exception request (requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("vulnerabilityId", "reason", "expirationDate"),
+        "properties" to mapOf(
+            "vulnerabilityId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the vulnerability to request exception for"
+            ),
+            "reason" to mapOf(
+                "type" to "string",
+                "description" to "Business justification (50-2048 characters)",
+                "minLength" to 50,
+                "maxLength" to 2048
+            ),
+            "expirationDate" to mapOf(
+                "type" to "string",
+                "format" to "date-time",
+                "description" to "When the exception should expire (ISO-8601, must be future date)"
+            ),
+            "scope" to mapOf(
+                "type" to "string",
+                "enum" to listOf("SINGLE_VULNERABILITY", "CVE_PATTERN"),
+                "default" to "SINGLE_VULNERABILITY",
+                "description" to "Exception scope (default: SINGLE_VULNERABILITY)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-006: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            // Parse and validate vulnerabilityId
+            val vulnerabilityId = (arguments["vulnerabilityId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "vulnerabilityId is required")
+
+            // Parse and validate reason
+            val reason = arguments["reason"] as? String
+                ?: return McpToolResult.error("VALIDATION_ERROR", "reason is required")
+
+            if (reason.length < 50) {
+                return McpToolResult.error("VALIDATION_ERROR", "Reason must be at least 50 characters")
+            }
+            if (reason.length > 2048) {
+                return McpToolResult.error("VALIDATION_ERROR", "Reason must not exceed 2048 characters")
+            }
+
+            // Parse and validate expirationDate
+            val expirationDateStr = arguments["expirationDate"] as? String
+                ?: return McpToolResult.error("VALIDATION_ERROR", "expirationDate is required")
+
+            val expirationDate = try {
+                LocalDateTime.parse(expirationDateStr)
+            } catch (e: DateTimeParseException) {
+                return McpToolResult.error("VALIDATION_ERROR", "Invalid date format. Use ISO-8601 (e.g., 2026-04-11T00:00:00)")
+            }
+
+            if (expirationDate.isBefore(LocalDateTime.now())) {
+                return McpToolResult.error("VALIDATION_ERROR", "Expiration date must be in the future")
+            }
+
+            // Parse scope with default
+            val scopeStr = arguments["scope"] as? String ?: "SINGLE_VULNERABILITY"
+            val scope = try {
+                ExceptionScope.valueOf(scopeStr)
+            } catch (e: IllegalArgumentException) {
+                return McpToolResult.error("VALIDATION_ERROR", "Invalid scope. Must be SINGLE_VULNERABILITY or CVE_PATTERN")
+            }
+
+            // Create DTO
+            val dto = CreateExceptionRequestDto(
+                vulnerabilityId = vulnerabilityId,
+                scope = scope,
+                reason = reason,
+                expirationDate = expirationDate
+            )
+
+            // Call service
+            val result = exceptionRequestService.createRequest(
+                dto = dto,
+                requesterUserId = context.delegatedUserId!!,
+                clientIp = null
+            )
+
+            // Determine message based on auto-approval
+            val message = if (result.autoApproved) {
+                "Exception request auto-approved (ADMIN/SECCHAMPION role)"
+            } else {
+                "Exception request created successfully. Status: PENDING"
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "request" to mapOf(
+                        "id" to result.id,
+                        "vulnerabilityId" to result.vulnerabilityId,
+                        "vulnerabilityCve" to result.vulnerabilityCve,
+                        "assetName" to result.assetName,
+                        "assetIp" to result.assetIp,
+                        "requestedByUsername" to result.requestedByUsername,
+                        "scope" to result.scope.name,
+                        "reason" to result.reason,
+                        "expirationDate" to result.expirationDate.toString(),
+                        "status" to result.status.name,
+                        "autoApproved" to result.autoApproved,
+                        "reviewedByUsername" to result.reviewedByUsername,
+                        "reviewDate" to result.reviewDate?.toString(),
+                        "createdAt" to result.createdAt.toString(),
+                        "updatedAt" to result.updatedAt.toString()
+                    ),
+                    "message" to message
+                )
+            )
+
+        } catch (e: IllegalArgumentException) {
+            // Handle specific validation errors from service
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error("NOT_FOUND", message)
+                message.contains("active exception request") -> McpToolResult.error("CONFLICT", message)
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to create exception request: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetAllVulnerabilitiesDetailTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetAllVulnerabilitiesDetailTool.kt
@@ -168,15 +168,6 @@ class GetAllVulnerabilitiesDetailTool(
                 }
             }
 
-            // Check total results limit
-            if (resultPage.totalSize > 100_000) {
-                return McpToolResult.error(
-                    "TOTAL_RESULTS_EXCEEDED",
-                    "Query would return more than 100,000 results. Please add more filters.",
-                    mapOf("totalResults" to resultPage.totalSize)
-                )
-            }
-
             // Map vulnerabilities to response format
             val vulnerabilities = filteredContent.map { vuln ->
                 mapOf(

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestsTool.kt
@@ -1,0 +1,125 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.ExceptionRequestStatus
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for getting the current user's own exception requests.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Any authenticated user can view their own requests
+ * - Only returns requests created by the delegated user
+ *
+ * Spec reference: spec.md FR-011 through FR-013
+ * User Story: US3 - View My Exception Requests (P2)
+ */
+@Singleton
+class GetMyExceptionRequestsTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "get_my_exception_requests"
+    override val description = "Get your own exception requests (requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "status" to mapOf(
+                "type" to "string",
+                "enum" to listOf("PENDING", "APPROVED", "REJECTED", "EXPIRED", "CANCELLED"),
+                "description" to "Filter by request status"
+            ),
+            "page" to mapOf(
+                "type" to "number",
+                "description" to "Page number (0-indexed, default: 0)"
+            ),
+            "size" to mapOf(
+                "type" to "number",
+                "description" to "Page size (default: 20, max: 100)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-011: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            // Parse parameters
+            val page = (arguments["page"] as? Number)?.toInt() ?: 0
+            val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+
+            // Parse optional status filter
+            val statusStr = arguments["status"] as? String
+            val status = statusStr?.let {
+                try {
+                    ExceptionRequestStatus.valueOf(it)
+                } catch (e: IllegalArgumentException) {
+                    return McpToolResult.error(
+                        "VALIDATION_ERROR",
+                        "Invalid status. Must be one of: PENDING, APPROVED, REJECTED, EXPIRED, CANCELLED"
+                    )
+                }
+            }
+
+            // Create pageable sorted by createdAt descending (newest first)
+            val pageable = Pageable.from(page, size, Sort.of(Sort.Order.desc("createdAt")))
+
+            // Call service - filtered by delegated user ID
+            val result = exceptionRequestService.getUserRequests(
+                userId = context.delegatedUserId!!,
+                status = status,
+                pageable = pageable
+            )
+
+            // Map results to response format
+            val requests = result.content.map { request ->
+                mapOf(
+                    "id" to request.id,
+                    "vulnerabilityId" to request.vulnerabilityId,
+                    "vulnerabilityCve" to request.vulnerabilityCve,
+                    "assetName" to request.assetName,
+                    "assetIp" to request.assetIp,
+                    "requestedByUsername" to request.requestedByUsername,
+                    "scope" to request.scope.name,
+                    "reason" to request.reason,
+                    "expirationDate" to request.expirationDate.toString(),
+                    "status" to request.status.name,
+                    "autoApproved" to request.autoApproved,
+                    "reviewedByUsername" to request.reviewedByUsername,
+                    "reviewDate" to request.reviewDate?.toString(),
+                    "reviewComment" to request.reviewComment,
+                    "createdAt" to request.createdAt.toString(),
+                    "updatedAt" to request.updatedAt.toString()
+                )
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "requests" to requests,
+                    "totalElements" to result.totalSize,
+                    "totalPages" to result.totalPages,
+                    "page" to page,
+                    "size" to size
+                )
+            )
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve exception requests: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt
@@ -1,0 +1,149 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.OutdatedAssetService
+import io.micronaut.data.model.Pageable
+import io.micronaut.security.authentication.Authentication
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for getting assets with overdue vulnerabilities.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN or VULN role required
+ * - ADMIN sees all overdue assets
+ * - VULN sees only assets from assigned workgroups
+ *
+ * Spec reference: spec.md FR-001 through FR-005
+ * User Story: US1 - View Overdue Assets (P1)
+ */
+@Singleton
+class GetOverdueAssetsTool(
+    @Inject private val outdatedAssetService: OutdatedAssetService
+) : McpTool {
+
+    override val name = "get_overdue_assets"
+    override val description = "Get assets with overdue vulnerabilities (ADMIN/VULN role required, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "page" to mapOf(
+                "type" to "number",
+                "description" to "Page number (0-indexed, default: 0)"
+            ),
+            "size" to mapOf(
+                "type" to "number",
+                "description" to "Page size (default: 20, max: 100)"
+            ),
+            "minSeverity" to mapOf(
+                "type" to "string",
+                "enum" to listOf("CRITICAL", "HIGH", "MEDIUM", "LOW"),
+                "description" to "Minimum severity filter"
+            ),
+            "searchTerm" to mapOf(
+                "type" to "string",
+                "description" to "Search by asset name (case-insensitive)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-002: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // FR-003: Require ADMIN or VULN role
+        val hasRole = context.isAdmin || context.delegatedUserRoles?.contains("VULN") == true
+        if (!hasRole) {
+            return McpToolResult.error(
+                "ROLE_REQUIRED",
+                "ADMIN or VULN role required to view overdue assets"
+            )
+        }
+
+        try {
+            // Parse parameters with defaults
+            val page = (arguments["page"] as? Number)?.toInt() ?: 0
+            val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+            val minSeverity = arguments["minSeverity"] as? String
+            val searchTerm = arguments["searchTerm"] as? String
+
+            // Create minimal Authentication adapter from McpExecutionContext
+            val authentication = createAuthenticationFromContext(context)
+
+            // Call service with access control
+            val pageable = Pageable.from(page, size)
+            val result = outdatedAssetService.getOutdatedAssets(
+                authentication = authentication,
+                searchTerm = searchTerm,
+                minSeverity = minSeverity,
+                pageable = pageable
+            )
+
+            // Map results to response format
+            val assets = result.content.map { asset ->
+                // Determine max severity based on counts
+                val maxSeverity = when {
+                    asset.criticalCount > 0 -> "CRITICAL"
+                    asset.highCount > 0 -> "HIGH"
+                    asset.mediumCount > 0 -> "MEDIUM"
+                    asset.lowCount > 0 -> "LOW"
+                    else -> "NONE"
+                }
+                mapOf(
+                    "id" to asset.id,
+                    "assetId" to asset.assetId,
+                    "name" to asset.assetName,
+                    "type" to asset.assetType,
+                    "totalVulnerabilities" to asset.totalOverdueCount,
+                    "criticalCount" to asset.criticalCount,
+                    "highCount" to asset.highCount,
+                    "mediumCount" to asset.mediumCount,
+                    "lowCount" to asset.lowCount,
+                    "oldestVulnDays" to asset.oldestVulnDays,
+                    "maxSeverity" to maxSeverity
+                )
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "assets" to assets,
+                    "totalElements" to result.totalSize,
+                    "totalPages" to result.totalPages,
+                    "page" to page,
+                    "size" to size
+                )
+            )
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve overdue assets: ${e.message}")
+        }
+    }
+
+    /**
+     * Create a minimal Authentication adapter from McpExecutionContext.
+     * This allows the OutdatedAssetService to apply its workgroup-based access control.
+     */
+    private fun createAuthenticationFromContext(context: McpExecutionContext): Authentication {
+        return object : Authentication {
+            override fun getName(): String = context.delegatedUserEmail ?: "mcp-user"
+
+            override fun getRoles(): Collection<String> = context.delegatedUserRoles ?: emptySet()
+
+            override fun getAttributes(): Map<String, Any> = mapOf(
+                "userId" to (context.delegatedUserId ?: 0L),
+                "workgroupIds" to (context.accessibleWorkgroupIds?.toList() ?: emptyList<Long>())
+            )
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetPendingExceptionRequestsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetPendingExceptionRequestsTool.kt
@@ -1,0 +1,112 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for getting all pending exception requests awaiting approval.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN or SECCHAMPION role required
+ * - Returns all pending requests system-wide
+ *
+ * Spec reference: spec.md FR-014 through FR-016
+ * User Story: US4 - View Pending Requests (P2)
+ */
+@Singleton
+class GetPendingExceptionRequestsTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "get_pending_exception_requests"
+    override val description = "Get all pending exception requests awaiting approval (ADMIN/SECCHAMPION role required, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "page" to mapOf(
+                "type" to "number",
+                "description" to "Page number (0-indexed, default: 0)"
+            ),
+            "size" to mapOf(
+                "type" to "number",
+                "description" to "Page size (default: 20, max: 100)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // FR-014: Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // FR-015: Require ADMIN or SECCHAMPION role
+        val hasApprovalRole = context.isAdmin || context.delegatedUserRoles?.contains("SECCHAMPION") == true
+        if (!hasApprovalRole) {
+            return McpToolResult.error(
+                "APPROVAL_ROLE_REQUIRED",
+                "ADMIN or SECCHAMPION role required to view pending requests"
+            )
+        }
+
+        try {
+            // Parse parameters
+            val page = (arguments["page"] as? Number)?.toInt() ?: 0
+            val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+
+            // Create pageable sorted by createdAt ascending (oldest first - FIFO)
+            val pageable = Pageable.from(page, size, Sort.of(Sort.Order.asc("createdAt")))
+
+            // Call service
+            val result = exceptionRequestService.getPendingRequests(pageable)
+
+            // Get pending count for badge display
+            val pendingCount = exceptionRequestService.getPendingCount()
+
+            // Map results to response format
+            val requests = result.content.map { request ->
+                mapOf(
+                    "id" to request.id,
+                    "vulnerabilityId" to request.vulnerabilityId,
+                    "vulnerabilityCve" to request.vulnerabilityCve,
+                    "assetName" to request.assetName,
+                    "assetIp" to request.assetIp,
+                    "requestedByUsername" to request.requestedByUsername,
+                    "scope" to request.scope.name,
+                    "reason" to request.reason,
+                    "expirationDate" to request.expirationDate.toString(),
+                    "status" to request.status.name,
+                    "autoApproved" to request.autoApproved,
+                    "createdAt" to request.createdAt.toString(),
+                    "updatedAt" to request.updatedAt.toString()
+                )
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "requests" to requests,
+                    "totalElements" to result.totalSize,
+                    "totalPages" to result.totalPages,
+                    "page" to page,
+                    "size" to size,
+                    "pendingCount" to pendingCount
+                )
+            )
+
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve pending requests: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetVulnerabilitiesTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetVulnerabilitiesTool.kt
@@ -174,15 +174,6 @@ class GetVulnerabilitiesTool(
                 }
             }
 
-            // Check total results limit
-            if (resultPage.totalSize > 50000) {
-                return McpToolResult.error(
-                    "TOTAL_RESULTS_EXCEEDED",
-                    "Query would return more than 50,000 results. Please add more filters.",
-                    mapOf("totalResults" to resultPage.totalSize)
-                )
-            }
-
             // Map vulnerabilities to response format
             val vulnerabilities = resultPage.content.map { vuln ->
                 mapOf(

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/RejectExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/RejectExceptionRequestTool.kt
@@ -1,0 +1,139 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.ReviewExceptionRequestDto
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.exception.ConcurrentApprovalException
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for rejecting pending exception requests.
+ * Feature: 062-mcp-vuln-exceptions
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN or SECCHAMPION role required
+ * - Rejection comment is REQUIRED (minimum 10 characters)
+ * - Uses optimistic locking for concurrent review handling
+ *
+ * Spec reference: spec.md FR-018, FR-019, FR-020
+ * User Story: US6 - Reject Exception Request (P2)
+ */
+@Singleton
+class RejectExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "reject_exception_request"
+    override val description = "Reject a pending exception request (ADMIN/SECCHAMPION role required, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("requestId", "comment"),
+        "properties" to mapOf(
+            "requestId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the exception request to reject"
+            ),
+            "comment" to mapOf(
+                "type" to "string",
+                "description" to "Required rejection reason (10-1024 characters)",
+                "minLength" to 10,
+                "maxLength" to 1024
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN or SECCHAMPION role
+        val hasApprovalRole = context.isAdmin || context.delegatedUserRoles?.contains("SECCHAMPION") == true
+        if (!hasApprovalRole) {
+            return McpToolResult.error(
+                "APPROVAL_ROLE_REQUIRED",
+                "ADMIN or SECCHAMPION role required to reject requests"
+            )
+        }
+
+        try {
+            // Parse requestId
+            val requestId = (arguments["requestId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "requestId is required")
+
+            // Parse and validate comment (REQUIRED for rejection)
+            val comment = arguments["comment"] as? String
+            if (comment.isNullOrBlank()) {
+                return McpToolResult.error("VALIDATION_ERROR", "Rejection comment is required")
+            }
+            if (comment.length < 10) {
+                return McpToolResult.error("VALIDATION_ERROR", "Rejection comment must be at least 10 characters")
+            }
+            if (comment.length > 1024) {
+                return McpToolResult.error("VALIDATION_ERROR", "Rejection comment must not exceed 1024 characters")
+            }
+
+            // Create review DTO
+            val reviewDto = ReviewExceptionRequestDto(reviewComment = comment)
+
+            // Call service
+            val result = exceptionRequestService.rejectRequest(
+                requestId = requestId,
+                reviewerUserId = context.delegatedUserId!!,
+                reviewDto = reviewDto,
+                clientIp = null
+            )
+
+            return McpToolResult.success(
+                mapOf(
+                    "request" to mapOf(
+                        "id" to result.id,
+                        "vulnerabilityId" to result.vulnerabilityId,
+                        "vulnerabilityCve" to result.vulnerabilityCve,
+                        "assetName" to result.assetName,
+                        "assetIp" to result.assetIp,
+                        "requestedByUsername" to result.requestedByUsername,
+                        "scope" to result.scope.name,
+                        "reason" to result.reason,
+                        "expirationDate" to result.expirationDate.toString(),
+                        "status" to result.status.name,
+                        "autoApproved" to result.autoApproved,
+                        "reviewedByUsername" to result.reviewedByUsername,
+                        "reviewDate" to result.reviewDate?.toString(),
+                        "reviewComment" to result.reviewComment,
+                        "createdAt" to result.createdAt.toString(),
+                        "updatedAt" to result.updatedAt.toString()
+                    ),
+                    "message" to "Exception request rejected"
+                )
+            )
+
+        } catch (e: ConcurrentApprovalException) {
+            // Concurrent modification handling
+            return McpToolResult.error(
+                "CONCURRENT_MODIFICATION",
+                "Request was already reviewed by ${e.reviewedBy} at ${e.reviewedAt}"
+            )
+        } catch (e: IllegalArgumentException) {
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error("NOT_FOUND", message)
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: IllegalStateException) {
+            // Invalid state transition
+            return McpToolResult.error("INVALID_STATE", e.message ?: "Invalid state transition")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to reject request: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
Implements 7 new MCP tools for overdue asset querying and vulnerability exception handling: get_overdue_assets, create_exception_request, get_my_exception_requests, get_pending_exception_requests, approve_exception_request, reject_exception_request, and cancel_exception_request. Updates documentation, specification, and project configuration for Kotlin 2.3.0 / Java 25. No schema changes; all tools wrap existing service layer functionality with proper access control and response DTOs.