### PR TITLE
Add requirement ID.Revision versioning feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing `user_mapping` table) (064-mcp-cli-user-mapping)
 - Kotlin 2.3.0 / Java 21 + Micronaut 4.10, PicoCLI 4.7.5, AWS SDK for Java v2 (S3) (065-s3-user-mapping-import)
 - MariaDB 11.4 (existing user_mapping table), local temp files for S3 downloads (065-s3-user-mapping-import)
+- Kotlin 2.3.0 / Java 25 + Micronaut 4.10, Hibernate JPA, Apache POI 5.3 (Excel/Word exports) (066-requirement-versioning)
+- MariaDB 11.4 (existing `requirement`, `requirement_snapshot`, `releases` tables) (066-requirement-versioning)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/specs/066-requirement-versioning/checklists/requirements.md
+++ b/specs/066-requirement-versioning/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Requirement ID.Revision Versioning
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Key assumption documented: Existing `versionNumber` field will be repurposed as revision number
+- Migration strategy for existing requirements is defined (assign IDs based on database ID order)

--- a/specs/066-requirement-versioning/contracts/api-changes.yaml
+++ b/specs/066-requirement-versioning/contracts/api-changes.yaml
@@ -1,0 +1,342 @@
+# OpenAPI 3.0 - API Changes for Requirement ID.Revision Versioning
+# Feature: 066-requirement-versioning
+# This documents the DELTA (changes) to existing API, not full spec
+
+openapi: 3.0.3
+info:
+  title: Secman API - Requirement Versioning Changes
+  version: 1.1.0
+  description: |
+    API changes for requirement ID.Revision versioning feature.
+    All changes are backward compatible - new fields added to existing responses.
+
+paths:
+  /api/requirements:
+    get:
+      summary: List requirements (MODIFIED)
+      description: |
+        **Changes**: Response now includes `internalId`, `revision`, and `idRevision` fields.
+      responses:
+        '200':
+          description: List of requirements
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RequirementResponse'
+
+    post:
+      summary: Create requirement (MODIFIED)
+      description: |
+        **Changes**:
+        - System automatically assigns `internalId` on creation
+        - Initial `revision` is 1
+        - Response includes new versioning fields
+      responses:
+        '200':
+          description: Created requirement with assigned ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequirementResponse'
+
+  /api/requirements/{id}:
+    get:
+      summary: Get requirement by ID (UNCHANGED)
+      description: Response includes new versioning fields
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Requirement details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequirementResponse'
+
+    put:
+      summary: Update requirement (MODIFIED)
+      description: |
+        **Changes**:
+        - Content changes increment `revision`
+        - Relationship-only changes do NOT increment revision
+        - `internalId` remains unchanged
+      responses:
+        '200':
+          description: Updated requirement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequirementResponse'
+
+  /api/requirements/export/xlsx:
+    get:
+      summary: Export to Excel (MODIFIED)
+      description: |
+        **Changes**: First column is now "ID.Revision" with values like "REQ-001.3"
+      parameters:
+        - name: releaseId
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+          description: Export from release snapshot (uses frozen ID.Revision)
+      responses:
+        '200':
+          description: Excel file download
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+
+  /api/requirements/export/docx:
+    get:
+      summary: Export to Word (MODIFIED)
+      description: |
+        **Changes**: Requirement headers now show ID.Revision prefix
+        Example: "REQ-001.3: The system shall..."
+      parameters:
+        - name: releaseId
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+          description: Export from release snapshot (uses frozen ID.Revision)
+      responses:
+        '200':
+          description: Word file download
+          content:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+
+  /api/releases/compare:
+    get:
+      summary: Compare releases (MODIFIED)
+      description: |
+        **Changes**:
+        - Modified requirements now show old and new revision numbers
+        - Added/deleted requirements show their ID.Revision
+      parameters:
+        - name: fromReleaseId
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: toReleaseId
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Comparison result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComparisonResult'
+
+components:
+  schemas:
+    RequirementResponse:
+      type: object
+      description: Requirement with versioning information
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Database ID (unchanged)
+        internalId:
+          type: string
+          description: Human-readable ID (NEW)
+          example: "REQ-001"
+        revision:
+          type: integer
+          description: Revision number (NEW)
+          example: 3
+        idRevision:
+          type: string
+          description: Combined ID.Revision (NEW)
+          example: "REQ-001.3"
+        shortreq:
+          type: string
+          description: Short requirement text
+        details:
+          type: string
+          nullable: true
+          description: Detailed description
+        language:
+          type: string
+          nullable: true
+        example:
+          type: string
+          nullable: true
+        motivation:
+          type: string
+          nullable: true
+        usecase:
+          type: string
+          nullable: true
+        norm:
+          type: string
+          nullable: true
+        chapter:
+          type: string
+          nullable: true
+        usecases:
+          type: array
+          items:
+            $ref: '#/components/schemas/UseCaseResponse'
+        norms:
+          type: array
+          items:
+            $ref: '#/components/schemas/NormResponse'
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - id
+        - internalId
+        - revision
+        - idRevision
+        - shortreq
+
+    UseCaseResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+
+    NormResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        version:
+          type: string
+
+    ComparisonResult:
+      type: object
+      description: Release comparison result (MODIFIED)
+      properties:
+        fromRelease:
+          $ref: '#/components/schemas/ReleaseInfo'
+        toRelease:
+          $ref: '#/components/schemas/ReleaseInfo'
+        added:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequirementSnapshotSummary'
+        deleted:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequirementSnapshotSummary'
+        modified:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequirementDiff'
+        unchanged:
+          type: integer
+
+    ReleaseInfo:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        version:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    RequirementSnapshotSummary:
+      type: object
+      description: Snapshot summary (MODIFIED - now includes ID.Revision)
+      properties:
+        id:
+          type: integer
+          format: int64
+        originalRequirementId:
+          type: integer
+          format: int64
+        internalId:
+          type: string
+          description: Internal ID from snapshot (NEW)
+          example: "REQ-001"
+        revision:
+          type: integer
+          description: Revision from snapshot (NEW)
+          example: 3
+        idRevision:
+          type: string
+          description: Combined ID.Revision (NEW)
+          example: "REQ-001.3"
+        shortreq:
+          type: string
+        details:
+          type: string
+          nullable: true
+
+    RequirementDiff:
+      type: object
+      description: Modified requirement diff (MODIFIED - shows revision change)
+      properties:
+        id:
+          type: integer
+          format: int64
+        internalId:
+          type: string
+          description: Internal requirement ID (NEW)
+          example: "REQ-001"
+        oldRevision:
+          type: integer
+          description: Revision in "from" release (NEW)
+          example: 2
+        newRevision:
+          type: integer
+          description: Revision in "to" release (NEW)
+          example: 5
+        shortreq:
+          type: string
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldChange'
+
+    FieldChange:
+      type: object
+      properties:
+        fieldName:
+          type: string
+        oldValue:
+          type: string
+          nullable: true
+        newValue:
+          type: string
+          nullable: true

--- a/specs/066-requirement-versioning/data-model.md
+++ b/specs/066-requirement-versioning/data-model.md
@@ -1,0 +1,295 @@
+# Data Model: Requirement ID.Revision Versioning
+
+**Feature**: 066-requirement-versioning
+**Date**: 2026-01-23
+
+## Entity Changes
+
+### 1. Requirement (Modified)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/domain/Requirement.kt`
+
+**Current State**: Extends `VersionedEntity`, has `id`, `shortreq`, `details`, etc.
+
+**Changes**:
+
+| Field | Type | Constraint | Description |
+|-------|------|------------|-------------|
+| `internalId` | VARCHAR(20) | UNIQUE, NOT NULL | Human-readable ID (e.g., "REQ-001") |
+
+**Notes**:
+- `versionNumber` from `VersionedEntity` serves as revision (already exists)
+- `internalId` assigned on creation, never changes
+- Computed property `idRevision` returns `"$internalId.$versionNumber"`
+
+**Entity Definition (additions)**:
+```kotlin
+@Column(name = "internal_id", unique = true, nullable = false, length = 20)
+var internalId: String = ""
+
+// Computed property (not persisted)
+val idRevision: String
+    get() = "$internalId.$versionNumber"
+```
+
+**Validation Rules**:
+- `internalId` must match pattern `REQ-\d{3,}` (e.g., REQ-001, REQ-1234)
+- `internalId` is immutable after first save
+- `versionNumber` increments on content field changes only
+
+---
+
+### 2. RequirementSnapshot (Modified)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt`
+
+**Current State**: Stores requirement data at release time via `originalRequirementId`
+
+**Changes**:
+
+| Field | Type | Constraint | Description |
+|-------|------|------------|-------------|
+| `internalId` | VARCHAR(20) | NOT NULL | Captured from requirement at snapshot time |
+| `revision` | INT | NOT NULL, DEFAULT 1 | Captured revision number |
+
+**Notes**:
+- These fields capture the ID.Revision at the moment of release creation
+- `originalRequirementId` remains for database-level linking
+- Enables accurate diff comparisons showing revision changes
+
+**Entity Definition (additions)**:
+```kotlin
+@Column(name = "internal_id", nullable = false, length = 20)
+var internalId: String = ""
+
+@Column(name = "revision", nullable = false)
+var revision: Int = 1
+
+// Computed property
+val idRevision: String
+    get() = "$internalId.$revision"
+```
+
+**Update `fromRequirement()` companion method**:
+```kotlin
+fun fromRequirement(requirement: Requirement, release: Release): RequirementSnapshot {
+    return RequirementSnapshot(
+        // ... existing fields ...
+        internalId = requirement.internalId,
+        revision = requirement.versionNumber,
+        // ... rest unchanged ...
+    )
+}
+```
+
+---
+
+### 3. RequirementIdSequence (New)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/domain/RequirementIdSequence.kt`
+
+**Purpose**: Track next available internal ID number for atomic generation
+
+| Field | Type | Constraint | Description |
+|-------|------|------------|-------------|
+| `id` | BIGINT | PRIMARY KEY | Always 1 (single-row table) |
+| `nextValue` | INT | NOT NULL | Next ID number to assign |
+| `updatedAt` | TIMESTAMP | NOT NULL | Last modification timestamp |
+
+**Entity Definition**:
+```kotlin
+@Entity
+@Table(name = "requirement_id_sequence")
+@Serdeable
+data class RequirementIdSequence(
+    @Id
+    var id: Long = 1L,
+
+    @Column(name = "next_value", nullable = false)
+    var nextValue: Int = 1,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+) {
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+}
+```
+
+**Access Pattern**:
+- Single row with `id = 1`
+- Use `SELECT ... FOR UPDATE` for atomic increment
+- Initialize to `max(existing_requirement_count) + 1` during migration
+
+---
+
+## Relationships
+
+```
+┌─────────────────────┐
+│    Requirement      │
+├─────────────────────┤
+│ id (PK)             │
+│ internalId (UNIQUE) │◄──────┐
+│ versionNumber       │       │ captured as
+│ shortreq            │       │ internalId + revision
+│ ...                 │       │
+└─────────────────────┘       │
+         │                    │
+         │ snapshots          │
+         ▼                    │
+┌─────────────────────┐       │
+│ RequirementSnapshot │       │
+├─────────────────────┤       │
+│ id (PK)             │       │
+│ originalReqId (FK)  │───────┘
+│ internalId          │
+│ revision            │
+│ release_id (FK)     │
+│ ...                 │
+└─────────────────────┘
+         │
+         │ belongs to
+         ▼
+┌─────────────────────┐
+│      Release        │
+├─────────────────────┤
+│ id (PK)             │
+│ version             │
+│ name                │
+│ status              │
+└─────────────────────┘
+
+┌─────────────────────┐
+│RequirementIdSequence│
+├─────────────────────┤
+│ id = 1 (singleton)  │
+│ nextValue           │
+│ updatedAt           │
+└─────────────────────┘
+```
+
+---
+
+## State Transitions
+
+### Requirement Lifecycle
+
+```
+                    ┌──────────────────┐
+                    │    CREATED       │
+                    │ (internalId set) │
+                    │ (revision = 1)   │
+                    └────────┬─────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              │                             │
+              ▼                             ▼
+    ┌─────────────────┐          ┌─────────────────┐
+    │  CONTENT EDIT   │          │ RELATIONSHIP    │
+    │ (revision++)    │          │ EDIT ONLY       │
+    │                 │          │ (revision same) │
+    └────────┬────────┘          └────────┬────────┘
+              │                             │
+              └──────────────┬──────────────┘
+                             │
+                             ▼
+                    ┌─────────────────┐
+                    │    DELETED      │
+                    │ (ID never reused│
+                    └─────────────────┘
+```
+
+### Content Fields (trigger revision increment)
+- `shortreq`
+- `details`
+- `example`
+- `motivation`
+- `usecase`
+- `norm`
+- `chapter`
+
+### Metadata Fields (do NOT trigger revision increment)
+- `usecases` (ManyToMany relationship)
+- `norms` (ManyToMany relationship)
+- `language`
+
+---
+
+## Database Schema (Flyway Migration)
+
+**File**: `src/backendng/src/main/resources/db/migration/V066__add_requirement_internal_id.sql`
+
+```sql
+-- 1. Create sequence table
+CREATE TABLE requirement_id_sequence (
+    id BIGINT PRIMARY KEY DEFAULT 1,
+    next_value INT NOT NULL DEFAULT 1,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 2. Add internal_id column to requirement (nullable initially for migration)
+ALTER TABLE requirement
+ADD COLUMN internal_id VARCHAR(20) NULL;
+
+-- 3. Migrate existing requirements: assign IDs by database ID order
+SET @rank := 0;
+UPDATE requirement r
+JOIN (
+    SELECT id, @rank := @rank + 1 AS rn
+    FROM requirement
+    ORDER BY id ASC
+) ranked ON r.id = ranked.id
+SET r.internal_id = CONCAT('REQ-', LPAD(ranked.rn, 3, '0'));
+
+-- 4. Initialize sequence to next available value
+INSERT INTO requirement_id_sequence (id, next_value, updated_at)
+SELECT 1, COALESCE(MAX(CAST(SUBSTRING(internal_id, 5) AS UNSIGNED)), 0) + 1, NOW()
+FROM requirement;
+
+-- 5. Make internal_id NOT NULL and add unique constraint
+ALTER TABLE requirement
+MODIFY COLUMN internal_id VARCHAR(20) NOT NULL,
+ADD CONSTRAINT uk_requirement_internal_id UNIQUE (internal_id);
+
+-- 6. Add columns to requirement_snapshot
+ALTER TABLE requirement_snapshot
+ADD COLUMN internal_id VARCHAR(20) NULL,
+ADD COLUMN revision INT NOT NULL DEFAULT 1;
+
+-- 7. Backfill snapshot data from original requirements
+UPDATE requirement_snapshot rs
+JOIN requirement r ON rs.original_requirement_id = r.id
+SET rs.internal_id = r.internal_id,
+    rs.revision = r.version_number;
+
+-- 8. Make snapshot internal_id NOT NULL
+ALTER TABLE requirement_snapshot
+MODIFY COLUMN internal_id VARCHAR(20) NOT NULL;
+
+-- 9. Add index for snapshot lookups by internal_id
+CREATE INDEX idx_snapshot_internal_id ON requirement_snapshot(internal_id);
+```
+
+---
+
+## Indexes
+
+| Table | Index Name | Columns | Purpose |
+|-------|------------|---------|---------|
+| requirement | uk_requirement_internal_id | internal_id | Uniqueness enforcement, lookup by ID |
+| requirement_snapshot | idx_snapshot_internal_id | internal_id | Fast lookup during release comparison |
+
+---
+
+## Validation Rules Summary
+
+| Entity | Field | Rule |
+|--------|-------|------|
+| Requirement | internalId | Format: `REQ-\d{3,}`, unique, immutable after creation |
+| Requirement | versionNumber | >= 1, increments only on content changes |
+| RequirementSnapshot | internalId | Must match source requirement's internalId at snapshot time |
+| RequirementSnapshot | revision | Must match source requirement's versionNumber at snapshot time |
+| RequirementIdSequence | nextValue | >= 1, monotonically increasing |

--- a/specs/066-requirement-versioning/plan.md
+++ b/specs/066-requirement-versioning/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Requirement ID.Revision Versioning
+
+**Branch**: `066-requirement-versioning` | **Date**: 2026-01-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/066-requirement-versioning/spec.md`
+
+## Summary
+
+Extend the existing requirements management system to add explicit versioning with a user-facing "ID.Revision" format. This involves:
+1. Adding `internalId` field (e.g., "REQ-001") to Requirement entity - unique, never changes, never reused
+2. Using existing `versionNumber` from VersionedEntity as the revision counter
+3. Adding ID.Revision to Excel/Word exports and release snapshots
+4. Enhancing diff export to show revision changes between releases
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA, Apache POI 5.3 (Excel/Word exports)
+**Storage**: MariaDB 11.4 (existing `requirement`, `requirement_snapshot`, `releases` tables)
+**Testing**: JUnit 5 with Mockk (user-requested only per constitution)
+**Target Platform**: Linux server (web application)
+**Project Type**: Web application (backend + frontend)
+**Performance Goals**: Standard CRUD operations, no high-throughput requirements
+**Constraints**: Maintain backward compatibility with existing API responses
+**Scale/Scope**: Existing system scale (~100s of requirements, ~10s of releases)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | No new user input vectors; existing RBAC applies (ADMIN, REQ, SECCHAMPION for requirements) |
+| III. API-First | PASS | Extends existing REST endpoints; backward compatible (adds fields, doesn't remove) |
+| IV. User-Requested Testing | PASS | No test planning in this plan per constitution; tests only when requested |
+| V. RBAC | PASS | Uses existing @Secured annotations; no new access patterns |
+| VI. Schema Evolution | PASS | Adds columns via Hibernate auto-migration; Flyway script required for `internalId` and `requirement_id_sequence` table |
+
+**Gate Result**: PASS - All principles satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/066-requirement-versioning/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api-changes.yaml # OpenAPI delta
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/
+├── src/main/kotlin/com/secman/
+│   ├── domain/
+│   │   ├── Requirement.kt           # Add internalId field
+│   │   ├── RequirementSnapshot.kt   # Add internalId, revision fields
+│   │   └── RequirementIdSequence.kt # New entity for ID generation
+│   ├── repository/
+│   │   ├── RequirementRepository.kt
+│   │   └── RequirementIdSequenceRepository.kt # New repository
+│   ├── service/
+│   │   ├── RequirementService.kt    # ID assignment logic
+│   │   └── RequirementIdService.kt  # New service for ID generation
+│   └── controller/
+│       └── RequirementController.kt # Update responses, export methods
+└── src/main/resources/
+    └── db/migration/
+        └── V066__add_requirement_internal_id.sql # Flyway migration
+
+src/frontend/
+├── src/components/
+│   ├── RequirementManagement.tsx    # Display ID.Revision
+│   ├── ReleaseComparison.tsx        # Show revision changes in diff
+│   └── ReleaseManagement.tsx        # Display ID.Revision in snapshots
+└── src/utils/
+    └── comparisonExport.ts          # Update diff export columns
+```
+
+**Structure Decision**: Web application structure following existing patterns. Backend changes focus on domain entities, service layer for ID generation, and controller updates for exports.
+
+## Complexity Tracking
+
+> No constitutional violations requiring justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/066-requirement-versioning/quickstart.md
+++ b/specs/066-requirement-versioning/quickstart.md
@@ -1,0 +1,163 @@
+# Quickstart: Requirement ID.Revision Versioning
+
+**Feature**: 066-requirement-versioning
+**Date**: 2026-01-23
+
+## Overview
+
+This guide provides a quick reference for implementing the requirement ID.Revision versioning feature.
+
+## Prerequisites
+
+- Existing secman development environment
+- MariaDB 11.4+ running
+- Backend and frontend projects building successfully
+
+## Implementation Order
+
+### Phase 1: Database Migration
+1. Create Flyway migration `V066__add_requirement_internal_id.sql`
+2. Run migration to add `internal_id` column and sequence table
+3. Verify existing requirements have IDs assigned
+
+### Phase 2: Backend Entity Changes
+1. Add `internalId` field to `Requirement.kt`
+2. Add `internalId`, `revision` fields to `RequirementSnapshot.kt`
+3. Create `RequirementIdSequence.kt` entity
+4. Create `RequirementIdSequenceRepository.kt`
+
+### Phase 3: Service Layer
+1. Create `RequirementIdService.kt` for atomic ID generation
+2. Update `RequirementService.kt` to assign IDs on creation
+3. Add revision increment logic to update method
+
+### Phase 4: API Updates
+1. Update `RequirementResponse` DTO with new fields
+2. Update export methods (Excel, Word) to include ID.Revision
+3. Update comparison DTOs with revision info
+
+### Phase 5: Frontend Updates
+1. Display ID.Revision in requirement list/detail views
+2. Update diff view to show revision changes
+3. Add tooltip showing last modified date
+
+## Key Code Snippets
+
+### ID Generation Service
+```kotlin
+@Singleton
+open class RequirementIdService(
+    private val sequenceRepository: RequirementIdSequenceRepository
+) {
+    @Transactional
+    open fun getNextId(): String {
+        val sequence = sequenceRepository.findByIdForUpdate(1L)
+            ?: throw IllegalStateException("ID sequence not initialized")
+        val nextVal = sequence.nextValue
+        sequence.nextValue = nextVal + 1
+        sequenceRepository.update(sequence)
+        return formatId(nextVal)
+    }
+
+    private fun formatId(num: Int): String =
+        if (num < 1000) "REQ-${num.toString().padStart(3, '0')}"
+        else "REQ-$num"
+}
+```
+
+### Revision Increment Logic
+```kotlin
+// In RequirementService.updateRequirement()
+private fun shouldIncrementRevision(existing: Requirement, update: RequirementUpdateRequest): Boolean {
+    return update.shortreq != existing.shortreq ||
+           update.details != existing.details ||
+           update.example != existing.example ||
+           update.motivation != existing.motivation ||
+           update.usecase != existing.usecase ||
+           update.norm != existing.norm ||
+           update.chapter != existing.chapter
+}
+
+// Apply before save:
+if (shouldIncrementRevision(existing, request)) {
+    existing.incrementVersion() // Uses VersionedEntity method
+}
+```
+
+### Excel Export Column Addition
+```kotlin
+// In createExcelWorkbook()
+val headers = arrayOf(
+    "ID.Revision",  // NEW - first column
+    "Chapter", "Norm", "Short req", "DetailsEN", "MotivationEN", "ExampleEN", "UseCase"
+)
+
+// Data row:
+row.createCell(0).setCellValue(requirement.idRevision)  // e.g., "REQ-001.3"
+```
+
+### Word Export Header Change
+```kotlin
+// In createWordDocument()
+// OLD: reqHeaderRun.setText("Req $requirementNumber: ${requirement.shortreq}")
+// NEW:
+reqHeaderRun.setText("${requirement.idRevision}: ${requirement.shortreq}")
+```
+
+### Frontend Display
+```tsx
+// In RequirementManagement.tsx
+<td>
+  <span
+    className="badge bg-secondary"
+    title={`Last modified: ${requirement.updatedAt}`}
+  >
+    {requirement.idRevision}
+  </span>
+</td>
+```
+
+## Testing Checklist
+
+- [ ] New requirement gets ID (REQ-001, REQ-002, etc.)
+- [ ] Editing content increments revision (REQ-001.1 → REQ-001.2)
+- [ ] Editing relationships does NOT increment revision
+- [ ] ID never changes after creation
+- [ ] Deleted ID is not reused
+- [ ] Excel export shows ID.Revision as first column
+- [ ] Word export shows ID.Revision in headers
+- [ ] Release snapshot captures ID.Revision correctly
+- [ ] Release comparison shows revision changes
+
+## Common Issues
+
+### ID Sequence Not Found
+Ensure Flyway migration ran and inserted initial row:
+```sql
+SELECT * FROM requirement_id_sequence;
+-- Should show: id=1, next_value=N (where N = existing req count + 1)
+```
+
+### Revision Not Incrementing
+Check that content fields are actually changing, not just relationships:
+- Content fields: shortreq, details, example, motivation, usecase, norm, chapter
+- Relationship fields (no increment): usecases, norms ManyToMany
+
+### Export Shows Wrong ID.Revision
+For release exports, ensure you're using snapshot's `internalId` and `revision`, not current requirement values.
+
+## Files Changed Summary
+
+| File | Change Type |
+|------|-------------|
+| `Requirement.kt` | Modified (add internalId) |
+| `RequirementSnapshot.kt` | Modified (add internalId, revision) |
+| `RequirementIdSequence.kt` | New entity |
+| `RequirementIdSequenceRepository.kt` | New repository |
+| `RequirementIdService.kt` | New service |
+| `RequirementService.kt` | Modified (ID assignment, revision logic) |
+| `RequirementController.kt` | Modified (response DTOs, exports) |
+| `RequirementManagement.tsx` | Modified (display ID.Revision) |
+| `ReleaseComparison.tsx` | Modified (show revisions in diff) |
+| `comparisonExport.ts` | Modified (export columns) |
+| `V066__add_requirement_internal_id.sql` | New migration |

--- a/specs/066-requirement-versioning/research.md
+++ b/specs/066-requirement-versioning/research.md
@@ -1,0 +1,161 @@
+# Research: Requirement ID.Revision Versioning
+
+**Feature**: 066-requirement-versioning
+**Date**: 2026-01-23
+
+## Research Topics
+
+### 1. ID Generation Strategy
+
+**Decision**: Database sequence table with atomic increment
+
+**Rationale**:
+- Single-row `requirement_id_sequence` table ensures atomicity across restarts
+- `SELECT FOR UPDATE` + increment provides concurrency safety
+- Simpler than database sequences (portable across MySQL/MariaDB versions)
+- Matches existing patterns in codebase (no database-specific features)
+
+**Alternatives Considered**:
+- **Auto-increment column**: Rejected - IDs would be recycled if requirement deleted and re-created
+- **UUID**: Rejected - User explicitly requested "REQ-NNN" format for human readability
+- **Database sequence (MariaDB SEQUENCE)**: Rejected - Requires MariaDB 10.3+ specific syntax; table approach is portable
+
+**Implementation Pattern**:
+```kotlin
+@Transactional
+fun getNextId(): String {
+    val sequence = repository.findForUpdate() // SELECT ... FOR UPDATE
+    val nextVal = sequence.nextValue
+    sequence.nextValue = nextVal + 1
+    repository.update(sequence)
+    return formatId(nextVal) // "REQ-001", "REQ-1000", etc.
+}
+```
+
+### 2. Revision Tracking Approach
+
+**Decision**: Repurpose existing `versionNumber` field from `VersionedEntity`
+
+**Rationale**:
+- Field already exists in database schema (no migration needed for column)
+- Already has `incrementVersion()` method
+- Reduces schema changes and migration complexity
+- Existing `isCurrent` field can track if requirement is "active" version
+
+**Alternatives Considered**:
+- **New `revision` column**: Rejected - Redundant with existing infrastructure
+- **Audit table with history**: Rejected - Over-engineering; spec only requires revision number, not full change history
+
+**Content Change Detection**:
+- Compare field values before update
+- Increment only if: shortreq, details, example, motivation, usecase, norm, or chapter changed
+- Do NOT increment for: usecases relationship, norms relationship changes (per FR-005)
+
+### 3. ID Format and Zero-Padding
+
+**Decision**: "REQ-NNN" with minimum 3 digits, auto-extend to 4+ when needed
+
+**Rationale**:
+- 3 digits covers 999 requirements (typical use case)
+- Auto-extend (REQ-1000, REQ-10000) handles growth without format change
+- "REQ-" prefix distinguishes from database IDs in exports and UI
+
+**Implementation**:
+```kotlin
+fun formatId(num: Int): String {
+    return if (num < 1000) {
+        "REQ-${num.toString().padStart(3, '0')}"
+    } else {
+        "REQ-$num"
+    }
+}
+```
+
+### 4. Migration Strategy for Existing Requirements
+
+**Decision**: Assign IDs by database ID order during Flyway migration
+
+**Rationale**:
+- Clarification confirmed: database ID order (lowest → REQ-001)
+- Single migration script handles both schema and data
+- Deterministic and reproducible
+
+**Migration Steps**:
+1. Create `requirement_id_sequence` table
+2. Add `internal_id` column to `requirement` table (nullable initially)
+3. UPDATE requirements SET internal_id = CONCAT('REQ-', LPAD(rank, 3, '0')) ordered by id
+4. Set `requirement_id_sequence.next_value` to max(rank) + 1
+5. ALTER `internal_id` to NOT NULL with UNIQUE constraint
+6. Add `internal_id` and `revision` columns to `requirement_snapshot`
+
+### 5. Snapshot Storage
+
+**Decision**: Store both `internalId` and `revision` in RequirementSnapshot
+
+**Rationale**:
+- Snapshots must preserve ID.Revision at release time
+- Current `originalRequirementId` is database ID, not internal ID
+- Adding fields enables accurate historical diff comparison
+
+**Schema Change**:
+```sql
+ALTER TABLE requirement_snapshot
+  ADD COLUMN internal_id VARCHAR(20),
+  ADD COLUMN revision INT DEFAULT 1;
+```
+
+### 6. Export Format Changes
+
+**Decision**: ID.Revision as first column in Excel, prefix in Word headers
+
+**Excel Changes**:
+- Current headers: `Chapter, Norm, Short req, DetailsEN, MotivationEN, ExampleEN, UseCase`
+- New headers: `ID.Revision, Chapter, Norm, Short req, DetailsEN, MotivationEN, ExampleEN, UseCase`
+- For release exports: use snapshot's `internalId` and `revision`
+
+**Word Changes**:
+- Current: `Req N: {shortreq}`
+- New: `{ID.Revision}: {shortreq}` (e.g., "REQ-001.3: The system shall...")
+
+### 7. API Response Backward Compatibility
+
+**Decision**: Add fields to existing responses; do not remove any fields
+
+**Rationale**:
+- Constitution requires backward compatibility within major versions
+- Existing consumers won't break when new fields appear
+
+**Changes to RequirementResponse**:
+```kotlin
+data class RequirementResponse(
+    val id: Long,                    // Keep: database ID
+    val internalId: String,          // Add: "REQ-001"
+    val revision: Int,               // Add: 3
+    val idRevision: String,          // Add: "REQ-001.3"
+    // ... existing fields unchanged
+)
+```
+
+## Dependencies Verified
+
+| Dependency | Version | Usage | Status |
+|------------|---------|-------|--------|
+| Apache POI | 5.3 | Excel/Word export modification | Already present |
+| Micronaut Data | 4.10 | Repository queries | Already present |
+| Hibernate JPA | 6.x | Entity mapping, @PreUpdate | Already present |
+
+## Best Practices Applied
+
+1. **Atomic ID Generation**: Use `SELECT FOR UPDATE` to prevent race conditions
+2. **Immutable IDs**: Never change `internalId` after assignment
+3. **Revision Semantics**: Only increment on meaningful content changes
+4. **Migration Safety**: Run migration in transaction; rollback if any step fails
+5. **Export Consistency**: Include ID.Revision in all export formats (standard, release, translated)
+
+## Open Questions Resolved
+
+| Question | Resolution |
+|----------|------------|
+| Migration order for existing requirements | Database ID order (lowest → REQ-001) per clarification session |
+| Reuse `versionNumber` or add `revision`? | Reuse existing `versionNumber` field |
+| What triggers revision increment? | Content field changes only (FR-004), not relationship changes (FR-005) |

--- a/specs/066-requirement-versioning/spec.md
+++ b/specs/066-requirement-versioning/spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: Requirement ID.Revision Versioning
+
+**Feature Branch**: `066-requirement-versioning`
+**Created**: 2026-01-22
+**Status**: Draft
+**Input**: User description: "Extend requirements management with ID.Revision versioning format, unique internal IDs, release management UI, and diff table exports showing changed revisions between releases"
+
+## Clarifications
+
+### Session 2026-01-23
+
+- Q: Should existing requirements receive IDs based on database ID order or creation timestamp order? → A: Database ID order (REQ-001 = lowest DB id)
+
+## Overview
+
+This feature extends the existing requirements management system to add explicit versioning with a user-facing "ID.Revision" format. Currently, requirements have database IDs and releases create snapshots, but there is no stable internal requirement identifier that persists across changes. This feature adds:
+
+1. **Requirement Internal ID**: A unique, human-readable identifier (e.g., "REQ-001") that never changes once assigned
+2. **Revision Tracking**: Each change to a requirement increments its revision number (e.g., "REQ-001.3")
+3. **ID.Revision in Exports**: Both Excel and Word exports include the ID.Revision column
+4. **Enhanced Release Management UI**: Admin dashboard to create, view, and switch between releases
+5. **Revision Diff Export**: Export table showing which requirements changed between two releases
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Assign and Display Requirement IDs (Priority: P1/MVP)
+
+As a requirement author, I want each requirement to have a unique internal ID that never changes, so I can reference requirements consistently across documents and conversations.
+
+**Why this priority**: This is the foundational feature. Without stable IDs, all other features (revision tracking, diff exports) cannot work. This delivers immediate value by giving requirements traceable identifiers.
+
+**Independent Test**: Can be fully tested by creating a new requirement and verifying it receives a unique ID (e.g., "REQ-001"). Editing the requirement should NOT change its ID.
+
+**Acceptance Scenarios**:
+
+1. **Given** I create a new requirement, **When** the requirement is saved, **Then** it is automatically assigned a unique internal ID in the format "REQ-NNN" (zero-padded to 3 digits minimum)
+2. **Given** a requirement with ID "REQ-005" exists, **When** I edit its content, **Then** the ID remains "REQ-005" (unchanged)
+3. **Given** multiple requirements exist, **When** I view the requirements list, **Then** I can see each requirement's internal ID displayed
+4. **Given** a requirement is deleted, **When** I create a new requirement, **Then** the deleted ID is NOT reused (IDs are never recycled)
+
+---
+
+### User Story 2 - Track Requirement Revisions (Priority: P1/MVP)
+
+As a compliance officer, I want to see which revision of a requirement I'm looking at, so I can track the evolution of requirements over time.
+
+**Why this priority**: Revision tracking is core to the "ID.Revision" format the user requested. Combined with US1, this completes the versioning model.
+
+**Independent Test**: Can be tested by creating a requirement, editing it multiple times, and verifying the revision number increments each time.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new requirement is created, **When** I view it, **Then** its revision number starts at 1 (displayed as "REQ-001.1")
+2. **Given** requirement "REQ-001.2" exists, **When** I edit any field (shortreq, details, motivation, example, etc.), **Then** the revision increments to "REQ-001.3"
+3. **Given** requirement "REQ-001.3" exists, **When** I view its edit history, **Then** I can see when each revision was created (timestamp of last update)
+4. **Given** a requirement in display, **When** hovering over the ID.Revision badge, **Then** a tooltip shows the last modified date
+
+---
+
+### User Story 3 - Export ID.Revision in Excel and Word (Priority: P2)
+
+As a document author, I want the ID.Revision to appear in both Excel and Word exports, so I can reference specific requirement versions in external documents.
+
+**Why this priority**: Export functionality is essential for sharing requirements with stakeholders who don't use the system. This builds on US1 and US2.
+
+**Independent Test**: Can be tested by exporting requirements to Excel and Word, then verifying the ID.Revision column appears with correct values.
+
+**Acceptance Scenarios**:
+
+1. **Given** requirements with various ID.Revisions exist, **When** I export to Excel, **Then** the first column shows "ID.Revision" with values like "REQ-001.3"
+2. **Given** requirements with various ID.Revisions exist, **When** I export to Word, **Then** each requirement header includes the ID.Revision (e.g., "REQ-001.3: Short requirement text")
+3. **Given** I export a release snapshot to Excel, **When** I open the file, **Then** it shows the ID.Revision as it was at the time of the release (not current values)
+4. **Given** I export a release snapshot to Word, **When** I open the file, **Then** requirement headers show the ID.Revision from that release snapshot
+
+---
+
+### User Story 4 - Create and Manage Releases (Priority: P2)
+
+As an admin or release manager, I want to create releases that capture the state of all requirements at a point in time, so I can track how requirements evolved across versions.
+
+**Why this priority**: Release management exists but needs enhancement to store ID.Revision in snapshots. This is prerequisite for diff exports.
+
+**Independent Test**: Can be tested by creating a release, then modifying requirements, then verifying the release snapshot still shows original ID.Revision values.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the Release Management page, **When** I create a new release, **Then** all current requirements are captured as snapshots including their current ID.Revision
+2. **Given** a release "v1.0" exists with requirement "REQ-001.2", **When** I update that requirement to "REQ-001.3", **Then** viewing release "v1.0" still shows "REQ-001.2"
+3. **Given** I view a release, **When** I look at its requirements, **Then** I see the ID.Revision as frozen at release time
+4. **Given** releases exist, **When** I select a release from the admin dashboard, **Then** I can view all requirements as they were at that point in time
+
+---
+
+### User Story 5 - Compare Releases and Export Diff Table (Priority: P3)
+
+As a compliance officer, I want to compare two releases and export a table showing which requirements changed, so I can document changes between versions.
+
+**Why this priority**: Diff comparison already exists, but export needs to show ID.Revision changes. This is the final piece requested by the user.
+
+**Independent Test**: Can be tested by creating two releases with different requirement revisions, comparing them, and exporting the diff table.
+
+**Acceptance Scenarios**:
+
+1. **Given** release "v1.0" has "REQ-001.2" and release "v2.0" has "REQ-001.5", **When** I compare these releases, **Then** "REQ-001" appears in the "Modified" list showing revision changed from .2 to .5
+2. **Given** I compare two releases with changes, **When** I click "Export Diff to Excel", **Then** an Excel file is downloaded with columns: ID, Old Revision, New Revision, Change Summary
+3. **Given** a requirement exists only in the newer release, **When** I compare releases, **Then** it shows as "Added" with its ID.Revision
+4. **Given** a requirement was deleted between releases, **When** I compare releases, **Then** it shows as "Deleted" with its last known ID.Revision
+
+---
+
+### Edge Cases
+
+- **EC-001**: What happens when importing requirements via Excel that don't have IDs? System assigns new IDs automatically
+- **EC-002**: What happens if a requirement ID column is provided in import but conflicts with existing IDs? System ignores imported IDs and assigns new ones (IDs are system-generated only)
+- **EC-003**: What if a requirement is restored after deletion? It receives a NEW ID (old IDs are never reused)
+- **EC-004**: What if the ID sequence reaches maximum (999)? System auto-extends to 4 digits (REQ-1000)
+- **EC-005**: What if two users edit the same requirement simultaneously? Standard optimistic locking; last save wins but both edits increment revision
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST assign a unique internal ID to each requirement upon creation in format "REQ-NNN" (zero-padded, minimum 3 digits)
+- **FR-002**: System MUST never reuse a deleted requirement's internal ID
+- **FR-003**: System MUST maintain a revision number for each requirement, starting at 1
+- **FR-004**: System MUST increment the revision number on any content change (shortreq, details, motivation, example, norm, chapter, usecase)
+- **FR-005**: System MUST NOT increment revision on metadata-only changes (associated usecases/norms relationships)
+- **FR-006**: System MUST display ID.Revision in format "REQ-NNN.R" throughout the UI (list views, detail views, edit forms)
+- **FR-007**: System MUST include ID.Revision as the first column in Excel exports
+- **FR-008**: System MUST include ID.Revision in Word export requirement headers
+- **FR-009**: System MUST store ID.Revision in requirement snapshots when a release is created
+- **FR-010**: System MUST allow comparison between any two releases
+- **FR-011**: System MUST provide diff export functionality showing ID, old revision, new revision, and change summary
+- **FR-012**: System MUST persist the internal ID counter to ensure uniqueness across restarts
+
+### Key Entities
+
+- **Requirement** (extends existing):
+  - `internalId`: Unique human-readable ID (e.g., "REQ-001"), assigned once, never changes
+  - `revision`: Integer starting at 1, increments on content changes
+  - Computed property `idRevision`: Returns "REQ-NNN.R" format string
+
+- **RequirementSnapshot** (extends existing):
+  - `internalId`: Captured from requirement at snapshot time
+  - `revision`: Captured from requirement at snapshot time
+
+- **RequirementIdSequence** (new):
+  - Single-row table tracking next available ID number
+  - Ensures atomicity and persistence of ID generation
+
+## Assumptions
+
+- The existing `versionNumber` field in `VersionedEntity` will be repurposed as the revision number (it's currently unused)
+- Internal IDs use the "REQ-" prefix for clarity (distinguishes from database IDs)
+- IDs are zero-padded to 3 digits minimum for readability and sorting
+- The system will migrate existing requirements to assign IDs based on database ID order (lowest DB id → REQ-001, next → REQ-002, etc.)
+- Relationship changes (adding/removing usecases or norms) do NOT increment revision (only content changes do)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of requirements display their ID.Revision in list and detail views
+- **SC-002**: Every content edit to a requirement results in exactly one revision increment
+- **SC-003**: Excel and Word exports include ID.Revision for all requirements with 100% accuracy
+- **SC-004**: Release snapshots preserve ID.Revision values correctly, verifiable by comparing export before and after subsequent edits
+- **SC-005**: Diff export between releases correctly identifies all added, deleted, and modified requirements with their ID.Revisions
+- **SC-006**: Data migration assigns IDs to existing requirements without data loss or duplicate IDs

--- a/specs/066-requirement-versioning/tasks.md
+++ b/specs/066-requirement-versioning/tasks.md
@@ -1,0 +1,238 @@
+# Tasks: Requirement ID.Revision Versioning
+
+**Input**: Design documents from `/specs/066-requirement-versioning/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Not requested in feature specification. Tasks focus on implementation only.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `src/backendng/src/main/kotlin/com/secman/`
+- **Frontend**: `src/frontend/src/`
+- **Migrations**: `src/backendng/src/main/resources/db/migration/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Database migration and foundational entity setup
+
+- [x] T001 Create Flyway migration V066__add_requirement_internal_id.sql in src/backendng/src/main/resources/db/migration/V066__add_requirement_internal_id.sql
+- [x] T002 [P] Create RequirementIdSequence entity in src/backendng/src/main/kotlin/com/secman/domain/RequirementIdSequence.kt
+- [x] T003 [P] Create RequirementIdSequenceRepository in src/backendng/src/main/kotlin/com/secman/repository/RequirementIdSequenceRepository.kt
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core ID generation service and entity modifications that ALL user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add internalId field to Requirement entity in src/backendng/src/main/kotlin/com/secman/domain/Requirement.kt
+- [x] T005 Add idRevision computed property to Requirement entity in src/backendng/src/main/kotlin/com/secman/domain/Requirement.kt
+- [x] T006 [P] Add internalId and revision fields to RequirementSnapshot entity in src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt
+- [x] T007 [P] Add idRevision computed property to RequirementSnapshot in src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt
+- [x] T008 Update RequirementSnapshot.fromRequirement() to capture internalId and versionNumber in src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt
+- [x] T009 Create RequirementIdService with getNextId() method using SELECT FOR UPDATE in src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
+- [x] T010 Add formatId() helper function to format IDs as REQ-NNN in src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Assign and Display Requirement IDs (Priority: P1) 🎯 MVP
+
+**Goal**: Each requirement has a unique internal ID (REQ-001, REQ-002, ...) that never changes
+
+**Independent Test**: Create a new requirement and verify it receives a unique ID. Edit the requirement and verify ID remains unchanged.
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Update RequirementService.createRequirement() to call RequirementIdService.getNextId() and assign internalId in src/backendng/src/main/kotlin/com/secman/service/RequirementService.kt
+- [x] T012 [US1] Update RequirementResponse DTO to include internalId, revision (versionNumber), and idRevision fields in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T013 [US1] Update RequirementResponse.from() to map internalId and versionNumber from Requirement in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T014 [P] [US1] Update RequirementManagement.tsx to display internalId badge in requirement list in src/frontend/src/components/RequirementManagement.tsx
+- [x] T015 [P] [US1] Update RequirementManagement.tsx to display internalId in requirement detail view in src/frontend/src/components/RequirementManagement.tsx
+- [x] T016 [US1] Verify internalId is NOT editable in RequirementManagement.tsx edit form in src/frontend/src/components/RequirementManagement.tsx
+
+**Checkpoint**: User Story 1 complete - requirements have unique IDs that display correctly
+
+---
+
+## Phase 4: User Story 2 - Track Requirement Revisions (Priority: P1)
+
+**Goal**: Revision number increments on content changes, displayed as ID.Revision (e.g., REQ-001.3)
+
+**Independent Test**: Create a requirement, edit content fields multiple times, verify revision increments each time. Edit relationship-only, verify revision does NOT increment.
+
+### Implementation for User Story 2
+
+- [x] T017 [US2] Add shouldIncrementRevision() helper to detect content changes in src/backendng/src/main/kotlin/com/secman/service/RequirementService.kt
+- [x] T018 [US2] Update RequirementService.updateRequirement() to call incrementVersion() on content changes in src/backendng/src/main/kotlin/com/secman/service/RequirementService.kt
+- [x] T019 [US2] Ensure relationship-only changes (usecases, norms) do NOT increment revision in src/backendng/src/main/kotlin/com/secman/service/RequirementService.kt
+- [x] T020 [P] [US2] Update RequirementManagement.tsx to display full ID.Revision format (e.g., REQ-001.3) in src/frontend/src/components/RequirementManagement.tsx
+- [x] T021 [P] [US2] Add tooltip showing updatedAt timestamp when hovering over ID.Revision badge in src/frontend/src/components/RequirementManagement.tsx
+
+**Checkpoint**: User Story 2 complete - revisions track content changes correctly
+
+---
+
+## Phase 5: User Story 3 - Export ID.Revision in Excel and Word (Priority: P2)
+
+**Goal**: Excel and Word exports include ID.Revision column/header for all requirements
+
+**Independent Test**: Export requirements to Excel and Word, verify ID.Revision appears as first column/header prefix.
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Update createExcelWorkbook() to add ID.Revision as first column header in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T023 [US3] Update createExcelWorkbook() to populate ID.Revision column with requirement.idRevision in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T024 [US3] Update createWordDocument() to use ID.Revision in requirement headers instead of "Req N" in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T025 [US3] Update translated export methods to include ID.Revision in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+- [x] T026 [US3] Update snapshotToRequirement() to set internalId and versionNumber from snapshot for release exports in src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+
+**Checkpoint**: User Story 3 complete - exports include ID.Revision
+
+---
+
+## Phase 6: User Story 4 - Create and Manage Releases with ID.Revision (Priority: P2)
+
+**Goal**: Release snapshots capture and preserve ID.Revision at release time
+
+**Independent Test**: Create a release, modify requirements, verify release snapshot still shows original ID.Revision values.
+
+### Implementation for User Story 4
+
+- [x] T027 [US4] Verify ReleaseService.createRelease() uses updated RequirementSnapshot.fromRequirement() with internalId/revision in src/backendng/src/main/kotlin/com/secman/service/ReleaseService.kt
+- [x] T028 [P] [US4] Update ReleaseManagement.tsx to display ID.Revision for requirements in release view in src/frontend/src/components/ReleaseManagement.tsx
+- [x] T029 [P] [US4] Update RequirementSnapshotSummary DTO to include internalId, revision, idRevision in src/backendng/src/main/kotlin/com/secman/dto/ComparisonResult.kt
+
+**Checkpoint**: User Story 4 complete - releases capture ID.Revision snapshots
+
+---
+
+## Phase 7: User Story 5 - Compare Releases and Export Diff Table (Priority: P3)
+
+**Goal**: Release comparison shows revision changes and diff export includes ID, old revision, new revision columns
+
+**Independent Test**: Create two releases with modified requirements, compare them, verify old/new revisions shown. Export diff and verify columns.
+
+### Implementation for User Story 5
+
+- [x] T030 [US5] Update RequirementDiff DTO to include internalId, oldRevision, newRevision in src/backendng/src/main/kotlin/com/secman/dto/ComparisonResult.kt
+- [x] T031 [US5] Update RequirementComparisonService.compare() to populate revision fields in RequirementDiff in src/backendng/src/main/kotlin/com/secman/service/RequirementComparisonService.kt
+- [x] T032 [P] [US5] Update ReleaseComparison.tsx to display old/new revisions in modified requirements section in src/frontend/src/components/ReleaseComparison.tsx
+- [x] T033 [P] [US5] Update comparisonExport.ts to add ID.Revision columns (ID, Old Rev, New Rev) in src/frontend/src/utils/comparisonExport.ts
+- [x] T034 [US5] Update RequirementSnapshotSummary in added/deleted sections to show idRevision in src/frontend/src/components/ReleaseComparison.tsx
+
+**Checkpoint**: User Story 5 complete - release comparison shows revision changes with export
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [ ] T035 Run Flyway migration and verify existing requirements have IDs assigned in database ID order
+- [x] T036 Verify ./gradlew build passes with all changes
+- [x] T037 [P] Update API documentation with new response fields in contracts/api-changes.yaml
+- [ ] T038 Run quickstart.md validation checklist manually
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup (T001-T003) completion - BLOCKS all user stories
+- **User Stories (Phases 3-7)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 priority but can run in parallel
+  - US3 and US4 are P2 and can run after US1/US2 or in parallel
+  - US5 is P3 and can run last or in parallel with others
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Foundational - No dependencies on other stories
+- **User Story 2 (P1)**: Depends on Foundational - No dependencies on other stories (shares display with US1)
+- **User Story 3 (P2)**: Depends on Foundational - Uses idRevision from US1/US2 but independently testable
+- **User Story 4 (P2)**: Depends on Foundational - Extends snapshot behavior from setup
+- **User Story 5 (P3)**: Depends on Foundational - Uses snapshot data from US4 context
+
+### Within Each User Story
+
+- Backend changes before frontend changes
+- Service layer before controller/DTO changes
+- Core implementation before UI integration
+- All [P] tasks within a story can run in parallel
+
+### Parallel Opportunities
+
+- T002, T003 can run in parallel (Setup phase)
+- T004-T005, T006-T008 can run in parallel (different entities)
+- T014, T015 can run in parallel (different UI views)
+- T020, T021 can run in parallel (different UI features)
+- T028, T029 can run in parallel (different files)
+- T032, T033 can run in parallel (different files)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch backend tasks first:
+Task T011: "Update RequirementService to assign internalId"
+Task T012-T013: "Update RequirementResponse DTO"
+
+# Then launch frontend tasks in parallel:
+Task T014: "Display internalId in requirement list"
+Task T015: "Display internalId in detail view"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + User Story 2)
+
+1. Complete Phase 1: Setup (migration + entities)
+2. Complete Phase 2: Foundational (ID service + entity fields)
+3. Complete Phase 3: User Story 1 (ID assignment + display)
+4. Complete Phase 4: User Story 2 (revision tracking)
+5. **STOP and VALIDATE**: Create requirements, edit them, verify ID.Revision works
+6. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 + US2 → ID.Revision displays correctly (MVP!)
+3. Add US3 → Exports include ID.Revision
+4. Add US4 → Releases capture snapshots
+5. Add US5 → Release comparison shows revisions
+6. Each story adds value without breaking previous stories
+
+### Single Developer Strategy
+
+Execute phases sequentially:
+1. Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6 → Phase 7 → Phase 8
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies within phase
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable after Foundational phase
+- Flyway migration handles data backfill for existing requirements
+- Revision uses existing versionNumber field from VersionedEntity (no new column needed)
+- Commit after each task or logical group

--- a/src/backendng/src/main/kotlin/com/secman/domain/Requirement.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/Requirement.kt
@@ -13,6 +13,9 @@ data class Requirement(
     @GeneratedValue
     var id: Long? = null,
 
+    @Column(name = "internal_id", unique = true, nullable = false, length = 20)
+    var internalId: String = "",
+
     @Column(nullable = false)
     @NotBlank
     var shortreq: String,
@@ -60,6 +63,9 @@ data class Requirement(
     @Column(name = "updated_at")
     var updatedAt: Instant? = null
 ) : VersionedEntity() {
+
+    val idRevision: String
+        get() = "$internalId.$versionNumber"
 
     @PrePersist
     fun onCreate() {

--- a/src/backendng/src/main/kotlin/com/secman/domain/RequirementIdSequence.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/RequirementIdSequence.kt
@@ -1,0 +1,24 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+@Table(name = "requirement_id_sequence")
+@Serdeable
+data class RequirementIdSequence(
+    @Id
+    var id: Long = 1L,
+
+    @Column(name = "next_value", nullable = false)
+    var nextValue: Int = 1,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+) {
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/RequirementSnapshot.kt
@@ -26,6 +26,12 @@ data class RequirementSnapshot(
     @Column(name = "original_requirement_id", nullable = false)
     var originalRequirementId: Long,
 
+    @Column(name = "internal_id", nullable = false, length = 20)
+    var internalId: String = "",
+
+    @Column(name = "revision", nullable = false)
+    var revision: Int = 1,
+
     @Column(nullable = false)
     @NotBlank
     var shortreq: String,
@@ -60,6 +66,9 @@ data class RequirementSnapshot(
     @Column(name = "snapshot_timestamp", nullable = false, updatable = false)
     var snapshotTimestamp: Instant = Instant.now()
 ) {
+    val idRevision: String
+        get() = "$internalId.$revision"
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is RequirementSnapshot) return false
@@ -76,6 +85,8 @@ data class RequirementSnapshot(
             return RequirementSnapshot(
                 release = release,
                 originalRequirementId = requirement.id!!,
+                internalId = requirement.internalId,
+                revision = requirement.versionNumber,
                 shortreq = requirement.shortreq,
                 details = requirement.details,
                 language = requirement.language,

--- a/src/backendng/src/main/kotlin/com/secman/dto/ComparisonResult.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/ComparisonResult.kt
@@ -34,6 +34,9 @@ data class ReleaseInfo(
 data class RequirementSnapshotSummary(
     val id: Long,
     val originalRequirementId: Long,
+    val internalId: String,
+    val revision: Int,
+    val idRevision: String,
     val shortreq: String,
     val details: String?
 )
@@ -44,6 +47,9 @@ data class RequirementSnapshotSummary(
 @Serdeable
 data class RequirementDiff(
     val id: Long,  // originalRequirementId
+    val internalId: String,
+    val oldRevision: Int,
+    val newRevision: Int,
     val shortreq: String,
     val changes: List<FieldChange>
 )

--- a/src/backendng/src/main/kotlin/com/secman/repository/RequirementIdSequenceRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/RequirementIdSequenceRepository.kt
@@ -1,0 +1,14 @@
+package com.secman.repository
+
+import com.secman.domain.RequirementIdSequence
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import java.util.*
+
+@Repository
+interface RequirementIdSequenceRepository : JpaRepository<RequirementIdSequence, Long> {
+
+    @Query("SELECT s FROM RequirementIdSequence s WHERE s.id = :id", nativeQuery = false)
+    fun findByIdForUpdate(id: Long): Optional<RequirementIdSequence>
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/RequirementComparisonService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/RequirementComparisonService.kt
@@ -82,6 +82,9 @@ class RequirementComparisonService(
                     modified.add(
                         RequirementDiff(
                             id = toSnapshot.originalRequirementId,
+                            internalId = toSnapshot.internalId,
+                            oldRevision = fromSnapshot.revision,
+                            newRevision = toSnapshot.revision,
                             shortreq = toSnapshot.shortreq,
                             changes = changes
                         )
@@ -122,6 +125,9 @@ class RequirementComparisonService(
         return RequirementSnapshotSummary(
             id = snapshot.id!!,
             originalRequirementId = snapshot.originalRequirementId,
+            internalId = snapshot.internalId,
+            revision = snapshot.revision,
+            idRevision = snapshot.idRevision,
             shortreq = snapshot.shortreq,
             details = snapshot.details
         )

--- a/src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
@@ -1,0 +1,30 @@
+package com.secman.service
+
+import com.secman.repository.RequirementIdSequenceRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+
+@Singleton
+open class RequirementIdService(
+    @Inject private val sequenceRepository: RequirementIdSequenceRepository
+) {
+
+    @Transactional
+    open fun getNextId(): String {
+        val sequence = sequenceRepository.findByIdForUpdate(1L)
+            .orElseThrow { IllegalStateException("Requirement ID sequence not initialized. Run database migrations.") }
+        val nextVal = sequence.nextValue
+        sequence.nextValue = nextVal + 1
+        sequenceRepository.update(sequence)
+        return formatId(nextVal)
+    }
+
+    fun formatId(num: Int): String {
+        return if (num < 1000) {
+            "REQ-${num.toString().padStart(3, '0')}"
+        } else {
+            "REQ-$num"
+        }
+    }
+}

--- a/src/backendng/src/main/resources/db/migration/V066__add_requirement_internal_id.sql
+++ b/src/backendng/src/main/resources/db/migration/V066__add_requirement_internal_id.sql
@@ -1,0 +1,51 @@
+-- Feature 066: Requirement ID.Revision Versioning
+-- Add internal ID tracking for requirements with unique identifiers
+
+-- 1. Create sequence table for atomic ID generation
+CREATE TABLE requirement_id_sequence (
+    id BIGINT PRIMARY KEY DEFAULT 1,
+    next_value INT NOT NULL DEFAULT 1,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 2. Add internal_id column to requirement (nullable initially for migration)
+ALTER TABLE requirement
+ADD COLUMN internal_id VARCHAR(20) NULL;
+
+-- 3. Migrate existing requirements: assign IDs by database ID order
+SET @rank := 0;
+UPDATE requirement r
+JOIN (
+    SELECT id, @rank := @rank + 1 AS rn
+    FROM requirement
+    ORDER BY id ASC
+) ranked ON r.id = ranked.id
+SET r.internal_id = CONCAT('REQ-', LPAD(ranked.rn, 3, '0'));
+
+-- 4. Initialize sequence to next available value
+INSERT INTO requirement_id_sequence (id, next_value, updated_at)
+SELECT 1, COALESCE(MAX(CAST(SUBSTRING(internal_id, 5) AS UNSIGNED)), 0) + 1, NOW()
+FROM requirement;
+
+-- 5. Make internal_id NOT NULL and add unique constraint
+ALTER TABLE requirement
+MODIFY COLUMN internal_id VARCHAR(20) NOT NULL,
+ADD CONSTRAINT uk_requirement_internal_id UNIQUE (internal_id);
+
+-- 6. Add columns to requirement_snapshot
+ALTER TABLE requirement_snapshot
+ADD COLUMN internal_id VARCHAR(20) NULL,
+ADD COLUMN revision INT NOT NULL DEFAULT 1;
+
+-- 7. Backfill snapshot data from original requirements
+UPDATE requirement_snapshot rs
+JOIN requirement r ON rs.original_requirement_id = r.id
+SET rs.internal_id = r.internal_id,
+    rs.revision = r.version_number;
+
+-- 8. Make snapshot internal_id NOT NULL
+ALTER TABLE requirement_snapshot
+MODIFY COLUMN internal_id VARCHAR(20) NOT NULL;
+
+-- 9. Add index for snapshot lookups by internal_id
+CREATE INDEX idx_snapshot_internal_id ON requirement_snapshot(internal_id);

--- a/src/frontend/src/components/ReleaseComparison.tsx
+++ b/src/frontend/src/components/ReleaseComparison.tsx
@@ -222,8 +222,13 @@ const ReleaseComparison: React.FC = () => {
                             <div className="list-group">
                                 {comparisonResult.added.map((req) => (
                                     <div key={req.id} className="list-group-item list-group-item-success">
-                                        <h6 className="mb-1">{req.shortreq}</h6>
-                                        {req.details && <p className="mb-0 text-muted small">{req.details}</p>}
+                                        <div className="d-flex align-items-start">
+                                            <span className="badge bg-secondary me-2">{req.idRevision}</span>
+                                            <div>
+                                                <h6 className="mb-1">{req.shortreq}</h6>
+                                                {req.details && <p className="mb-0 text-muted small">{req.details}</p>}
+                                            </div>
+                                        </div>
                                     </div>
                                 ))}
                             </div>
@@ -239,8 +244,13 @@ const ReleaseComparison: React.FC = () => {
                             <div className="list-group">
                                 {comparisonResult.deleted.map((req) => (
                                     <div key={req.id} className="list-group-item list-group-item-danger">
-                                        <h6 className="mb-1">{req.shortreq}</h6>
-                                        {req.details && <p className="mb-0 text-muted small">{req.details}</p>}
+                                        <div className="d-flex align-items-start">
+                                            <span className="badge bg-secondary me-2">{req.idRevision}</span>
+                                            <div>
+                                                <h6 className="mb-1">{req.shortreq}</h6>
+                                                {req.details && <p className="mb-0 text-muted small">{req.details}</p>}
+                                            </div>
+                                        </div>
                                     </div>
                                 ))}
                             </div>
@@ -264,7 +274,13 @@ const ReleaseComparison: React.FC = () => {
                                                 style={{ cursor: 'pointer' }}
                                                 onClick={() => toggleExpanded(req.id)}
                                             >
-                                                <h6 className="mb-1">{req.shortreq}</h6>
+                                                <div className="d-flex align-items-center">
+                                                    <span className="badge bg-secondary me-2">{req.internalId}</span>
+                                                    <span className="badge bg-info me-2" title="Revision change">
+                                                        .{req.oldRevision} → .{req.newRevision}
+                                                    </span>
+                                                    <h6 className="mb-0">{req.shortreq}</h6>
+                                                </div>
                                                 <span className="badge bg-secondary">
                                                     {req.changes.length} field{req.changes.length !== 1 ? 's' : ''} changed
                                                 </span>

--- a/src/frontend/src/components/RequirementManagement.tsx
+++ b/src/frontend/src/components/RequirementManagement.tsx
@@ -16,6 +16,9 @@ interface Norm {
 
 interface Requirement {
     id?: number;
+    internalId?: string;
+    revision?: number;
+    idRevision?: string;
     shortreq: string; // Renamed from title
     details: string;  // Renamed from description
     language?: string; // New optional field

--- a/src/frontend/src/utils/comparisonExport.ts
+++ b/src/frontend/src/utils/comparisonExport.ts
@@ -25,6 +25,9 @@ export interface ReleaseInfo {
 export interface RequirementSnapshotSummary {
     id: number;
     originalRequirementId: number;
+    internalId: string;
+    revision: number;
+    idRevision: string;
     shortreq: string;
     chapter?: string;
     norm?: string;
@@ -43,6 +46,9 @@ export interface FieldChange {
 export interface RequirementDiff {
     id: number;
     originalRequirementId?: number;
+    internalId: string;
+    oldRevision: number;
+    newRevision: number;
     shortreq: string;
     chapter?: string;
     norm?: string;
@@ -117,6 +123,7 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
         const addedSheet = workbook.addWorksheet('Added');
         addedSheet.columns = [
             { header: 'Change Type', key: 'changeType', width: 15 },
+            { header: 'ID.Revision', key: 'idRevision', width: 15 },
             { header: 'Short Req', key: 'shortreq', width: 20 },
             { header: 'Chapter', key: 'chapter', width: 15 },
             { header: 'Norm', key: 'norm', width: 15 },
@@ -129,6 +136,7 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
         comparison.added.forEach((req) => {
             addedSheet.addRow({
                 changeType: 'ADDED',
+                idRevision: req.idRevision,
                 shortreq: req.shortreq,
                 chapter: req.chapter || '',
                 norm: req.norm || '',
@@ -148,6 +156,7 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
         const deletedSheet = workbook.addWorksheet('Deleted');
         deletedSheet.columns = [
             { header: 'Change Type', key: 'changeType', width: 15 },
+            { header: 'ID.Revision', key: 'idRevision', width: 15 },
             { header: 'Short Req', key: 'shortreq', width: 20 },
             { header: 'Chapter', key: 'chapter', width: 15 },
             { header: 'Norm', key: 'norm', width: 15 },
@@ -160,6 +169,7 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
         comparison.deleted.forEach((req) => {
             deletedSheet.addRow({
                 changeType: 'DELETED',
+                idRevision: req.idRevision,
                 shortreq: req.shortreq,
                 chapter: req.chapter || '',
                 norm: req.norm || '',
@@ -179,6 +189,9 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
         const modifiedSheet = workbook.addWorksheet('Modified');
         modifiedSheet.columns = [
             { header: 'Change Type', key: 'changeType', width: 15 },
+            { header: 'ID', key: 'internalId', width: 12 },
+            { header: 'Old Rev', key: 'oldRevision', width: 10 },
+            { header: 'New Rev', key: 'newRevision', width: 10 },
             { header: 'Short Req', key: 'shortreq', width: 20 },
             { header: 'Chapter', key: 'chapter', width: 15 },
             { header: 'Norm', key: 'norm', width: 15 },
@@ -192,6 +205,9 @@ export async function exportComparisonToExcel(comparison: ComparisonResult): Pro
             req.changes.forEach((change, index) => {
                 modifiedSheet.addRow({
                     changeType: index === 0 ? 'MODIFIED' : '',
+                    internalId: index === 0 ? req.internalId : '',
+                    oldRevision: index === 0 ? req.oldRevision : '',
+                    newRevision: index === 0 ? req.newRevision : '',
                     shortreq: index === 0 ? req.shortreq : '',
                     chapter: index === 0 ? req.chapter || '' : '',
                     norm: index === 0 ? req.norm || '' : '',


### PR DESCRIPTION
Implements unique, immutable internal IDs (e.g., REQ-001) and revision tracking for requirements. Updates backend entities, services, and repositories to support ID assignment and revision incrementing. Adds database migration for new fields and sequence table. Modifies API responses, exports (Excel/Word), release snapshots, and frontend components to display and utilize the new ID.Revision format. Includes documentation, OpenAPI changes, and planning/specification files for the new versioning system.