### PR TITLE
Implement requirement releases with historical viewing

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="dataSourceStorageLocal" created-in="IU-253.29346.240">
+  <component name="dataSourceStorageLocal" created-in="IU-253.30387.90">
     <data-source name="secman@localhost" uuid="90352fce-ba45-402e-9b8a-736ffb037f91">
       <database-info product="MariaDB" version="11.8.2-MariaDB" jdbc-version="4.2" driver-name="MariaDB Connector/J" driver-version="3.3.3" dbms="MARIADB" exact-version="11.8.2" exact-driver-version="3.3">
         <extra-name-characters>#@</extra-name-characters>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,17 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
-      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/ImportController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/ImportController.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/dataSources.local.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources.local.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/Release.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/Release.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/ReleaseService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/ReleaseService.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/ReleaseList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/ReleaseList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/ReleaseStatusActions.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/ReleaseStatusActions.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/RequirementManagement.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/RequirementManagement.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/Sidebar.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/Sidebar.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/services/releaseService.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/services/releaseService.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/utils/permissions.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/utils/permissions.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -92,7 +102,7 @@
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "067-requirement-releases",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/flake/sources/misc/secman",
@@ -223,8 +233,8 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-jdk-30f59d01ecdd-26cb7f24e5b0-intellij.indexing.shared.core-IU-253.29346.240" />
-        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-IU-253.29346.240" />
+        <option value="bundled-jdk-30f59d01ecdd-2fc7cc6b9a17-intellij.indexing.shared.core-IU-253.30387.90" />
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-IU-253.30387.90" />
       </set>
     </attachedChunks>
   </component>

--- a/specs/067-requirement-releases/checklists/requirements.md
+++ b/specs/067-requirement-releases/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Requirement Releases
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Assumptions documented: ID.Revision tracking (066), existing export functionality, navigation structure, ADMIN role system

--- a/specs/067-requirement-releases/spec.md
+++ b/specs/067-requirement-releases/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Requirement Releases
+
+**Feature Branch**: `067-requirement-releases`
+**Created**: 2026-01-24
+**Status**: Draft
+**Input**: User description: "Introduce Release concept for requirements. A Release captures a snapshot of all requirements at a point in time. Only ADMIN users can create releases. The current release is shown in the UI. Releases cannot be edited but can be deleted. Export functions work with any release (current or historical)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Admin Creates a Release (Priority: P1)
+
+An administrator wants to freeze the current state of all requirements as a named release before a product milestone, audit, or compliance review. This creates an immutable snapshot that can be referenced later.
+
+**Why this priority**: Creating releases is the core functionality that enables all other features (viewing, exporting historical data). Without this, the feature has no value.
+
+**Independent Test**: Can be fully tested by an admin user creating a release with a version name and verifying it appears in the releases list with the correct timestamp and requirement count.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has ADMIN role and there are requirements in the system, **When** they navigate to the admin section and create a new release with version "1.0.0", **Then** a release is created with a timestamp, the version name, and a snapshot of all current requirements is stored.
+2. **Given** the user has ADMIN role, **When** they create a release, **Then** each requirement's current state (including its ID.Revision) is captured immutably.
+3. **Given** the user does NOT have ADMIN role, **When** they attempt to access release creation, **Then** they are denied access.
+
+---
+
+### User Story 2 - View Current Release Indicator (Priority: P1)
+
+Any user viewing the requirements UI should always see which release they are currently viewing. If no release has been created yet, it shows "CURRENT" to indicate they are viewing live/working requirements.
+
+**Why this priority**: Users need context about what version of requirements they are viewing. This is essential for clarity and prevents confusion about whether they are viewing historical or current data.
+
+**Independent Test**: Can be tested by verifying the release indicator appears in the upper right of the requirements UI and changes appropriately when viewing different releases.
+
+**Acceptance Scenarios**:
+
+1. **Given** no releases have been created, **When** a user views the requirements UI, **Then** they see "CURRENT" displayed in the upper right corner.
+2. **Given** one or more releases exist, **When** a user views the requirements UI, **Then** they see "CURRENT" by default (indicating live working requirements).
+3. **Given** a user is viewing a historical release, **When** they look at the release indicator, **Then** it shows the release version (e.g., "v1.0.0") instead of "CURRENT".
+
+---
+
+### User Story 3 - View Release History (Priority: P2)
+
+Users need to see when releases were created and what versions exist. A dedicated releases page below "Requirements" in the navigation shows a list of all releases with their creation dates.
+
+**Why this priority**: Before users can export or compare releases, they need to see what releases exist. This enables navigation and selection of historical releases.
+
+**Independent Test**: Can be tested by navigating to the Releases page and verifying all created releases appear with correct metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** releases exist in the system, **When** a user navigates to "Releases" in the sidebar, **Then** they see a list of all releases with version name, creation date/time, and creator.
+2. **Given** no releases exist, **When** a user navigates to "Releases", **Then** they see a message indicating no releases have been created yet.
+3. **Given** the releases list is displayed, **When** a user views it, **Then** releases are ordered by creation date (newest first).
+
+---
+
+### User Story 4 - Export Historical Release (Priority: P2)
+
+Users need to export requirements from any release (current or historical) to Word or Excel format. The export function is enhanced to allow selection of which release to export.
+
+**Why this priority**: Export functionality already exists for current requirements. Extending it to historical releases provides audit trails and compliance documentation.
+
+**Independent Test**: Can be tested by selecting a historical release and exporting to Excel/Word, then verifying the exported content matches that release's snapshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the export page and releases exist, **When** they initiate an export, **Then** they can select which release to export (including "CURRENT" for live data).
+2. **Given** a user selects release "v1.0.0" for Excel export, **When** the export completes, **Then** the Excel file contains the requirements as they existed at that release point, with their historical ID.Revision values.
+3. **Given** a user selects release "v1.0.0" for Word export, **When** the export completes, **Then** the Word document contains the requirements as they existed at that release point.
+
+---
+
+### User Story 5 - Delete a Release (Priority: P3)
+
+An administrator may need to delete a release that was created in error or is no longer needed. Deleting a release removes it from the list but does not affect current requirements.
+
+**Why this priority**: This is an administrative cleanup feature. While important for maintenance, it's not core to the primary use case.
+
+**Independent Test**: Can be tested by an admin deleting a release and verifying it no longer appears in the releases list, while current requirements remain unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has ADMIN role and releases exist, **When** they delete a release, **Then** the release is removed from the system and no longer appears in the releases list.
+2. **Given** a user has ADMIN role, **When** they delete a release, **Then** the current/live requirements are not affected.
+3. **Given** a user does NOT have ADMIN role, **When** they attempt to delete a release, **Then** they are denied access.
+4. **Given** an admin attempts to delete the most recent release, **When** confirmed, **Then** the system allows deletion (releases are independent snapshots, not sequential dependencies).
+
+---
+
+### User Story 6 - View Requirements at a Specific Release (Priority: P3)
+
+Users can browse requirements as they existed at a specific release point, separate from the current working requirements.
+
+**Why this priority**: While useful for auditing, most users will primarily use exports for historical data. Direct UI viewing is a convenience feature.
+
+**Independent Test**: Can be tested by selecting a historical release and verifying the requirements UI shows requirements with their historical values.
+
+**Acceptance Scenarios**:
+
+1. **Given** releases exist, **When** a user selects a historical release from the releases page or a release selector, **Then** the requirements UI shows requirements as they existed at that release.
+2. **Given** a user is viewing a historical release, **When** they view requirements, **Then** requirements that were deleted since that release are still visible, and requirements added since that release are not visible.
+3. **Given** a user is viewing a historical release, **When** they view a requirement's ID.Revision, **Then** it shows the revision number as it was at that release point.
+
+---
+
+### Edge Cases
+
+- What happens when a release is created but there are no requirements? The release is created successfully with zero requirements captured.
+- What happens when viewing a historical release and a requirement has since been deleted? The requirement still appears as it was captured in that release snapshot.
+- What happens when a requirement is modified multiple times between releases? Only the final state before each release is captured in that release's snapshot.
+- What happens when the last/only release is deleted? The system returns to showing "CURRENT" with no historical releases available.
+- What happens during concurrent release creation by two admins? The system should handle this gracefully, creating two separate releases with different timestamps.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow users with ADMIN role to create a new release with a version identifier
+- **FR-002**: System MUST capture a complete snapshot of all requirements when a release is created, including each requirement's ID, revision number, and all content fields
+- **FR-003**: System MUST display the current release context (version or "CURRENT") in the upper right of the requirements UI
+- **FR-004**: System MUST provide a "Releases" navigation item below "Requirements" in the sidebar
+- **FR-005**: System MUST display a list of all releases showing version, creation timestamp, and creator
+- **FR-006**: System MUST allow users with ADMIN role to delete releases
+- **FR-007**: System MUST NOT allow editing of releases (releases are immutable snapshots)
+- **FR-008**: System MUST allow export (Excel and Word) from any release, not just current requirements
+- **FR-009**: System MUST preserve requirement snapshots even if the original requirement is later deleted
+- **FR-010**: System MUST restrict release creation and deletion to users with ADMIN role only
+- **FR-011**: System MUST allow all authenticated users to view releases and export from them
+- **FR-012**: System MUST display "CURRENT" as the release indicator when no releases exist or when viewing live requirements
+- **FR-013**: System MUST store the ID.Revision of each requirement at the time of release creation
+
+### Key Entities
+
+- **Release**: Represents a named point-in-time snapshot of all requirements. Contains version identifier, creation timestamp, creator user reference, and a collection of requirement snapshots. Releases are immutable once created.
+- **RequirementSnapshot**: A frozen copy of a requirement at release time. Contains all requirement fields (shortreq, details, motivation, example, norm associations, use case associations) plus the ID.Revision as it was at snapshot time. Links back to the original requirement (if it still exists) and to the parent release.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Admin users can create a release in under 30 seconds
+- **SC-002**: The release indicator is visible within 1 second of page load on any requirements page
+- **SC-003**: Release list page loads within 2 seconds showing all releases with accurate metadata
+- **SC-004**: Exporting from a historical release completes within the same time constraints as current requirement export
+- **SC-005**: 100% of requirement data at release time is accurately captured and retrievable in exports
+- **SC-006**: Users can distinguish between current and historical views at all times through clear visual indicators
+- **SC-007**: Deleting a release does not affect current requirements or other releases
+
+## Assumptions
+
+- Requirements already have ID.Revision tracking implemented (from feature 066)
+- Existing Word and Excel export functionality can be extended to work with snapshot data
+- The navigation structure already exists and can accommodate a new "Releases" item
+- User role system (ADMIN) is already implemented and functioning

--- a/src/backendng/src/main/kotlin/com/secman/domain/Release.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/Release.kt
@@ -34,7 +34,7 @@ data class Release(
     var releaseDate: Instant? = null,
 
     @ManyToOne
-    @JoinColumn(name = "created_by_id")
+    @JoinColumn(name = "created_by")
     var createdBy: User? = null,
 
     @Column(name = "created_at", updatable = false)
@@ -44,7 +44,7 @@ data class Release(
     var updatedAt: Instant? = null
 ) {
     enum class ReleaseStatus {
-        DRAFT, ACTIVE, PUBLISHED, ARCHIVED
+        DRAFT, ACTIVE, LEGACY
     }
 
     @PrePersist

--- a/src/frontend/src/components/ReleaseIndicator.tsx
+++ b/src/frontend/src/components/ReleaseIndicator.tsx
@@ -1,0 +1,64 @@
+/**
+ * ReleaseIndicator Component
+ * Feature: 067-requirement-releases, FR-003
+ *
+ * Displays the current release context in the upper right of the requirements UI.
+ * Shows "CURRENT" when viewing live requirements or the release version when
+ * viewing a historical release.
+ */
+
+import React from 'react';
+
+interface Release {
+    id: number;
+    version: string;
+    name: string;
+    status: string;
+}
+
+interface ReleaseIndicatorProps {
+    selectedRelease: Release | null;
+    onClearRelease?: () => void;
+}
+
+const ReleaseIndicator: React.FC<ReleaseIndicatorProps> = ({
+    selectedRelease,
+    onClearRelease
+}) => {
+    const isHistorical = selectedRelease !== null;
+
+    return (
+        <div
+            className={`release-indicator d-flex align-items-center gap-2 px-3 py-2 rounded ${
+                isHistorical ? 'bg-warning bg-opacity-25 border border-warning' : 'bg-success bg-opacity-10 border border-success'
+            }`}
+            data-testid="release-indicator"
+        >
+            <i className={`bi ${isHistorical ? 'bi-clock-history' : 'bi-check-circle'}`}></i>
+            <span className="fw-semibold">
+                {isHistorical ? (
+                    <>
+                        v{selectedRelease.version}
+                        <span className="text-muted ms-2 fw-normal" style={{ fontSize: '0.85em' }}>
+                            (Historical)
+                        </span>
+                    </>
+                ) : (
+                    'CURRENT'
+                )}
+            </span>
+            {isHistorical && onClearRelease && (
+                <button
+                    className="btn btn-sm btn-outline-secondary ms-2 py-0 px-1"
+                    onClick={onClearRelease}
+                    title="Return to current requirements"
+                    aria-label="Clear release selection"
+                >
+                    <i className="bi bi-x"></i>
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default ReleaseIndicator;

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -172,6 +172,14 @@ const Sidebar = () => {
                                         </a>
                                     </li>
                                 )}
+                                {/* Feature 067: Releases navigation below Requirements */}
+                                {canAccessReleases(userRoles) && (
+                                    <li>
+                                        <a href="/releases" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
+                                            <i className="bi bi-tag me-2"></i> Releases
+                                        </a>
+                                    </li>
+                                )}
                             </ul>
                         )}
                     </li>
@@ -484,20 +492,6 @@ const Sidebar = () => {
                                         <i className="bi bi-radar me-2"></i> Scans
                                     </a>
                                 </li>
-                                {canAccessReleases(userRoles) && (
-                                    <li>
-                                        <a href="/releases" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
-                                            <i className="bi bi-archive me-2"></i> Releases
-                                        </a>
-                                    </li>
-                                )}
-                                {canAccessCompareReleases(userRoles) && (
-                                    <li>
-                                        <a href="/releases/compare" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
-                                            <i className="bi bi-columns-gap me-2"></i> Compare Releases
-                                        </a>
-                                    </li>
-                                )}
 
                                 {/* Monitoring */}
                                 <li className="admin-subsection-header">Monitoring</li>

--- a/src/frontend/src/services/releaseService.ts
+++ b/src/frontend/src/services/releaseService.ts
@@ -14,7 +14,7 @@ export interface Release {
     version: string;
     name: string;
     description: string;
-    status: 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+    status: 'DRAFT' | 'ACTIVE' | 'LEGACY';
     releaseDate: string | null;
     createdBy: string;
     createdAt: string;
@@ -155,7 +155,7 @@ export const releaseService = {
      * @param status New status (PUBLISHED or ARCHIVED)
      * @returns Updated release
      */
-    async updateStatus(id: number, status: 'PUBLISHED' | 'ARCHIVED'): Promise<Release> {
+    async updateStatus(id: number, status: 'ACTIVE'): Promise<Release> {
         const response = await authenticatedFetch(`/api/releases/${id}/status`, {
             method: 'PUT',
             headers: {

--- a/src/frontend/src/utils/permissions.ts
+++ b/src/frontend/src/utils/permissions.ts
@@ -134,32 +134,37 @@ export function canAccessUseCaseManagement(roles: string[] | undefined): boolean
 
 /**
  * Check if user can access Releases
- * 
+ * Feature: 067-requirement-releases
+ *
  * Rules:
- * - ADMIN only
+ * - All users with requirements access can view releases (FR-011)
+ * - ADMIN, REQ, and SECCHAMPION can access
  */
 export function canAccessReleases(roles: string[] | undefined): boolean {
-  return isAdmin(roles);
+  return hasReqAccess(roles);
 }
 
 /**
  * Check if user can access Compare Releases
- * 
+ * Feature: 067-requirement-releases
+ *
  * Rules:
- * - ADMIN only
+ * - All users with requirements access can view/compare releases (FR-011)
+ * - ADMIN, REQ, and SECCHAMPION can access
  */
 export function canAccessCompareReleases(roles: string[] | undefined): boolean {
-  return isAdmin(roles);
+  return hasReqAccess(roles);
 }
 
 /**
  * Check if user can delete a specific release
- * 
+ *
  * Rules:
- * - ADMIN can delete any release
- * - RELEASE_MANAGER can delete only releases they created
+ * - ACTIVE releases cannot be deleted (must set another release as active first)
+ * - ADMIN can delete any non-ACTIVE release
+ * - RELEASE_MANAGER can delete only releases they created (if not ACTIVE)
  * - USER cannot delete releases
- * 
+ *
  * @param release - The release to check permissions for
  * @param currentUser - The current user object
  * @param currentUserRoles - The current user's roles array
@@ -172,7 +177,12 @@ export function canDeleteRelease(
 ): boolean {
   if (!release || !currentUser) return false;
 
-  // ADMIN can delete any release
+  // ACTIVE releases cannot be deleted
+  if (release.status === 'ACTIVE') {
+    return false;
+  }
+
+  // ADMIN can delete any non-ACTIVE release
   if (isAdmin(currentUserRoles)) {
     return true;
   }


### PR DESCRIPTION
Adds the Requirement Releases feature, enabling ADMIN users to create immutable snapshots of requirements, set releases as active, and delete non-active releases. Introduces backend support for release status workflow (DRAFT → ACTIVE → LEGACY), paginated snapshot retrieval, and enforces permissions. Frontend updates include a release indicator, release selector, historical requirements viewing (read-only), updated sidebar navigation, and revised permissions logic. Specification and checklist documentation for the feature are also included.