### PR TITLE
Add admin summary email CLI feature and logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing user_mapping table), local temp files for S3 downloads (065-s3-user-mapping-import)
 - Kotlin 2.3.0 / Java 25 + Micronaut 4.10, Hibernate JPA, Apache POI 5.3 (Excel/Word exports) (066-requirement-versioning)
 - MariaDB 11.4 (existing `requirement`, `requirement_snapshot`, `releases` tables) (066-requirement-versioning)
+- Kotlin 2.3.0 / Java 25 + Micronaut 4.10, PicoCLI (CLI framework), Jakarta Mail (email) (070-admin-summary-email)
+- MariaDB 11.4 (existing database) (070-admin-summary-email)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/specs/070-admin-summary-email/checklists/requirements.md
+++ b/specs/070-admin-summary-email/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Admin Summary Email
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is complete and ready for `/speckit.clarify` or `/speckit.plan`
+- Leverages existing notification infrastructure from feature 035
+- All requirements are testable with clear success/failure criteria

--- a/specs/070-admin-summary-email/data-model.md
+++ b/specs/070-admin-summary-email/data-model.md
@@ -1,0 +1,84 @@
+# Data Model: Admin Summary Email
+
+**Feature**: 070-admin-summary-email
+**Date**: 2026-01-27
+
+## New Entities
+
+### AdminSummaryLog
+
+Execution log for admin summary email sends. One record per CLI execution.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | Long | PK, auto-generated | Unique identifier |
+| executedAt | Instant | NOT NULL | Timestamp of execution start |
+| recipientCount | Int | NOT NULL | Number of ADMIN users targeted |
+| userCount | Long | NOT NULL | Total users statistic at time of send |
+| vulnerabilityCount | Long | NOT NULL | Total vulnerabilities at time of send |
+| assetCount | Long | NOT NULL | Total assets at time of send |
+| emailsSent | Int | NOT NULL, default 0 | Number of successfully sent emails |
+| emailsFailed | Int | NOT NULL, default 0 | Number of failed email sends |
+| status | ExecutionStatus | NOT NULL | Overall execution status |
+| dryRun | Boolean | NOT NULL, default false | Whether this was a dry run (no emails sent) |
+
+**Enum: ExecutionStatus**
+- `SUCCESS` - All emails sent successfully
+- `PARTIAL_FAILURE` - Some emails failed, some succeeded
+- `FAILURE` - All emails failed or no recipients found
+- `DRY_RUN` - Dry run mode, no emails sent
+
+**Indexes**:
+- `idx_admin_summary_log_executed_at` on `executedAt` (query recent executions)
+
+## Existing Entities Used (Read-Only)
+
+### User
+- Query: `findByRolesContaining(User.Role.ADMIN)` for recipients
+- Query: `count()` for total user statistic
+
+### Vulnerability
+- Query: `count()` for total vulnerability statistic
+
+### Asset
+- Query: `count()` for total asset statistic
+
+### EmailConfig
+- Used by EmailService to get SMTP configuration
+
+## Entity Relationships
+
+```
+AdminSummaryLog (new)
+    └── No direct relationships (standalone audit log)
+
+User ←── query ←── AdminSummaryService
+    └── findByRolesContaining(ADMIN)
+    └── count()
+
+Vulnerability ←── query ←── AdminSummaryService
+    └── count()
+
+Asset ←── query ←── AdminSummaryService
+    └── count()
+```
+
+## Database Table
+
+```sql
+CREATE TABLE admin_summary_log (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    executed_at TIMESTAMP NOT NULL,
+    recipient_count INT NOT NULL,
+    user_count BIGINT NOT NULL,
+    vulnerability_count BIGINT NOT NULL,
+    asset_count BIGINT NOT NULL,
+    emails_sent INT NOT NULL DEFAULT 0,
+    emails_failed INT NOT NULL DEFAULT 0,
+    status VARCHAR(20) NOT NULL,
+    dry_run BOOLEAN NOT NULL DEFAULT FALSE,
+    INDEX idx_admin_summary_log_executed_at (executed_at)
+);
+```
+
+*Note: Table will be auto-created by Hibernate based on entity annotations.*

--- a/specs/070-admin-summary-email/plan.md
+++ b/specs/070-admin-summary-email/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Admin Summary Email
+
+**Branch**: `070-admin-summary-email` | **Date**: 2026-01-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/070-admin-summary-email/spec.md`
+
+## Summary
+
+Implement a CLI command `send-admin-summary` that sends a summary email to all ADMIN users containing system statistics (total users, vulnerabilities, assets). The feature reuses the existing email infrastructure from feature 035 (notification system), adds a new email template, and logs each execution to the database for audit purposes.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25
+**Primary Dependencies**: Micronaut 4.10, PicoCLI (CLI framework), Jakarta Mail (email)
+**Storage**: MariaDB 11.4 (existing database)
+**Testing**: User-requested only (per Constitution Principle IV)
+**Target Platform**: Linux server (CLI command executed via cron or manually)
+**Project Type**: CLI extension to existing web application
+**Performance Goals**: Complete within 30 seconds for up to 100 ADMIN users
+**Constraints**: Must reuse existing EmailService infrastructure
+**Scale/Scope**: Small feature - 1 CLI command, 1 service class, 1 entity, 2 email templates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | ✅ PASS | No user input beyond CLI flags; uses existing auth-free CLI execution model |
+| III. API-First | ✅ PASS | CLI command only; no new REST API endpoints needed |
+| IV. User-Requested Testing | ✅ PASS | Tests prepared only when requested |
+| V. RBAC | ✅ PASS | No new endpoints; CLI runs with system privileges |
+| VI. Schema Evolution | ✅ PASS | New AdminSummaryLog entity uses Hibernate auto-migration |
+
+**All gates pass. Proceeding to Phase 0.**
+
+### Post-Phase 1 Re-check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | ✅ PASS | No injection vectors; email addresses from database only |
+| III. API-First | ✅ PASS | No REST endpoints added |
+| IV. User-Requested Testing | ✅ PASS | No test tasks created |
+| V. RBAC | ✅ PASS | Uses existing User.Role.ADMIN for recipient filtering |
+| VI. Schema Evolution | ✅ PASS | AdminSummaryLog entity follows JPA/Hibernate patterns |
+
+**All gates pass. Phase 1 design complete.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/070-admin-summary-email/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # N/A - no REST API
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/cli/src/main/kotlin/com/secman/cli/
+├── commands/
+│   └── SendAdminSummaryCommand.kt       # NEW: CLI command
+└── service/
+    └── AdminSummaryCliService.kt        # NEW: CLI service
+
+src/backendng/src/main/kotlin/com/secman/
+├── domain/
+│   └── AdminSummaryLog.kt               # NEW: Execution log entity
+├── repository/
+│   └── AdminSummaryLogRepository.kt     # NEW: Repository
+└── service/
+    └── AdminSummaryService.kt           # NEW: Backend service
+
+src/backendng/src/main/resources/email-templates/
+├── admin-summary.html                   # NEW: HTML email template
+└── admin-summary.txt                    # NEW: Plain text template
+```
+
+**Structure Decision**: Follows existing CLI pattern (SendNotificationsCommand → NotificationCliService → backend services). Backend service handles statistics gathering and email sending; CLI service coordinates the flow.
+
+## Complexity Tracking
+
+> No Constitution violations - no complexity tracking required.

--- a/specs/070-admin-summary-email/quickstart.md
+++ b/specs/070-admin-summary-email/quickstart.md
@@ -1,0 +1,105 @@
+# Quickstart: Admin Summary Email
+
+**Feature**: 070-admin-summary-email
+**Date**: 2026-01-27
+
+## Overview
+
+CLI command to send system statistics summary email to all ADMIN users.
+
+## Usage
+
+### Basic Execution
+
+```bash
+# Send admin summary email
+./bin/secman send-admin-summary
+
+# Preview without sending (dry run)
+./bin/secman send-admin-summary --dry-run
+
+# Detailed output
+./bin/secman send-admin-summary --verbose
+
+# Combined
+./bin/secman send-admin-summary --dry-run --verbose
+```
+
+### Expected Output
+
+```
+============================================================
+SecMan Admin Summary Email
+============================================================
+
+📊 Gathering statistics...
+   Users: 145
+   Vulnerabilities: 23,456
+   Assets: 1,234
+
+📧 Sending to 3 ADMIN users...
+   ✓ admin@example.com
+   ✓ security-lead@example.com
+   ✓ ciso@example.com
+
+============================================================
+Summary
+============================================================
+Recipients: 3
+Emails sent: 3
+Failures: 0
+
+✅ Admin summary email sent successfully
+```
+
+### Dry Run Output
+
+```
+============================================================
+SecMan Admin Summary Email
+============================================================
+
+⚠️  DRY-RUN MODE: No emails will be sent
+
+📊 Statistics to be sent:
+   Users: 145
+   Vulnerabilities: 23,456
+   Assets: 1,234
+
+📧 Would send to 3 ADMIN users:
+   - admin@example.com
+   - security-lead@example.com
+   - ciso@example.com
+
+✅ Dry run complete - no emails sent
+```
+
+## Cron Scheduling
+
+Weekly summary (every Monday at 8 AM):
+
+```cron
+0 8 * * 1 /opt/secman/bin/secman send-admin-summary >> /var/log/secman/admin-summary.log 2>&1
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success - all emails sent |
+| 1 | Failure - some or all emails failed |
+
+## Prerequisites
+
+1. Email configuration must be active in database
+2. At least one user must have ADMIN role with valid email
+3. CLI environment configured (see `./bin/secman help`)
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "No active email configuration" | Configure SMTP in Admin → Email Settings |
+| "No ADMIN users found" | Assign ADMIN role to at least one user |
+| "Email send failed" | Check SMTP settings, verify recipient addresses |
+| "ADMIN user skipped" | User has no email address configured |

--- a/specs/070-admin-summary-email/research.md
+++ b/specs/070-admin-summary-email/research.md
@@ -1,0 +1,99 @@
+# Research: Admin Summary Email
+
+**Feature**: 070-admin-summary-email
+**Date**: 2026-01-27
+
+## Research Topics
+
+### 1. Existing CLI Command Pattern
+
+**Decision**: Follow the `SendNotificationsCommand` pattern
+
+**Rationale**: The existing `SendNotificationsCommand` demonstrates the established pattern:
+- PicoCLI `@Command` annotation with name, description, mixinStandardHelpOptions
+- `@Option` annotations for `--dry-run` and `--verbose` flags
+- Service injection via `lateinit var`
+- `Runnable` interface implementation
+- Exit codes: 0 for success, 1 for failures
+
+**Alternatives considered**:
+- Picocli subcommand under existing command - rejected (feature is distinct enough)
+- HTTP endpoint instead of CLI - rejected (spec requires CLI)
+
+### 2. Email Service Integration
+
+**Decision**: Reuse `EmailService.sendEmail()` method directly
+
+**Rationale**: The `EmailService` already provides:
+- `sendEmail(to, subject, textContent, htmlContent)` method
+- Automatic SMTP configuration lookup via `getActiveEmailConfig()`
+- HTML + plain text multipart email support
+- Retry logic and error handling
+
+**Alternatives considered**:
+- Create new email sending method - rejected (unnecessary duplication)
+- Use bulk sending - rejected (admin list is small, individual sending gives better error tracking)
+
+### 3. Statistics Query Strategy
+
+**Decision**: Create dedicated service methods with count queries
+
+**Rationale**: Use repository `count()` methods for efficiency:
+- `UserRepository.count()` - total users
+- `VulnerabilityRepository.count()` - total vulnerabilities
+- `AssetRepository.count()` - total assets
+- `UserRepository.findByRolesContaining(User.Role.ADMIN)` - ADMIN recipients
+
+**Alternatives considered**:
+- Load full entities and count - rejected (inefficient for large datasets)
+- Cache statistics - rejected (overkill for periodic CLI command)
+
+### 4. Execution Logging Entity
+
+**Decision**: Create `AdminSummaryLog` entity with minimal fields
+
+**Rationale**: Match spec FR-013 requirements:
+- `id` (Long, auto-generated)
+- `executedAt` (Instant, timestamp of execution)
+- `recipientCount` (Int, number of recipients)
+- `userCount` (Long, users statistic sent)
+- `vulnerabilityCount` (Long, vulnerabilities statistic sent)
+- `assetCount` (Long, assets statistic sent)
+- `emailsSent` (Int, successful sends)
+- `emailsFailed` (Int, failed sends)
+- `status` (Enum: SUCCESS, PARTIAL_FAILURE, FAILURE)
+
+**Alternatives considered**:
+- Reuse `EmailNotificationLog` - rejected (different purpose, different schema)
+- Log to file only - rejected (user requested database logging in clarification)
+
+### 5. Email Template Design
+
+**Decision**: Create new `admin-summary.html` and `admin-summary.txt` templates
+
+**Rationale**:
+- Follow existing template pattern (`new-vulnerability-notification.html/txt`)
+- Use placeholders: `{{executionDate}}`, `{{userCount}}`, `{{vulnerabilityCount}}`, `{{assetCount}}`
+- Professional styling matching existing email design
+
+**Alternatives considered**:
+- Generate HTML in code - rejected (harder to maintain, less flexible)
+- Single template with conditionals - rejected (HTML and text need different formatting)
+
+### 6. Error Handling Strategy
+
+**Decision**: Continue on individual email failures, report summary
+
+**Rationale**:
+- If 10 ADMIN users, and 1 email fails, send to remaining 9
+- Report partial success in summary output
+- Exit code 1 if any failures (for cron monitoring)
+- Log entry captures exact counts for audit
+
+**Alternatives considered**:
+- Stop on first failure - rejected (other admins should still receive email)
+- Ignore failures - rejected (need visibility for troubleshooting)
+
+## Summary
+
+All technical decisions are resolved. No NEEDS CLARIFICATION items remain. Ready for Phase 1 design.

--- a/specs/070-admin-summary-email/spec.md
+++ b/specs/070-admin-summary-email/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Admin Summary Email
+
+**Feature Branch**: `070-admin-summary-email`
+**Created**: 2026-01-27
+**Status**: Draft
+**Input**: User description: "implement a functionality usable via CLI to sent to all ADMIN users an update via email, summarizing user numbers, numbers of vulns, number of assets. Use feature branch nr 70 for it"
+
+## Clarifications
+
+### Session 2026-01-27
+
+- Q: Should the system persist a log record of each admin summary email execution? → A: Yes, persist execution logs to database (audit trail)
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Send Admin Summary Email via CLI (Priority: P1/MVP)
+
+An administrator wants to send a summary email to all admin users containing key system metrics (total users, total vulnerabilities, total assets) to keep leadership informed about the security posture.
+
+The administrator runs a CLI command that gathers current statistics from the system and sends a formatted email to all users with the ADMIN role.
+
+**Why this priority**: Core functionality - without this, the feature provides no value. This is the minimum viable product.
+
+**Independent Test**: Can be fully tested by running the CLI command and verifying that all ADMIN users receive an email containing the correct statistics.
+
+**Acceptance Scenarios**:
+
+1. **Given** the system has users, vulnerabilities, and assets data, **When** an administrator runs the admin summary email command, **Then** all users with ADMIN role receive an email containing total user count, total vulnerability count, and total asset count.
+
+2. **Given** no users have the ADMIN role, **When** the command is executed, **Then** the system reports that no recipients were found and exits gracefully without sending emails.
+
+3. **Given** the email service is unavailable, **When** the command is executed, **Then** the system reports the failure with an appropriate error message.
+
+---
+
+### User Story 2 - Dry Run Mode for Testing (Priority: P2)
+
+An administrator wants to preview what would be sent without actually sending emails, to verify the statistics and recipient list before committing to the email send.
+
+**Why this priority**: Important for safe operations and testing, but not required for basic functionality.
+
+**Independent Test**: Can be tested by running the command with dry-run flag and verifying output shows planned recipients and statistics without sending emails.
+
+**Acceptance Scenarios**:
+
+1. **Given** the system has data and ADMIN users exist, **When** the command is run with `--dry-run` flag, **Then** the system displays the list of recipients and the statistics that would be sent, but no emails are delivered.
+
+2. **Given** dry-run mode is active, **When** the command completes, **Then** the output clearly indicates it was a dry run and no emails were sent.
+
+---
+
+### User Story 3 - Verbose Output for Troubleshooting (Priority: P3)
+
+An administrator wants detailed logging to troubleshoot issues or confirm email delivery status for each recipient.
+
+**Why this priority**: Enhancement for operations - useful but not essential for core functionality.
+
+**Independent Test**: Can be tested by running the command with verbose flag and verifying detailed per-recipient status is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** verbose mode is enabled, **When** the command sends emails, **Then** the output shows per-recipient delivery status (success/failure) with email addresses.
+
+---
+
+### Edge Cases
+
+- What happens when the email configuration is missing or invalid? System should report configuration error clearly.
+- What happens when some ADMIN users have no email address configured? Those users should be skipped with a warning message.
+- What happens when the database is unreachable? System should report connection error and exit with non-zero status.
+- What happens when there are zero users, zero vulnerabilities, or zero assets? The email should still be sent with counts showing 0.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a CLI command `send-admin-summary` to trigger the admin summary email
+- **FR-002**: System MUST retrieve the total count of active users from the database
+- **FR-003**: System MUST retrieve the total count of vulnerabilities from the database
+- **FR-004**: System MUST retrieve the total count of assets from the database
+- **FR-005**: System MUST identify all users with the ADMIN role as email recipients
+- **FR-006**: System MUST send a formatted email to each ADMIN user containing the three statistics (users, vulnerabilities, assets)
+- **FR-007**: System MUST support a `--dry-run` flag that displays planned actions without sending emails
+- **FR-008**: System MUST support a `--verbose` flag for detailed per-recipient logging
+- **FR-009**: System MUST report a summary at completion showing: recipients count, emails sent, failures
+- **FR-010**: System MUST exit with non-zero status code if any email delivery fails
+- **FR-011**: System MUST skip ADMIN users who have no email address configured and report them as skipped
+- **FR-012**: System MUST provide both HTML and plain text versions of the email for compatibility
+- **FR-013**: System MUST persist an execution log record to the database for each run, including: timestamp, recipient count, statistics sent (user/vuln/asset counts), success/failure status
+
+### Key Entities
+
+- **User**: System users with roles (including ADMIN role) and email addresses
+- **Vulnerability**: Security vulnerabilities tracked in the system
+- **Asset**: IT assets/systems being managed
+- **Email Template**: The formatted message template for the admin summary email
+- **AdminSummaryLog**: Execution log record capturing: execution timestamp, recipient count, user/vulnerability/asset counts sent, success/failure status
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Command completes within 30 seconds for systems with up to 100 ADMIN users
+- **SC-002**: All ADMIN users with valid email addresses receive the summary email within 5 minutes of command execution
+- **SC-003**: Email content accurately reflects the current database counts at time of execution
+- **SC-004**: Dry-run mode produces output within 5 seconds without sending any emails
+- **SC-005**: Command provides clear success/failure feedback that can be used in automated scheduling (cron jobs)
+
+## Assumptions
+
+- The existing email infrastructure (SMTP configuration, email service) from the notification system (feature 035) will be reused
+- ADMIN users are identified by having "ADMIN" in their roles list
+- The command will be run manually or via cron job by system operators
+- Email addresses are stored in the User entity and are considered valid if present and non-empty
+- Statistics are point-in-time counts (no historical comparison in this initial version)

--- a/specs/070-admin-summary-email/tasks.md
+++ b/specs/070-admin-summary-email/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: Admin Summary Email
+
+**Input**: Design documents from `/specs/070-admin-summary-email/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: Not requested - no test tasks included (per Constitution Principle IV).
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md project structure:
+- **CLI**: `src/cli/src/main/kotlin/com/secman/cli/`
+- **Backend**: `src/backendng/src/main/kotlin/com/secman/`
+- **Templates**: `src/backendng/src/main/resources/email-templates/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create base infrastructure shared by all user stories
+
+- [ ] T001 [P] Create AdminSummaryLog entity in src/backendng/src/main/kotlin/com/secman/domain/AdminSummaryLog.kt
+- [ ] T002 [P] Create ExecutionStatus enum in src/backendng/src/main/kotlin/com/secman/domain/AdminSummaryLog.kt (same file as entity)
+- [ ] T003 [P] Create AdminSummaryLogRepository in src/backendng/src/main/kotlin/com/secman/repository/AdminSummaryLogRepository.kt
+- [ ] T004 [P] Create HTML email template in src/backendng/src/main/resources/email-templates/admin-summary.html
+- [ ] T005 [P] Create plain text email template in src/backendng/src/main/resources/email-templates/admin-summary.txt
+
+**Checkpoint**: Database entity and email templates ready. User story implementation can begin.
+
+---
+
+## Phase 2: User Story 1 - Send Admin Summary Email via CLI (Priority: P1/MVP)
+
+**Goal**: Core CLI command that sends summary email to all ADMIN users with system statistics.
+
+**Independent Test**: Run `./bin/secman send-admin-summary` and verify all ADMIN users receive email with user/vuln/asset counts.
+
+**FR Coverage**: FR-001 through FR-006, FR-009, FR-010, FR-011, FR-012, FR-013
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Create AdminSummaryService in src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt with methods: getSystemStatistics(), getAdminRecipients(), sendSummaryEmail(), logExecution()
+- [ ] T007 [US1] Implement getSystemStatistics() to query UserRepository.count(), VulnerabilityRepository.count(), AssetRepository.count()
+- [ ] T008 [US1] Implement getAdminRecipients() using UserRepository.findByRolesContaining(User.Role.ADMIN) filtering users with valid email
+- [ ] T009 [US1] Implement sendSummaryEmail() using EmailService.sendEmail() with template rendering
+- [ ] T010 [US1] Implement logExecution() to persist AdminSummaryLog entity with execution results
+- [ ] T011 [US1] Create AdminSummaryCliService in src/cli/src/main/kotlin/com/secman/cli/service/AdminSummaryCliService.kt bridging CLI to backend
+- [ ] T012 [US1] Create SendAdminSummaryCommand in src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt with basic execution flow
+- [ ] T013 [US1] Register SendAdminSummaryCommand in src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+- [ ] T014 [US1] Implement summary output showing recipients count, emails sent, failures
+- [ ] T015 [US1] Implement exit code logic (0 for success, 1 for any failures)
+
+**Checkpoint**: US1 complete - basic email sending works. Can run `./bin/secman send-admin-summary` successfully.
+
+---
+
+## Phase 3: User Story 2 - Dry Run Mode (Priority: P2)
+
+**Goal**: Preview mode that shows what would be sent without actually sending emails.
+
+**Independent Test**: Run `./bin/secman send-admin-summary --dry-run` and verify output shows recipients and statistics but no emails sent.
+
+**FR Coverage**: FR-007
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Add --dry-run flag to SendAdminSummaryCommand in src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
+- [ ] T017 [US2] Update AdminSummaryCliService to accept dryRun parameter in src/cli/src/main/kotlin/com/secman/cli/service/AdminSummaryCliService.kt
+- [ ] T018 [US2] Update AdminSummaryService.sendSummaryEmail() to skip actual sending when dryRun=true
+- [ ] T019 [US2] Implement dry-run output formatting showing planned recipients and statistics
+- [ ] T020 [US2] Log dry-run executions with status=DRY_RUN in AdminSummaryLog
+
+**Checkpoint**: US2 complete - dry run mode works. Can preview without sending.
+
+---
+
+## Phase 4: User Story 3 - Verbose Output (Priority: P3)
+
+**Goal**: Detailed per-recipient logging for troubleshooting.
+
+**Independent Test**: Run `./bin/secman send-admin-summary --verbose` and verify per-recipient status is displayed.
+
+**FR Coverage**: FR-008
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Add --verbose flag to SendAdminSummaryCommand in src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
+- [ ] T022 [US3] Update AdminSummaryCliService to accept verbose parameter
+- [ ] T023 [US3] Implement per-recipient status output (success/failure with email address) when verbose=true
+- [ ] T024 [US3] Add verbose logging for statistics gathering phase
+- [ ] T025 [US3] Add verbose logging for skipped recipients (no email configured)
+
+**Checkpoint**: US3 complete - verbose mode provides detailed troubleshooting info.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and final validation
+
+- [ ] T026 Update CLAUDE.md with new CLI command send-admin-summary and AdminSummaryLog entity
+- [ ] T027 Update docs/CLI.md with send-admin-summary command documentation
+- [ ] T028 Run quickstart.md validation scenarios manually
+- [ ] T029 Verify Hibernate auto-creates admin_summary_log table on startup
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies - can start immediately
+- **Phase 2 (US1)**: Depends on Phase 1 completion
+- **Phase 3 (US2)**: Depends on Phase 2 (US1) completion - extends CLI command
+- **Phase 4 (US3)**: Depends on Phase 2 (US1) completion - can run parallel with US2
+- **Phase 5 (Polish)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Setup - No dependencies on other stories
+- **User Story 2 (P2)**: Depends on US1 (adds flag to existing command)
+- **User Story 3 (P3)**: Depends on US1 (adds flag to existing command), independent of US2
+
+### Parallel Opportunities
+
+**Phase 1 (all can run in parallel)**:
+```
+T001 + T003 + T004 + T005 (different files, no dependencies)
+```
+
+**Phase 3 + Phase 4 (after US1 complete)**:
+```
+US2 (T016-T020) can run in parallel with US3 (T021-T025)
+Both add flags to same command but touch different code paths
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T005)
+2. Complete Phase 2: User Story 1 (T006-T015)
+3. **STOP and VALIDATE**: Test basic email sending works
+4. Deploy if ready - MVP complete!
+
+### Incremental Delivery
+
+1. Setup → Basic send works (MVP)
+2. Add US2 → Dry run preview works
+3. Add US3 → Verbose troubleshooting works
+4. Polish → Documentation complete
+
+### Task Counts
+
+| Phase | Tasks | Parallel Opportunities |
+|-------|-------|----------------------|
+| Setup | 5 | All 5 can run in parallel |
+| US1 (MVP) | 10 | T006 blocks T007-T015 |
+| US2 | 5 | Sequential (extends US1) |
+| US3 | 5 | Sequential (extends US1) |
+| Polish | 4 | T026+T027 can run in parallel |
+| **Total** | **29** | |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- No test tasks included (per Constitution Principle IV - user-requested only)
+- Entity uses Hibernate auto-migration (no Flyway scripts needed per CLAUDE.md)
+- Reuses existing EmailService infrastructure
+- Commit after each task or logical group

--- a/src/backendng/src/main/kotlin/com/secman/domain/AdminSummaryLog.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/AdminSummaryLog.kt
@@ -1,0 +1,67 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Execution log for admin summary email sends.
+ * One record per CLI execution.
+ * Feature: 070-admin-summary-email
+ */
+@Entity
+@Table(
+    name = "admin_summary_log",
+    indexes = [
+        Index(name = "idx_admin_summary_log_executed_at", columnList = "executed_at")
+    ]
+)
+@Serdeable
+data class AdminSummaryLog(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "executed_at", nullable = false)
+    val executedAt: Instant,
+
+    @Column(name = "recipient_count", nullable = false)
+    val recipientCount: Int,
+
+    @Column(name = "user_count", nullable = false)
+    val userCount: Long,
+
+    @Column(name = "vulnerability_count", nullable = false)
+    val vulnerabilityCount: Long,
+
+    @Column(name = "asset_count", nullable = false)
+    val assetCount: Long,
+
+    @Column(name = "emails_sent", nullable = false)
+    val emailsSent: Int = 0,
+
+    @Column(name = "emails_failed", nullable = false)
+    val emailsFailed: Int = 0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val status: ExecutionStatus,
+
+    @Column(name = "dry_run", nullable = false)
+    val dryRun: Boolean = false
+)
+
+/**
+ * Execution status for admin summary email sends.
+ * Feature: 070-admin-summary-email
+ */
+enum class ExecutionStatus {
+    /** All emails sent successfully */
+    SUCCESS,
+    /** Some emails failed, some succeeded */
+    PARTIAL_FAILURE,
+    /** All emails failed or no recipients found */
+    FAILURE,
+    /** Dry run mode, no emails sent */
+    DRY_RUN
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/AdminSummaryLogRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AdminSummaryLogRepository.kt
@@ -1,0 +1,12 @@
+package com.secman.repository
+
+import com.secman.domain.AdminSummaryLog
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+
+/**
+ * Repository for AdminSummaryLog entity
+ * Feature: 070-admin-summary-email
+ */
+@Repository
+interface AdminSummaryLogRepository : JpaRepository<AdminSummaryLog, Long>

--- a/src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt
@@ -1,0 +1,263 @@
+package com.secman.service
+
+import com.secman.domain.AdminSummaryLog
+import com.secman.domain.ExecutionStatus
+import com.secman.domain.User
+import com.secman.repository.AdminSummaryLogRepository
+import com.secman.repository.AssetRepository
+import com.secman.repository.UserRepository
+import com.secman.repository.VulnerabilityRepository
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Service for sending admin summary emails with system statistics.
+ * Feature: 070-admin-summary-email
+ */
+@Singleton
+class AdminSummaryService(
+    private val userRepository: UserRepository,
+    private val vulnerabilityRepository: VulnerabilityRepository,
+    private val assetRepository: AssetRepository,
+    private val adminSummaryLogRepository: AdminSummaryLogRepository,
+    private val emailService: EmailService
+) {
+    private val logger = LoggerFactory.getLogger(AdminSummaryService::class.java)
+
+    /**
+     * System statistics data class
+     */
+    data class SystemStatistics(
+        val userCount: Long,
+        val vulnerabilityCount: Long,
+        val assetCount: Long
+    )
+
+    /**
+     * Result of admin summary email execution
+     */
+    data class AdminSummaryResult(
+        val recipientCount: Int,
+        val emailsSent: Int,
+        val emailsFailed: Int,
+        val status: ExecutionStatus,
+        val recipients: List<String>,
+        val failedRecipients: List<String>
+    )
+
+    /**
+     * Get current system statistics (user count, vulnerability count, asset count)
+     */
+    fun getSystemStatistics(): SystemStatistics {
+        val userCount = userRepository.count()
+        val vulnerabilityCount = vulnerabilityRepository.count()
+        val assetCount = assetRepository.count()
+
+        logger.debug("System statistics: users={}, vulnerabilities={}, assets={}",
+            userCount, vulnerabilityCount, assetCount)
+
+        return SystemStatistics(
+            userCount = userCount,
+            vulnerabilityCount = vulnerabilityCount,
+            assetCount = assetCount
+        )
+    }
+
+    /**
+     * Get all ADMIN users with valid email addresses
+     */
+    fun getAdminRecipients(): List<User> {
+        val adminUsers = userRepository.findByRolesContaining(User.Role.ADMIN)
+            .filter { it.email.isNotBlank() }
+
+        logger.debug("Found {} ADMIN users with valid email", adminUsers.size)
+        return adminUsers
+    }
+
+    /**
+     * Send summary email to all ADMIN users
+     *
+     * @param dryRun If true, skip actual email sending but return planned recipients
+     * @param verbose If true, log detailed per-recipient information
+     * @return Result containing counts and recipient details
+     */
+    fun sendSummaryEmail(dryRun: Boolean = false, verbose: Boolean = false): AdminSummaryResult {
+        val statistics = getSystemStatistics()
+        val recipients = getAdminRecipients()
+
+        if (recipients.isEmpty()) {
+            logger.warn("No ADMIN users with valid email found")
+            val result = AdminSummaryResult(
+                recipientCount = 0,
+                emailsSent = 0,
+                emailsFailed = 0,
+                status = ExecutionStatus.FAILURE,
+                recipients = emptyList(),
+                failedRecipients = emptyList()
+            )
+            logExecution(statistics, result, dryRun)
+            return result
+        }
+
+        if (dryRun) {
+            logger.info("Dry run mode - would send to {} recipients", recipients.size)
+            val result = AdminSummaryResult(
+                recipientCount = recipients.size,
+                emailsSent = 0,
+                emailsFailed = 0,
+                status = ExecutionStatus.DRY_RUN,
+                recipients = recipients.map { it.email },
+                failedRecipients = emptyList()
+            )
+            logExecution(statistics, result, dryRun)
+            return result
+        }
+
+        // Render email templates
+        val executionDate = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.systemDefault())
+            .format(Instant.now())
+
+        val htmlContent = renderHtmlTemplate(statistics, executionDate)
+        val textContent = renderTextTemplate(statistics, executionDate)
+
+        val sentRecipients = mutableListOf<String>()
+        val failedRecipients = mutableListOf<String>()
+
+        recipients.forEach { user ->
+            try {
+                if (verbose) {
+                    logger.info("Sending admin summary email to {}", user.email)
+                }
+
+                val success = emailService.sendEmail(
+                    to = user.email,
+                    subject = "SecMan Admin Summary",
+                    textContent = textContent,
+                    htmlContent = htmlContent
+                ).get()
+
+                if (success) {
+                    sentRecipients.add(user.email)
+                    if (verbose) {
+                        logger.info("Successfully sent to {}", user.email)
+                    }
+                } else {
+                    failedRecipients.add(user.email)
+                    logger.warn("Failed to send email to {}", user.email)
+                }
+            } catch (e: Exception) {
+                failedRecipients.add(user.email)
+                logger.error("Error sending email to {}: {}", user.email, e.message)
+            }
+        }
+
+        val status = when {
+            failedRecipients.isEmpty() -> ExecutionStatus.SUCCESS
+            sentRecipients.isEmpty() -> ExecutionStatus.FAILURE
+            else -> ExecutionStatus.PARTIAL_FAILURE
+        }
+
+        val result = AdminSummaryResult(
+            recipientCount = recipients.size,
+            emailsSent = sentRecipients.size,
+            emailsFailed = failedRecipients.size,
+            status = status,
+            recipients = sentRecipients,
+            failedRecipients = failedRecipients
+        )
+
+        logExecution(statistics, result, dryRun)
+        return result
+    }
+
+    /**
+     * Log execution to database for audit purposes
+     */
+    fun logExecution(statistics: SystemStatistics, result: AdminSummaryResult, dryRun: Boolean) {
+        try {
+            val log = AdminSummaryLog(
+                executedAt = Instant.now(),
+                recipientCount = result.recipientCount,
+                userCount = statistics.userCount,
+                vulnerabilityCount = statistics.vulnerabilityCount,
+                assetCount = statistics.assetCount,
+                emailsSent = result.emailsSent,
+                emailsFailed = result.emailsFailed,
+                status = result.status,
+                dryRun = dryRun
+            )
+            adminSummaryLogRepository.save(log)
+            logger.debug("Logged admin summary execution: status={}", result.status)
+        } catch (e: Exception) {
+            logger.error("Failed to log admin summary execution: {}", e.message)
+        }
+    }
+
+    /**
+     * Render HTML email template with statistics
+     */
+    private fun renderHtmlTemplate(statistics: SystemStatistics, executionDate: String): String {
+        return try {
+            val templateStream = javaClass.getResourceAsStream("/email-templates/admin-summary.html")
+                ?: throw IllegalStateException("HTML template not found")
+
+            templateStream.bufferedReader().use { reader ->
+                reader.readText()
+                    .replace("\${executionDate}", executionDate)
+                    .replace("\${userCount}", statistics.userCount.toString())
+                    .replace("\${vulnerabilityCount}", statistics.vulnerabilityCount.toString())
+                    .replace("\${assetCount}", statistics.assetCount.toString())
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to render HTML template: {}", e.message)
+            // Fallback simple HTML
+            """
+            <html>
+            <body>
+                <h1>SecMan Admin Summary</h1>
+                <p>Generated on: $executionDate</p>
+                <ul>
+                    <li>Total Users: ${statistics.userCount}</li>
+                    <li>Total Vulnerabilities: ${statistics.vulnerabilityCount}</li>
+                    <li>Total Assets: ${statistics.assetCount}</li>
+                </ul>
+            </body>
+            </html>
+            """.trimIndent()
+        }
+    }
+
+    /**
+     * Render plain text email template with statistics
+     */
+    private fun renderTextTemplate(statistics: SystemStatistics, executionDate: String): String {
+        return try {
+            val templateStream = javaClass.getResourceAsStream("/email-templates/admin-summary.txt")
+                ?: throw IllegalStateException("Text template not found")
+
+            templateStream.bufferedReader().use { reader ->
+                reader.readText()
+                    .replace("\${executionDate}", executionDate)
+                    .replace("\${userCount}", statistics.userCount.toString())
+                    .replace("\${vulnerabilityCount}", statistics.vulnerabilityCount.toString())
+                    .replace("\${assetCount}", statistics.assetCount.toString())
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to render text template: {}", e.message)
+            // Fallback simple text
+            """
+            SecMan Admin Summary
+            ====================
+            Generated on: $executionDate
+
+            Total Users: ${statistics.userCount}
+            Total Vulnerabilities: ${statistics.vulnerabilityCount}
+            Total Assets: ${statistics.assetCount}
+            """.trimIndent()
+        }
+    }
+}

--- a/src/backendng/src/main/resources/email-templates/admin-summary.html
+++ b/src/backendng/src/main/resources/email-templates/admin-summary.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SecMan Admin Summary</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background-color: #0d6efd;
+            color: white;
+            padding: 20px;
+            text-align: center;
+            border-radius: 5px 5px 0 0;
+        }
+        .content {
+            background-color: #f8f9fa;
+            padding: 20px;
+            border-radius: 0 0 5px 5px;
+        }
+        .stats-box {
+            background-color: white;
+            border-radius: 5px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        .stat-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 12px 0;
+            border-bottom: 1px solid #e9ecef;
+        }
+        .stat-item:last-child {
+            border-bottom: none;
+        }
+        .stat-label {
+            font-weight: bold;
+            color: #495057;
+        }
+        .stat-value {
+            font-size: 1.2em;
+            color: #0d6efd;
+            font-weight: bold;
+        }
+        .info-box {
+            background-color: #cfe2ff;
+            border-left: 4px solid #0d6efd;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .footer {
+            text-align: center;
+            color: #6c757d;
+            font-size: 12px;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #ddd;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SecMan Admin Summary</h1>
+    </div>
+
+    <div class="content">
+        <p>Hello Administrator,</p>
+
+        <div class="info-box">
+            <strong>System Statistics Report</strong><br>
+            Generated on: ${executionDate}
+        </div>
+
+        <div class="stats-box">
+            <h3 style="margin-top: 0;">Current System Statistics</h3>
+
+            <div class="stat-item">
+                <span class="stat-label">Total Users</span>
+                <span class="stat-value">${userCount}</span>
+            </div>
+
+            <div class="stat-item">
+                <span class="stat-label">Total Vulnerabilities</span>
+                <span class="stat-value">${vulnerabilityCount}</span>
+            </div>
+
+            <div class="stat-item">
+                <span class="stat-label">Total Assets</span>
+                <span class="stat-value">${assetCount}</span>
+            </div>
+        </div>
+
+        <p>This is an automated summary of your SecMan instance. Review these statistics regularly to ensure your security posture remains strong.</p>
+    </div>
+
+    <div class="footer">
+        <p>This is an automated notification from the Security Management System.</p>
+        <p>Please do not reply to this email.</p>
+    </div>
+</body>
+</html>

--- a/src/backendng/src/main/resources/email-templates/admin-summary.txt
+++ b/src/backendng/src/main/resources/email-templates/admin-summary.txt
@@ -1,0 +1,21 @@
+SECMAN ADMIN SUMMARY
+====================
+
+Hello Administrator,
+
+SYSTEM STATISTICS REPORT
+------------------------
+Generated on: ${executionDate}
+
+CURRENT SYSTEM STATISTICS
+-------------------------
+Total Users:           ${userCount}
+Total Vulnerabilities: ${vulnerabilityCount}
+Total Assets:          ${assetCount}
+
+This is an automated summary of your SecMan instance. Review these
+statistics regularly to ensure your security posture remains strong.
+
+---
+This is an automated notification from the Security Management System.
+Please do not reply to this email.

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -9,6 +9,7 @@ import com.secman.cli.commands.ManageUserMappingsCommand
 import com.secman.cli.commands.ManageWorkgroupsCommand
 import com.secman.cli.commands.MonitorCommand
 import com.secman.cli.commands.QueryCommand
+import com.secman.cli.commands.SendAdminSummaryCommand
 import com.secman.cli.commands.SendNotificationsCommand
 import com.secman.cli.commands.ServersCommand
 import io.micronaut.configuration.picocli.PicocliRunner
@@ -236,6 +237,15 @@ class SecmanCli {
                 }
                 0
             }
+            args[0] == "send-admin-summary" -> {
+                // Use Picocli with Micronaut DI for send-admin-summary command
+                // Feature: 070-admin-summary-email
+                val subArgs = args.drop(1).toTypedArray()
+                ApplicationContext.run().use { ctx ->
+                    PicocliRunner.run(SendAdminSummaryCommand::class.java, ctx, *subArgs)
+                }
+                0
+            }
             else -> {
                 System.err.println("Unknown command: ${args[0]}")
                 showHelp()
@@ -256,6 +266,7 @@ class SecmanCli {
               monitor                Continuously monitor for HIGH/CRITICAL vulnerabilities
               config                 Configure CrowdStrike API credentials
               send-notifications     Send email notifications for outdated assets (Feature 035)
+              send-admin-summary     Send system statistics summary email to ADMIN users (Feature 070)
               manage-user-mappings   Manage user mappings for domains and AWS accounts (Feature 049)
               manage-workgroups      Manage workgroup asset assignments (list, assign, remove)
               add-vulnerability      Add or update a vulnerability for an asset (Feature 052)
@@ -336,6 +347,10 @@ class SecmanCli {
               --username <user>        Backend username with ADMIN role (or set SECMAN_USERNAME env var)
               --password <pass>        Backend password (or set SECMAN_PASSWORD env var)
               --verbose                Enable verbose output
+
+            Send Admin Summary Options (Feature 070):
+              --dry-run                Preview planned recipients without sending emails
+              --verbose, -v            Detailed logging (show per-recipient status)
 
             Environment Variables:
               SECMAN_USERNAME          Backend username for authentication
@@ -456,6 +471,13 @@ class SecmanCli {
               secman delete-all-requirements --confirm --verbose
               secman delete-all-requirements --confirm --backend-url http://test-server:8080
               secman delete-all-requirements --help
+
+              # Send admin summary email (Feature 070)
+              secman send-admin-summary
+              secman send-admin-summary --dry-run
+              secman send-admin-summary --verbose
+              secman send-admin-summary --dry-run --verbose
+              secman send-admin-summary --help
 
             For more information, visit: https://github.com/schmalle/secman
         """.trimIndent())

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
@@ -1,0 +1,133 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.AdminSummaryCliService
+import com.secman.domain.ExecutionStatus
+import picocli.CommandLine.*
+import jakarta.inject.Singleton
+
+/**
+ * CLI command to send admin summary email to all ADMIN users.
+ * Feature: 070-admin-summary-email
+ *
+ * Usage:
+ *   ./bin/secman send-admin-summary
+ *   ./bin/secman send-admin-summary --dry-run
+ *   ./bin/secman send-admin-summary --verbose
+ *   ./bin/secman send-admin-summary --dry-run --verbose
+ */
+@Singleton
+@Command(
+    name = "send-admin-summary",
+    description = ["Send system statistics summary email to all ADMIN users"],
+    mixinStandardHelpOptions = true
+)
+class SendAdminSummaryCommand : Runnable {
+
+    @Option(
+        names = ["--dry-run"],
+        description = ["Preview planned recipients without sending emails"]
+    )
+    var dryRun: Boolean = false
+
+    @Option(
+        names = ["--verbose", "-v"],
+        description = ["Detailed logging (show per-recipient status)"]
+    )
+    var verbose: Boolean = false
+
+    @Spec
+    lateinit var spec: Model.CommandSpec
+
+    lateinit var adminSummaryCliService: AdminSummaryCliService
+
+    override fun run() {
+        try {
+            println("=" .repeat(60))
+            println("SecMan Admin Summary Email")
+            println("=" .repeat(60))
+            println()
+
+            if (dryRun) {
+                println("DRY-RUN MODE: No emails will be sent")
+                println()
+            }
+
+            // Gather and display statistics
+            val statistics = adminSummaryCliService.getStatistics()
+            if (dryRun) {
+                println("Statistics to be sent:")
+            } else {
+                println("Gathering statistics...")
+            }
+            println("   Users: ${statistics.userCount}")
+            println("   Vulnerabilities: ${statistics.vulnerabilityCount}")
+            println("   Assets: ${statistics.assetCount}")
+            println()
+
+            // Execute send
+            val result = adminSummaryCliService.execute(dryRun, verbose)
+
+            if (dryRun) {
+                println("Would send to ${result.recipientCount} ADMIN users:")
+                result.recipients.forEach { email ->
+                    println("   - $email")
+                }
+            } else {
+                println("Sending to ${result.recipientCount} ADMIN users...")
+                if (verbose) {
+                    result.recipients.forEach { email ->
+                        println("   SUCCESS $email")
+                    }
+                    result.failedRecipients.forEach { email ->
+                        println("   FAILED $email")
+                    }
+                }
+            }
+
+            println()
+            println("=" .repeat(60))
+            println("Summary")
+            println("=" .repeat(60))
+            println("Recipients: ${result.recipientCount}")
+            println("Emails sent: ${result.emailsSent}")
+            println("Failures: ${result.emailsFailed}")
+            println()
+
+            when (result.status) {
+                ExecutionStatus.SUCCESS -> {
+                    println("Admin summary email sent successfully")
+                }
+                ExecutionStatus.DRY_RUN -> {
+                    println("Dry run complete - no emails sent")
+                }
+                ExecutionStatus.PARTIAL_FAILURE -> {
+                    println("Admin summary email completed with some failures")
+                    if (verbose && result.failedRecipients.isNotEmpty()) {
+                        println()
+                        println("Failed recipients:")
+                        result.failedRecipients.forEach { println("   - $it") }
+                    }
+                }
+                ExecutionStatus.FAILURE -> {
+                    println("Admin summary email failed")
+                    if (result.recipientCount == 0) {
+                        println("No ADMIN users with valid email found")
+                    }
+                }
+            }
+
+            // Exit with appropriate code
+            if (result.status == ExecutionStatus.FAILURE ||
+                result.status == ExecutionStatus.PARTIAL_FAILURE) {
+                System.exit(1)
+            }
+
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            System.exit(1)
+        }
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/service/AdminSummaryCliService.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/service/AdminSummaryCliService.kt
@@ -1,0 +1,52 @@
+package com.secman.cli.service
+
+import com.secman.service.AdminSummaryService
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * CLI-specific service that bridges CLI command to backend AdminSummaryService.
+ * Feature: 070-admin-summary-email
+ */
+@Singleton
+class AdminSummaryCliService(
+    private val adminSummaryService: AdminSummaryService
+) {
+    private val logger = LoggerFactory.getLogger(AdminSummaryCliService::class.java)
+
+    /**
+     * Execute admin summary email send
+     *
+     * @param dryRun If true, preview without sending emails
+     * @param verbose If true, log detailed per-recipient information
+     * @return Result from AdminSummaryService
+     */
+    fun execute(dryRun: Boolean, verbose: Boolean): AdminSummaryService.AdminSummaryResult {
+        if (verbose) {
+            logger.info("Starting admin summary email process (dry-run: {})", dryRun)
+        }
+
+        val result = adminSummaryService.sendSummaryEmail(dryRun, verbose)
+
+        if (verbose) {
+            logger.info("Admin summary complete: sent={}, failed={}, status={}",
+                result.emailsSent, result.emailsFailed, result.status)
+        }
+
+        return result
+    }
+
+    /**
+     * Get system statistics for display
+     */
+    fun getStatistics(): AdminSummaryService.SystemStatistics {
+        return adminSummaryService.getSystemStatistics()
+    }
+
+    /**
+     * Get list of ADMIN recipients
+     */
+    fun getRecipients(): List<String> {
+        return adminSummaryService.getAdminRecipients().map { it.email }
+    }
+}


### PR DESCRIPTION
Implements the admin summary email feature (feature 070) with a new CLI command `send-admin-summary` to email system statistics to all ADMIN users. Adds backend service, execution log entity, repository, email templates (HTML and text), CLI service, and command registration. Updates documentation and integrates execution logging for audit purposes.