### PR TITLE
Enhance admin summary email with link and top 10 stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing `requirement`, `requirement_snapshot`, `releases` tables) (066-requirement-versioning)
 - Kotlin 2.3.0 / Java 25 + Micronaut 4.10, PicoCLI (CLI framework), Jakarta Mail (email) (070-admin-summary-email)
 - MariaDB 11.4 (existing database) (070-admin-summary-email)
+- MariaDB 11.4 (read-only queries for statistics) (069-enhanced-admin-summary)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/specs/069-enhanced-admin-summary/checklists/requirements.md
+++ b/specs/069-enhanced-admin-summary/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Enhanced Admin Summary Email
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions section documents that the backend base URL serves as the frontend URL (shared domain in production).
+- No [NEEDS CLARIFICATION] markers needed — the feature description is specific and the existing codebase provides clear patterns to follow.

--- a/specs/069-enhanced-admin-summary/data-model.md
+++ b/specs/069-enhanced-admin-summary/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Enhanced Admin Summary Email
+
+**Feature**: 069-enhanced-admin-summary
+**Date**: 2026-01-28
+
+## Extended Entities
+
+### SystemStatistics (modified)
+
+The existing `SystemStatistics` data class in `AdminSummaryService` is extended with three new fields. No database schema changes — all data is derived from existing tables via read-only queries.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| userCount | Long | Total registered users (existing) |
+| vulnerabilityCount | Long | Total active vulnerabilities (existing) |
+| assetCount | Long | Total tracked assets (existing) |
+| **vulnerabilityStatisticsUrl** | **String** | Constructed URL: `{baseUrl}/vulnerability-statistics` (new) |
+| **topProducts** | **List\<ProductSummary\>** | Top 10 products by vulnerability count (new) |
+| **topServers** | **List\<ServerSummary\>** | Top 10 servers by vulnerability count (new) |
+
+### ProductSummary (new, inner data class)
+
+Simplified projection of `MostVulnerableProductDto` for email display.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | String | Product name |
+| vulnerabilityCount | Long | Total vulnerabilities affecting this product |
+
+### ServerSummary (new, inner data class)
+
+Simplified projection of `TopAssetByVulnerabilitiesDto` for email display.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | String | Server/asset name |
+| vulnerabilityCount | Long | Total vulnerabilities on this server |
+
+## Data Flow
+
+```
+VulnerabilityStatisticsService (existing queries, admin-level unfiltered)
+  ├── getMostVulnerableProducts() → MostVulnerableProductDto
+  │     → map to ProductSummary (name, count only)
+  └── getTopAssetsByVulnerabilities() → TopAssetByVulnerabilitiesDto
+        → map to ServerSummary (name, count only)
+
+AppConfig.backend.baseUrl (existing config)
+  → concatenate with "/vulnerability-statistics"
+
+AdminSummaryService.getSystemStatistics()
+  → returns extended SystemStatistics with all fields populated
+  → passed to template rendering methods
+  → template variables: ${vulnerabilityStatisticsUrl}, ${topProductsHtml}, ${topServersHtml}, etc.
+```
+
+## No Schema Changes
+
+This feature adds no new database tables, columns, or indexes. All data is derived from existing entities:
+- `vulnerability` table (for product/server counts)
+- `asset` table (for server names)
+- `users` table (for admin recipients — unchanged)

--- a/specs/069-enhanced-admin-summary/plan.md
+++ b/specs/069-enhanced-admin-summary/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Enhanced Admin Summary Email
+
+**Branch**: `069-enhanced-admin-summary` | **Date**: 2026-01-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/069-enhanced-admin-summary/spec.md`
+
+## Summary
+
+Extend the admin summary email (Feature 070) to include:
+1. A clickable link to the vulnerability statistics page using the configured backend base URL
+2. Top 10 most affected products (name + vulnerability count)
+3. Top 10 most affected servers (name + vulnerability count)
+
+Changes are backend-only: extend `SystemStatistics` data class, update `AdminSummaryService` to gather top-10 data from `VulnerabilityStatisticsService`, update both HTML and plain-text email templates, and update CLI output for dry-run preview.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA, PicoCLI (CLI)
+**Storage**: MariaDB 11.4 (read-only queries for statistics)
+**Testing**: JUnit 5, Mockk (user-requested only per constitution)
+**Target Platform**: Linux server (backend), CLI tool
+**Project Type**: Web application (backend + CLI, no frontend changes)
+**Performance Goals**: Email generation should complete within existing timeouts (30s read timeout)
+**Constraints**: Top-10 queries must use existing repository methods; no new database tables or schema changes
+**Scale/Scope**: Extends 3 existing files (service, 2 templates), updates 1 CLI service; ~150 lines of changes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | No user input handling; read-only statistics; email sent to ADMIN-only recipients |
+| III. API-First | PASS | No new API endpoints; internal service method extension only |
+| IV. User-Requested Testing | PASS | No test tasks included unless user requests them |
+| V. RBAC | PASS | Admin summary uses system-wide unfiltered statistics (all recipients are ADMIN) |
+| VI. Schema Evolution | PASS | No database schema changes; read-only queries on existing tables |
+
+No violations. All gates pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/069-enhanced-admin-summary/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - no new APIs)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/src/main/kotlin/com/secman/
+├── service/
+│   └── AdminSummaryService.kt          # Extend SystemStatistics, add top-10 data gathering
+├── config/
+│   └── AppConfig.kt                    # Already has backend.baseUrl (no changes needed)
+└── resources/email-templates/
+    ├── admin-summary.html              # Add link button, top-10 tables
+    └── admin-summary.txt               # Add link URL, top-10 ASCII tables
+
+src/cli/src/main/kotlin/com/secman/cli/
+├── service/
+│   └── AdminSummaryCliService.kt       # Update to pass through new statistics
+└── commands/
+    └── SendAdminSummaryCommand.kt      # Update dry-run output to show top-10 data
+```
+
+**Structure Decision**: Backend-only changes in existing files. No new files needed. The feature extends the existing admin summary email infrastructure (Feature 070).
+
+## Complexity Tracking
+
+No violations to justify.

--- a/specs/069-enhanced-admin-summary/quickstart.md
+++ b/specs/069-enhanced-admin-summary/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Enhanced Admin Summary Email
+
+**Feature**: 069-enhanced-admin-summary
+**Date**: 2026-01-28
+
+## Prerequisites
+
+- Kotlin/Java backend builds successfully: `./gradlew build`
+- CLI shadow JAR built: `./gradlew :cli:shadowJar`
+- MariaDB running with vulnerability data populated
+
+## Files to Modify
+
+1. **`src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`**
+   - Extend `SystemStatistics` data class with `vulnerabilityStatisticsUrl`, `topProducts`, `topServers`
+   - Add `ProductSummary` and `ServerSummary` inner data classes
+   - Inject `AppConfig` and `VulnerabilityStatisticsService`
+   - Update `getSystemStatistics()` to gather top-10 data
+   - Update `renderHtmlTemplate()` and `renderTextTemplate()` with new template variables
+
+2. **`src/backendng/src/main/resources/email-templates/admin-summary.html`**
+   - Add call-to-action button linking to vulnerability statistics page
+   - Add HTML table for top 10 most affected products
+   - Add HTML table for top 10 most affected servers
+   - Handle empty state with "No vulnerability data available" message
+
+3. **`src/backendng/src/main/resources/email-templates/admin-summary.txt`**
+   - Add vulnerability statistics URL as plain text
+   - Add ASCII-formatted top 10 products list
+   - Add ASCII-formatted top 10 servers list
+   - Handle empty state message
+
+4. **`src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt`**
+   - Update dry-run and verbose output to display top-10 data and the link URL
+
+## Verification
+
+```bash
+# Build the project
+./gradlew build
+
+# Build CLI JAR
+./gradlew :cli:shadowJar
+
+# Test with dry-run (no emails sent)
+./bin/secmanng send-admin-summary --dry-run --verbose
+
+# Expected output should now include:
+# - Vulnerability Statistics URL
+# - Top 10 Most Affected Products (name + count)
+# - Top 10 Most Affected Servers (name + count)
+```
+
+## Implementation Order
+
+1. Extend `SystemStatistics` and add data classes (service layer)
+2. Inject dependencies and update `getSystemStatistics()` method
+3. Update HTML template with link button and top-10 tables
+4. Update plain-text template with link URL and top-10 lists
+5. Update template rendering methods with new variable replacements
+6. Update CLI command output for dry-run preview
+7. Build and verify with `./gradlew build`
+8. Test end-to-end with `./bin/secmanng send-admin-summary --dry-run --verbose`

--- a/specs/069-enhanced-admin-summary/research.md
+++ b/specs/069-enhanced-admin-summary/research.md
@@ -1,0 +1,44 @@
+# Research: Enhanced Admin Summary Email
+
+**Feature**: 069-enhanced-admin-summary
+**Date**: 2026-01-28
+
+## R1: Base URL Configuration for Email Link
+
+**Decision**: Use `AppConfig.backend.baseUrl` injected via `@ConfigurationProperties("app")`
+
+**Rationale**: The `AppConfig` already provides `backend.baseUrl` from the `BACKEND_BASE_URL` environment variable (default: `https://localhost:8080`, production: `https://secman.covestro.net`). The backend and frontend share the same domain in production, so this URL is correct for constructing the link to `/vulnerability-statistics`.
+
+**Alternatives considered**:
+- Use `AppConfig.frontend.baseUrl` — rejected because the frontend URL (`FRONTEND_URL`) defaults to `http://localhost:4321` and is intended for dev-only CORS configuration, not for user-facing links.
+- Hardcode the URL — rejected for obvious inflexibility.
+
+## R2: Gathering Top-10 Data Without Authentication Context
+
+**Decision**: Create new overloaded methods in `AdminSummaryService` that query `VulnerabilityStatisticsService` data without the `Authentication` parameter, using direct repository queries for admin-level (unfiltered) access.
+
+**Rationale**: The existing `getMostVulnerableProducts(authentication, domain)` and `getTopAssetsByVulnerabilities(authentication, domain)` methods require an `Authentication` object for RBAC filtering. The admin summary email runs from a CLI context (no HTTP authentication). Since all recipients are ADMIN users and the email should reflect system-wide statistics, the service should query the vulnerability data directly without RBAC filtering.
+
+**Alternatives considered**:
+- Create a synthetic `Authentication` object with ADMIN role — adds complexity and violates clean separation between CLI and HTTP concerns.
+- Add `authentication: Authentication? = null` optional parameter to existing methods — changes existing API surface and risk of accidental unfiltered access from controllers.
+
+## R3: Template Variable Strategy for Lists
+
+**Decision**: Use simple string replacement with pre-rendered HTML/text blocks for the top-10 lists. Generate the list HTML/text in Kotlin code before passing to the template.
+
+**Rationale**: The existing template rendering uses `String.replace("${var}", value)` for simple scalar values. For the top-10 lists, generate the complete HTML table rows / ASCII text lines in Kotlin and inject them as a single template variable (e.g., `${topProductsHtml}`, `${topServersHtml}`, `${topProductsText}`, `${topServersText}`).
+
+**Alternatives considered**:
+- Use a template engine (Thymeleaf, Freemarker) — over-engineered for this use case; would require adding a new dependency and refactoring all existing templates.
+- Embed loop logic in templates — not supported by the current simple replacement approach.
+
+## R4: Email Link Placement and Styling
+
+**Decision**: Place the vulnerability statistics link as a prominent call-to-action button between the existing statistics summary and the new top-10 sections.
+
+**Rationale**: Placing the link after the summary statistics and before the detailed top-10 lists creates a natural reading flow: overview → action → details. The HTML version uses a styled button; the plain-text version shows the full URL.
+
+**Alternatives considered**:
+- Place at the top of the email — interrupts the header/date context.
+- Place at the bottom — may be missed if the email is long.

--- a/specs/069-enhanced-admin-summary/spec.md
+++ b/specs/069-enhanced-admin-summary/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Enhanced Admin Summary Email
+
+**Feature Branch**: `069-enhanced-admin-summary`
+**Created**: 2026-01-28
+**Status**: Draft
+**Input**: User description: "Extend the admin summary email by a link to the domain of secman (stored in backend) + /vulnerability-statistics, so that a user can directly click on it. Also add in the email the top 10 most affected products and servers."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Clickable Link to Vulnerability Statistics (Priority: P1)
+
+As an admin user receiving the summary email, I want a clickable link that takes me directly to the vulnerability statistics page in secman, so that I can quickly review the current security posture without manually navigating to the application.
+
+**Why this priority**: This is the simplest change and provides immediate navigational value. The link uses the existing backend-configured domain concatenated with `/vulnerability-statistics`, requiring minimal data gathering.
+
+**Independent Test**: Can be fully tested by sending a summary email (or dry-run preview) and verifying the link URL is correct and clickable, pointing to the vulnerability statistics page.
+
+**Acceptance Scenarios**:
+
+1. **Given** the admin summary email is sent, **When** the admin opens the email, **Then** the email contains a prominently displayed clickable link to `{configured-base-url}/vulnerability-statistics`.
+2. **Given** the backend base URL is configured as `https://secman.covestro.net`, **When** the email is rendered, **Then** the link points to `https://secman.covestro.net/vulnerability-statistics`.
+3. **Given** the admin clicks the link in the email, **When** the browser opens, **Then** the user is taken to the vulnerability statistics page (login may be required if not already authenticated).
+4. **Given** the email is viewed in a plain-text email client, **When** the admin reads the email, **Then** the full URL is displayed as readable text.
+
+---
+
+### User Story 2 - Top 10 Most Affected Products in Email (Priority: P2)
+
+As an admin user, I want to see the top 10 most affected products listed in the summary email, so that I can immediately identify which software products have the most vulnerabilities without logging into the application.
+
+**Why this priority**: Products are a key organizational concern for security management. Showing the top 10 most vulnerable products gives admins an at-a-glance understanding of where the greatest product-level risk lies.
+
+**Independent Test**: Can be tested by sending a summary email with known vulnerability data and verifying the top 10 products are listed with their vulnerability counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** vulnerabilities exist across multiple products, **When** the admin summary email is sent, **Then** the email lists the top 10 products sorted by total vulnerability count (descending).
+2. **Given** each product in the top 10 list, **When** the admin reads the email, **Then** each entry shows the product name and total vulnerability count.
+3. **Given** fewer than 10 products have vulnerabilities, **When** the email is sent, **Then** only the available products are listed (no empty rows or placeholders).
+4. **Given** no vulnerability data exists, **When** the email is sent, **Then** the products section displays a message indicating no vulnerability data is available.
+
+---
+
+### User Story 3 - Top 10 Most Affected Servers in Email (Priority: P3)
+
+As an admin user, I want to see the top 10 most affected servers (assets) listed in the summary email, so that I can immediately identify which servers require the most urgent attention.
+
+**Why this priority**: Server-level visibility complements the product view and helps admins prioritize remediation efforts on specific infrastructure. This builds on the same data-gathering pattern as the products story.
+
+**Independent Test**: Can be tested by sending a summary email with known vulnerability data and verifying the top 10 servers are listed with their vulnerability counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** vulnerabilities exist across multiple assets, **When** the admin summary email is sent, **Then** the email lists the top 10 servers/assets sorted by total vulnerability count (descending).
+2. **Given** each server in the top 10 list, **When** the admin reads the email, **Then** each entry shows the server name and total vulnerability count.
+3. **Given** fewer than 10 servers have vulnerabilities, **When** the email is sent, **Then** only the available servers are listed.
+4. **Given** no vulnerability data exists, **When** the email is sent, **Then** the servers section displays a message indicating no vulnerability data is available.
+
+---
+
+### Edge Cases
+
+- What happens when the backend base URL is not configured or empty? The link section should still render but use a sensible fallback (e.g., omit the link or show a placeholder message).
+- What happens when there are zero vulnerabilities in the system? The top 10 sections should show a "No vulnerability data available" message instead of empty tables.
+- What happens when the email is viewed in a plain-text email client? The link should appear as a full URL, and the top 10 lists should be formatted as readable ASCII-aligned text.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The summary email MUST include a clickable link to the vulnerability statistics page, constructed from the configured backend base URL and the path `/vulnerability-statistics`.
+- **FR-002**: The summary email MUST include a "Top 10 Most Affected Products" section listing products sorted by total vulnerability count in descending order.
+- **FR-003**: The summary email MUST include a "Top 10 Most Affected Servers" section listing assets/servers sorted by total vulnerability count in descending order.
+- **FR-004**: Each product entry MUST display the product name and total vulnerability count.
+- **FR-005**: Each server entry MUST display the server name and total vulnerability count.
+- **FR-006**: Both top 10 lists MUST gracefully handle fewer than 10 entries by showing only available data.
+- **FR-007**: Both top 10 lists MUST show a "No vulnerability data available" message when no data exists.
+- **FR-008**: The link and top 10 data MUST appear in both HTML and plain-text email formats.
+- **FR-009**: The top 10 data MUST reflect system-wide statistics (admin-level access, unfiltered by workgroup or domain).
+- **FR-010**: The vulnerability statistics link MUST be visually prominent in the email (e.g., styled as a button or highlighted link in the HTML version).
+
+### Key Entities
+
+- **SystemStatistics** (extended): The existing statistics data structure, extended to include top products, top servers, and the vulnerability statistics URL.
+- **Product Entry**: A product name paired with its total vulnerability count.
+- **Server Entry**: A server/asset name paired with its total vulnerability count.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Admin recipients can navigate from the email to the vulnerability statistics page in a single click.
+- **SC-002**: The top 10 most affected products are accurately displayed, matching the data shown on the vulnerability statistics page.
+- **SC-003**: The top 10 most affected servers are accurately displayed, matching the data shown on the vulnerability statistics page.
+- **SC-004**: Both HTML and plain-text email versions render all new content correctly.
+
+## Assumptions
+
+- The backend base URL configured via `app.backend.base-url` (environment variable `BACKEND_BASE_URL`) is the correct URL for linking to the frontend vulnerability statistics page. This is consistent with current production deployment where backend and frontend share the same domain.
+- The admin summary email uses admin-level (unfiltered) access when gathering top 10 data, since all recipients are ADMIN users.
+- The existing vulnerability statistics service methods provide the required data for the top 10 lists.
+- The top 10 lists show only the product/server name and total vulnerability count to keep the email concise. Severity breakdowns are available on the full statistics page via the link.

--- a/specs/069-enhanced-admin-summary/tasks.md
+++ b/specs/069-enhanced-admin-summary/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Enhanced Admin Summary Email
+
+**Input**: Design documents from `/specs/069-enhanced-admin-summary/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Not requested. No test tasks included per constitution Principle IV.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend service**: `src/backendng/src/main/kotlin/com/secman/service/`
+- **Backend config**: `src/backendng/src/main/kotlin/com/secman/config/`
+- **Email templates**: `src/backendng/src/main/resources/email-templates/`
+- **CLI commands**: `src/cli/src/main/kotlin/com/secman/cli/commands/`
+- **CLI service**: `src/cli/src/main/kotlin/com/secman/cli/service/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Extend the data model and inject dependencies needed by all user stories
+
+- [x] T001 Extend `SystemStatistics` data class with `vulnerabilityStatisticsUrl: String`, `topProducts: List<ProductSummary>`, `topServers: List<ServerSummary>` fields and add `ProductSummary` and `ServerSummary` inner data classes in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+- [x] T002 Inject `AppConfig` and `VulnerabilityStatisticsService` into `AdminSummaryService` constructor in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+- [x] T003 Add admin-level (no-auth) methods to gather top-10 products and top-10 servers data in `AdminSummaryService`, querying `VulnerabilityStatisticsService` repositories directly without `Authentication` parameter, and update `getSystemStatistics()` to populate all new fields in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+
+**Checkpoint**: `SystemStatistics` now contains the vulnerability statistics URL, top 10 products, and top 10 servers. Build should compile: `./gradlew build`
+
+---
+
+## Phase 2: User Story 1 - Clickable Link to Vulnerability Statistics (Priority: P1) 🎯 MVP
+
+**Goal**: Add a clickable link to the vulnerability statistics page in the admin summary email
+
+**Independent Test**: Send email with `./bin/secmanng send-admin-summary --dry-run` and verify the URL `{base-url}/vulnerability-statistics` appears in output
+
+### Implementation for User Story 1
+
+- [x] T004 [P] [US1] Add a call-to-action button/link section with `${vulnerabilityStatisticsUrl}` placeholder to the HTML email template, placed between the existing statistics summary and the end of content, styled as a prominent button (blue background, white text) in `src/backendng/src/main/resources/email-templates/admin-summary.html`
+- [x] T005 [P] [US1] Add a vulnerability statistics URL line with `${vulnerabilityStatisticsUrl}` placeholder to the plain-text email template, placed after the existing statistics section in `src/backendng/src/main/resources/email-templates/admin-summary.txt`
+- [x] T006 [US1] Update `renderHtmlTemplate()` and `renderTextTemplate()` methods to replace `${vulnerabilityStatisticsUrl}` with the actual URL from `SystemStatistics` in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+- [x] T007 [US1] Update `SendAdminSummaryCommand.run()` to print the vulnerability statistics URL in dry-run and verbose output in `src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt`
+
+**Checkpoint**: Email contains clickable link to vulnerability statistics page. Verify with `./gradlew build && ./bin/secmanng send-admin-summary --dry-run`
+
+---
+
+## Phase 3: User Story 2 - Top 10 Most Affected Products (Priority: P2)
+
+**Goal**: Add a top 10 most affected products section to the admin summary email
+
+**Independent Test**: Send email with `./bin/secmanng send-admin-summary --dry-run --verbose` and verify top 10 products list appears
+
+### Implementation for User Story 2
+
+- [x] T008 [P] [US2] Add a "Top 10 Most Affected Products" HTML table section with `${topProductsHtml}` placeholder to the HTML email template, placed after the call-to-action button, with empty-state message "No vulnerability data available" support in `src/backendng/src/main/resources/email-templates/admin-summary.html`
+- [x] T009 [P] [US2] Add a "Top 10 Most Affected Products" ASCII-formatted section with `${topProductsText}` placeholder to the plain-text email template in `src/backendng/src/main/resources/email-templates/admin-summary.txt`
+- [x] T010 [US2] Add `renderTopProductsHtml(products: List<ProductSummary>): String` and `renderTopProductsText(products: List<ProductSummary>): String` helper methods that generate the pre-rendered HTML table rows / ASCII lines, handling empty list with "No vulnerability data available" message, and wire into `renderHtmlTemplate()` and `renderTextTemplate()` in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+- [x] T011 [US2] Update `SendAdminSummaryCommand.run()` to print top 10 products (name + count) in dry-run and verbose output in `src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt`
+
+**Checkpoint**: Email contains top 10 products section. Verify with `./gradlew build && ./bin/secmanng send-admin-summary --dry-run --verbose`
+
+---
+
+## Phase 4: User Story 3 - Top 10 Most Affected Servers (Priority: P3)
+
+**Goal**: Add a top 10 most affected servers section to the admin summary email
+
+**Independent Test**: Send email with `./bin/secmanng send-admin-summary --dry-run --verbose` and verify top 10 servers list appears
+
+### Implementation for User Story 3
+
+- [x] T012 [P] [US3] Add a "Top 10 Most Affected Servers" HTML table section with `${topServersHtml}` placeholder to the HTML email template, placed after the products section, with empty-state message support in `src/backendng/src/main/resources/email-templates/admin-summary.html`
+- [x] T013 [P] [US3] Add a "Top 10 Most Affected Servers" ASCII-formatted section with `${topServersText}` placeholder to the plain-text email template in `src/backendng/src/main/resources/email-templates/admin-summary.txt`
+- [x] T014 [US3] Add `renderTopServersHtml(servers: List<ServerSummary>): String` and `renderTopServersText(servers: List<ServerSummary>): String` helper methods that generate the pre-rendered HTML table rows / ASCII lines, handling empty list with "No vulnerability data available" message, and wire into `renderHtmlTemplate()` and `renderTextTemplate()` in `src/backendng/src/main/kotlin/com/secman/service/AdminSummaryService.kt`
+- [x] T015 [US3] Update `SendAdminSummaryCommand.run()` to print top 10 servers (name + count) in dry-run and verbose output in `src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt`
+
+**Checkpoint**: Email contains top 10 servers section. Verify with `./gradlew build && ./bin/secmanng send-admin-summary --dry-run --verbose`
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and documentation
+
+- [x] T016 Run full build verification with `./gradlew build` to ensure no compilation errors or test regressions
+- [x] T017 Run end-to-end dry-run verification with `./bin/secmanng send-admin-summary --dry-run --verbose` and confirm all three new sections (link, products, servers) appear correctly
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately. T001 → T002 → T003 (sequential, same file)
+- **User Story 1 (Phase 2)**: Depends on Setup (Phase 1) completion
+- **User Story 2 (Phase 3)**: Depends on Setup (Phase 1) completion. Can run in parallel with US1 (different template sections)
+- **User Story 3 (Phase 4)**: Depends on Setup (Phase 1) completion. Can run in parallel with US1/US2 (different template sections)
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Setup — no dependencies on other stories
+- **User Story 2 (P2)**: Can start after Setup — no dependencies on US1 (different template sections and render methods)
+- **User Story 3 (P3)**: Can start after Setup — no dependencies on US1/US2 (different template sections and render methods)
+
+### Within Each User Story
+
+- Template changes (HTML + TXT) can run in parallel [P] (different files)
+- Service rendering methods depend on template placeholders being defined
+- CLI output updates depend on service methods being available
+
+### Parallel Opportunities
+
+- T004 and T005 can run in parallel (HTML vs TXT template, US1)
+- T008 and T009 can run in parallel (HTML vs TXT template, US2)
+- T012 and T013 can run in parallel (HTML vs TXT template, US3)
+- After Phase 1, all three user stories can be implemented in parallel if desired
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch template tasks in parallel (different files):
+Task: "T008 [P] [US2] Add top products HTML table in admin-summary.html"
+Task: "T009 [P] [US2] Add top products text section in admin-summary.txt"
+
+# Then sequentially:
+Task: "T010 [US2] Add render helpers and wire into template rendering"
+Task: "T011 [US2] Update CLI command output"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T003)
+2. Complete Phase 2: User Story 1 (T004-T007)
+3. **STOP and VALIDATE**: Build + dry-run to confirm link appears
+4. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup → Foundation ready
+2. Add User Story 1 (link) → Test → Deploy (MVP!)
+3. Add User Story 2 (products) → Test → Deploy
+4. Add User Story 3 (servers) → Test → Deploy
+5. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- All changes are in existing files — no new files created
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Commit after each phase checkpoint
+- The `AdminSummaryService.kt` file is modified across multiple phases — execute phase tasks sequentially within each phase
+- Template placeholders must be added before the corresponding render method updates

--- a/specs/185-enhanced-admin-summary/spec.md
+++ b/specs/185-enhanced-admin-summary/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/src/backendng/src/main/resources/email-templates/admin-summary.html
+++ b/src/backendng/src/main/resources/email-templates/admin-summary.html
@@ -97,6 +97,20 @@
             </div>
         </div>
 
+        <div style="text-align: center; margin: 25px 0;">
+            <a href="${vulnerabilityStatisticsUrl}" style="display: inline-block; background-color: #0d6efd; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold; font-size: 1.1em;">View Vulnerability Statistics</a>
+        </div>
+
+        <div class="stats-box">
+            <h3 style="margin-top: 0;">Top 10 Most Affected Products</h3>
+            ${topProductsHtml}
+        </div>
+
+        <div class="stats-box">
+            <h3 style="margin-top: 0;">Top 10 Most Affected Servers</h3>
+            ${topServersHtml}
+        </div>
+
         <p>This is an automated summary of your SecMan instance. Review these statistics regularly to ensure your security posture remains strong.</p>
     </div>
 

--- a/src/backendng/src/main/resources/email-templates/admin-summary.txt
+++ b/src/backendng/src/main/resources/email-templates/admin-summary.txt
@@ -13,6 +13,18 @@ Total Users:           ${userCount}
 Total Vulnerabilities: ${vulnerabilityCount}
 Total Assets:          ${assetCount}
 
+VIEW VULNERABILITY STATISTICS
+------------------------------
+${vulnerabilityStatisticsUrl}
+
+TOP 10 MOST AFFECTED PRODUCTS
+------------------------------
+${topProductsText}
+
+TOP 10 MOST AFFECTED SERVERS
+-----------------------------
+${topServersText}
+
 This is an automated summary of your SecMan instance. Review these
 statistics regularly to ensure your security posture remains strong.
 

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendAdminSummaryCommand.kt
@@ -66,6 +66,25 @@ class SendAdminSummaryCommand : Runnable {
             println("   Assets: ${statistics.assetCount}")
             println()
 
+            println("Vulnerability Statistics: ${statistics.vulnerabilityStatisticsUrl}")
+            println()
+
+            if (statistics.topProducts.isNotEmpty()) {
+                println("Top 10 Most Affected Products:")
+                statistics.topProducts.forEach { product ->
+                    println("   ${product.name}: ${product.vulnerabilityCount}")
+                }
+                println()
+            }
+
+            if (statistics.topServers.isNotEmpty()) {
+                println("Top 10 Most Affected Servers:")
+                statistics.topServers.forEach { server ->
+                    println("   ${server.name}: ${server.vulnerabilityCount}")
+                }
+                println()
+            }
+
             // Execute send
             val result = adminSummaryCliService.execute(dryRun, verbose)
 


### PR DESCRIPTION
Extends the admin summary email to include a clickable link to the vulnerability statistics page, and adds sections for the top 10 most affected products and servers. Updates the SystemStatistics data class, service logic, email templates (HTML and plain text), and CLI output to support these new features. No database schema changes; all data is derived from existing tables.