### PR TITLE
Rewrite SES email sending to use SMTP instead of SES API

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CLAUDE.md" beforeDir="false" afterPath="$PROJECT_DIR$/CLAUDE.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -81,37 +84,37 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_MARK_IGNORED_FILES_AS_EXCLUDED&quot;: &quot;true&quot;,
-    &quot;Gradle.OAuthServiceTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.backendng [build].executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;SHELLCHECK.PATH&quot;: &quot;/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/flake/sources/misc/secman&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Global Libraries&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.12135923&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.409894&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/flake/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_MARK_IGNORED_FILES_AS_EXCLUDED": "true",
+    "Gradle.OAuthServiceTest.executor": "Run",
+    "Gradle.backendng [build].executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.2/plugins/Shell Script/shellcheck",
+    "git-widget-placeholder": "071-ses-smtp-rewrite",
+    "junie.onboarding.icon.badge.shown": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/flake/sources/misc/secman",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Global Libraries",
+    "project.structure.proportion": "0.12135923",
+    "project.structure.side.proportion": "0.409894",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "ts.external.directory.path": "/Users/flake/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;mariadb&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "mariadb"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scripts/install/db" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - Kotlin 2.3.0 / Java 25 + Micronaut 4.10, PicoCLI (CLI framework), Jakarta Mail (email) (070-admin-summary-email)
 - MariaDB 11.4 (existing database) (070-admin-summary-email)
 - MariaDB 11.4 (read-only queries for statistics) (069-enhanced-admin-summary)
+- Kotlin 2.3.0 / Java 25 + Micronaut 4.10, Jakarta Mail (angus-mail 2.0.5), Hibernate JPA (071-ses-smtp-rewrite)
+- MariaDB 11.4 (existing `email_configs` table) (071-ses-smtp-rewrite)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/specs/071-ses-smtp-rewrite/checklists/requirements.md
+++ b/specs/071-ses-smtp-rewrite/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: SES SMTP Rewrite
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references AWS SES SMTP endpoint patterns and port 587 — these are protocol-level details, not implementation details, and are necessary to define the feature behavior.
+- Assumptions document the SMTP credential generation process and migration path from existing SES configurations.

--- a/specs/071-ses-smtp-rewrite/data-model.md
+++ b/specs/071-ses-smtp-rewrite/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: SES SMTP Rewrite
+
+**Feature**: 071-ses-smtp-rewrite
+**Date**: 2026-01-29
+
+## Modified Entities
+
+### EmailConfig (modified behavior, no schema change)
+
+The database schema remains unchanged. The semantic meaning of the SES fields changes:
+
+| Column | Before (SES API) | After (SES SMTP) |
+|--------|-------------------|-------------------|
+| `ses_access_key` | AWS IAM access key ID | SES SMTP username |
+| `ses_secret_key` | AWS IAM secret access key | SES SMTP password |
+| `ses_region` | AWS region for SES API endpoint | AWS region (used to derive SMTP host: `email-smtp.{region}.amazonaws.com`) |
+
+All three columns remain encrypted via `EncryptedStringConverter`. No migration script needed.
+
+### EmailConfig Method Changes
+
+| Method | Before | After |
+|--------|--------|-------|
+| `hasAuthentication()` (SES case) | Checks `sesAccessKey` + `sesSecretKey` not blank | Same check — fields now hold SMTP credentials |
+| `validate()` (SES case) | Validates `sesAccessKey`, `sesSecretKey`, `sesRegion` | Same validation — field names unchanged |
+| New: `getSesSmtpHost()` | N/A | Returns `email-smtp.{sesRegion}.amazonaws.com` |
+| New: `getSesSmtpProperties()` | N/A | Returns Jakarta Mail properties map for SES SMTP (host, port 587, STARTTLS, auth) |
+
+## No Schema Changes
+
+This feature modifies zero database columns, tables, or indexes. The existing `email_configs` table structure is fully compatible. The only change is the interpretation of `ses_access_key` and `ses_secret_key` from IAM credentials to SMTP credentials.
+
+## Removed Dependencies
+
+| Dependency | Version | Purpose | Replacement |
+|-----------|---------|---------|-------------|
+| `software.amazon.awssdk:ses` | 2.41.8 | AWS SES API client | Jakarta Mail SMTP (already present) |
+| `software.amazon.awssdk:auth` | 2.41.8 | AWS credential handling | Standard SMTP authentication |

--- a/specs/071-ses-smtp-rewrite/plan.md
+++ b/specs/071-ses-smtp-rewrite/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: SES SMTP Rewrite
+
+**Branch**: `071-ses-smtp-rewrite` | **Date**: 2026-01-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/071-ses-smtp-rewrite/spec.md`
+
+## Summary
+
+Replace AWS SES API-based email sending (`ses:SendRawEmail` via AWS SDK) with standard SMTP sending to the SES SMTP endpoint. This eliminates the IAM `ses:SendRawEmail` permission requirement. The `SesEmailService` class is rewritten to use Jakarta Mail SMTP (already available via `angus-mail`) instead of the AWS SES SDK. The `EmailConfig` entity's SES fields (`sesAccessKey`/`sesSecretKey`) are repurposed as SMTP username/password. The AWS SES SDK dependencies are removed from the build.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25
+**Primary Dependencies**: Micronaut 4.10, Jakarta Mail (angus-mail 2.0.5), Hibernate JPA
+**Storage**: MariaDB 11.4 (existing `email_configs` table)
+**Testing**: JUnit 5, Mockk (user-requested only per constitution)
+**Target Platform**: Linux server (backend)
+**Project Type**: Web application (backend only, no frontend changes)
+**Performance Goals**: Email send latency unchanged (existing 10s connection timeout, 30s read timeout)
+**Constraints**: Must maintain backward compatibility with existing SES database configurations; must not break standard SMTP provider path
+**Scale/Scope**: Rewrite 1 service class, modify 2 existing files, remove 1 Gradle dependency; ~100 lines changed
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | SMTP credentials remain encrypted via `EncryptedStringConverter`; STARTTLS enforced; header injection prevention preserved |
+| III. API-First | PASS | No new API endpoints; existing email config REST endpoints unchanged |
+| IV. User-Requested Testing | PASS | No test tasks included unless user requests them |
+| V. RBAC | PASS | Email configuration management remains ADMIN-only |
+| VI. Schema Evolution | PASS | No database schema changes; existing `ses_access_key`/`ses_secret_key` columns repurposed as SMTP credentials |
+
+No violations. All gates pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/071-ses-smtp-rewrite/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # N/A - no new APIs
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/
+├── build.gradle.kts                                          # Remove AWS SES SDK dependencies
+├── src/main/kotlin/com/secman/
+│   ├── service/
+│   │   ├── SesEmailService.kt                                # Rewrite: SES API → SMTP via Jakarta Mail
+│   │   ├── EmailSender.kt                                    # Update: sendEmailViaSes() uses SMTP path
+│   │   └── EmailProviderConfigService.kt                     # Update: verifySesConfig() validates SMTP connectivity
+│   └── domain/
+│       └── EmailConfig.kt                                    # Update: SES config derives SMTP host from region
+```
+
+**Structure Decision**: Backend-only changes in existing files. No new files needed. The feature rewrites the SES sending path to use SMTP instead of the AWS SES SDK.
+
+## Complexity Tracking
+
+No violations to justify.

--- a/specs/071-ses-smtp-rewrite/quickstart.md
+++ b/specs/071-ses-smtp-rewrite/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: SES SMTP Rewrite
+
+**Feature**: 071-ses-smtp-rewrite
+**Date**: 2026-01-29
+
+## Prerequisites
+
+- Kotlin/Java backend builds successfully: `./gradlew build`
+- Access to AWS SES console to generate SMTP credentials
+
+## Files to Modify
+
+1. **`src/backendng/build.gradle.kts`**
+   - Remove `software.amazon.awssdk:ses:2.41.8` dependency
+   - Remove `software.amazon.awssdk:auth:2.41.8` dependency
+
+2. **`src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt`**
+   - Remove all AWS SDK imports
+   - Rewrite `sendEmail()` to use Jakarta Mail SMTP with properties derived from `EmailConfig`
+   - Rewrite `sendTestEmail()` to use SMTP path
+   - Rewrite `verifyConfiguration()` to use `Transport.connect()` instead of SES API
+   - Keep `sanitizeEmailHeader()` unchanged
+
+3. **`src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt`**
+   - Add `getSesSmtpHost(): String` method (returns `email-smtp.{sesRegion}.amazonaws.com`)
+   - Add `getSesSmtpProperties(): Map<String, String>` method (returns Jakarta Mail properties for port 587, STARTTLS)
+
+4. **`src/backendng/src/main/kotlin/com/secman/service/EmailSender.kt`**
+   - No changes needed — `sendEmailViaSes()` already delegates to `SesEmailService.sendEmail()` which will now use SMTP internally
+
+5. **`src/backendng/src/main/kotlin/com/secman/service/EmailProviderConfigService.kt`**
+   - Update `verifySesConfig()` to call the rewritten `verifyConfiguration()` method (should work unchanged since the interface is the same)
+
+## Verification
+
+```bash
+# Build the project (confirms AWS SDK removal compiles cleanly)
+./gradlew build
+
+# Verify no AWS SES SDK imports remain
+grep -r "software.amazon.awssdk" src/backendng/src/main/kotlin/ || echo "No AWS SDK imports found (expected)"
+
+# Test email send via admin UI or CLI
+# Configure SES with SMTP credentials in the admin email config page
+# Send a test email to verify SMTP-based delivery
+```
+
+## Implementation Order
+
+1. Add `getSesSmtpHost()` and `getSesSmtpProperties()` to `EmailConfig.kt`
+2. Rewrite `SesEmailService.kt` to use Jakarta Mail SMTP
+3. Remove AWS SES SDK dependencies from `build.gradle.kts`
+4. Build and verify with `./gradlew build`
+5. Test email sending via the admin UI test email feature
+
+## Generating SES SMTP Credentials
+
+To use this feature, admins must generate SES SMTP credentials:
+
+1. Go to AWS Console → SES → SMTP Settings
+2. Click "Create SMTP credentials"
+3. This creates an IAM user and generates SMTP username + password
+4. Enter these as the SES access key and secret key in the secman email configuration

--- a/specs/071-ses-smtp-rewrite/research.md
+++ b/specs/071-ses-smtp-rewrite/research.md
@@ -1,0 +1,53 @@
+# Research: SES SMTP Rewrite
+
+**Feature**: 071-ses-smtp-rewrite
+**Date**: 2026-01-29
+
+## R1: AWS SES SMTP Endpoint Pattern
+
+**Decision**: Use `email-smtp.{region}.amazonaws.com` as the SMTP host, derived from the existing `sesRegion` field in `EmailConfig`.
+
+**Rationale**: AWS SES provides SMTP endpoints for every supported region following a consistent naming pattern. The existing `sesRegion` field (e.g., `eu-central-1`) maps directly to the SMTP hostname. Port 587 with STARTTLS is the recommended configuration.
+
+**Alternatives considered**:
+- Require manual SMTP host entry — rejected because the region-to-host mapping is deterministic and eliminating manual entry reduces misconfiguration.
+- Support port 465 (SMTPS) — not needed; port 587 with STARTTLS is the AWS-recommended approach and matches the existing SMTP provider behavior.
+
+## R2: Credential Reuse Strategy
+
+**Decision**: Repurpose the existing `sesAccessKey` and `sesSecretKey` database columns to store SES SMTP credentials (username and password).
+
+**Rationale**: AWS SES SMTP credentials are a username/password pair generated from IAM credentials via the AWS console. They are not the same as IAM access keys, but they serve the same purpose (authentication) and fit into the same storage model. The existing `EncryptedStringConverter` handles encryption. No schema migration is needed — the columns already exist and are encrypted.
+
+**Alternatives considered**:
+- Add new `ses_smtp_username`/`ses_smtp_password` columns — rejected because it would require a database migration for no functional benefit; the existing columns serve the identical purpose.
+- Add SMTP fields to the existing `smtpUsername`/`smtpPassword` columns and set `smtpHost` automatically — rejected because it would conflate two different provider types and make the domain model ambiguous.
+
+## R3: SesEmailService Rewrite Approach
+
+**Decision**: Rewrite `SesEmailService.sendEmail()` to use Jakarta Mail's `Transport.send()` with SMTP properties derived from `EmailConfig.sesRegion`, reusing the same MIME message construction pattern already used in `EmailSender.sendEmailInternalWithDbConfig()`.
+
+**Rationale**: The existing SMTP sending code in `EmailSender` already handles Jakarta Mail session creation, MIME multipart message construction, and transport. The SES SMTP path needs the same logic but with a different host/credentials source. Rather than duplicating code, `SesEmailService` constructs SMTP properties from the SES config fields and delegates to the same Jakarta Mail `Transport.send()` pattern.
+
+**Alternatives considered**:
+- Delete `SesEmailService` entirely and handle SES as a special SMTP case in `EmailSender` — this would simplify the code but removes the clean separation between provider-specific logic and routing. Keeping `SesEmailService` as a thin SMTP wrapper maintains the existing architecture.
+- Use Micronaut's email abstraction — adds unnecessary framework coupling; the direct Jakarta Mail approach is already established.
+
+## R4: AWS SDK Removal
+
+**Decision**: Remove `software.amazon.awssdk:ses:2.41.8` and `software.amazon.awssdk:auth:2.41.8` from `build.gradle.kts`.
+
+**Rationale**: With the SMTP rewrite, no AWS SDK classes are used. Removing the dependencies reduces the JAR size and eliminates transitive dependency risks. The SMTP approach uses only Jakarta Mail (`angus-mail:2.0.5`), which is already a project dependency.
+
+**Alternatives considered**:
+- Keep the dependencies for potential future use — rejected; YAGNI principle. They can be re-added if needed.
+
+## R5: Verify Configuration Without SES API
+
+**Decision**: Replace `SesEmailService.verifyConfiguration()` (which calls `GetAccountSendingEnabledRequest`) with an SMTP connection test using Jakarta Mail's `Transport.connect()`.
+
+**Rationale**: The current verification uses the SES API to check if account sending is enabled. With SMTP, the equivalent is attempting an SMTP connection and authentication handshake. A successful `Transport.connect()` confirms the credentials are valid and the SMTP endpoint is reachable. This is the same pattern used for standard SMTP config validation.
+
+**Alternatives considered**:
+- Remove verification entirely — rejected because admins need to validate their configuration before activating it.
+- Send a test email as the only verification — too intrusive; a connection test is sufficient for validation.

--- a/specs/071-ses-smtp-rewrite/spec.md
+++ b/specs/071-ses-smtp-rewrite/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: SES SMTP Rewrite
+
+**Feature Branch**: `071-ses-smtp-rewrite`
+**Created**: 2026-01-29
+**Status**: Draft
+**Input**: User description: "Rewrite the AWS SES Email send code to use SMTP instead of ses:SendRawEmail"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Send Emails via SMTP Instead of SES API (Priority: P1)
+
+As a system administrator, I want the email sending system to use standard SMTP protocol when configured with AWS SES, instead of the AWS SES API (`ses:SendRawEmail`), so that the IAM user only needs SMTP credentials and does not require the `ses:SendRawEmail` IAM permission.
+
+**Why this priority**: This is the core change. The current SES API-based sending fails with `554 Access denied` when the IAM user lacks `ses:SendRawEmail` permission. Switching to SMTP eliminates this IAM dependency entirely, using SMTP credentials (derived from IAM credentials) instead.
+
+**Independent Test**: Can be tested by configuring an AWS SES email configuration in the admin UI and sending a test email. The email should be delivered successfully without requiring `ses:SendRawEmail` IAM permission on the sending user.
+
+**Acceptance Scenarios**:
+
+1. **Given** an AWS SES email configuration is active, **When** the system sends an email, **Then** it uses the SMTP protocol (port 587 with STARTTLS) to connect to the SES SMTP endpoint instead of calling the SES API.
+2. **Given** the SES SMTP credentials are correctly configured, **When** a test email is sent, **Then** the email is delivered successfully.
+3. **Given** the SES configuration includes a region, **When** the system connects, **Then** it uses the correct regional SMTP endpoint (e.g., `email-smtp.eu-central-1.amazonaws.com` for eu-central-1).
+4. **Given** incorrect SMTP credentials, **When** the system attempts to send, **Then** a clear authentication error is returned.
+
+---
+
+### User Story 2 - Backward-Compatible Configuration (Priority: P2)
+
+As a system administrator, I want existing SES configurations stored in the database to continue working after the migration, so that no manual reconfiguration is required beyond providing SMTP credentials.
+
+**Why this priority**: Existing deployments have SES configurations in the database. The migration should reuse as much of the existing configuration as possible (region, from-email, from-name) while adding the new SMTP credential fields.
+
+**Independent Test**: Can be tested by verifying that an existing SES configuration in the database is still recognized and can be updated with SMTP credentials through the admin UI.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing SES configuration in the database, **When** the system loads it, **Then** the configuration is recognized and the admin can update it with SMTP credentials.
+2. **Given** an SES configuration with a region set, **When** the SMTP endpoint is derived, **Then** it maps to `email-smtp.{region}.amazonaws.com`.
+3. **Given** the admin updates the SES configuration with SMTP username and password, **When** the configuration is saved, **Then** the credentials are stored encrypted (same as existing credential storage).
+
+---
+
+### Edge Cases
+
+- What happens when the SES SMTP endpoint is unreachable? The system should return a connection error with the endpoint hostname, and retry logic should apply (same as existing retry behavior).
+- What happens when the configured region is invalid? The system should report a configuration validation error indicating the region is not recognized.
+- What happens when sending fails due to throttling? Standard SMTP error codes should be surfaced, and the retry mechanism should handle transient failures.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST send emails via SMTP protocol when an SES email provider is configured, instead of using the AWS SES API (`ses:SendRawEmail`).
+- **FR-002**: The system MUST derive the SES SMTP endpoint from the configured region using the pattern `email-smtp.{region}.amazonaws.com`.
+- **FR-003**: The system MUST use port 587 with STARTTLS for SES SMTP connections.
+- **FR-004**: The system MUST support SES SMTP credentials (username and password) stored in the email configuration, encrypted at rest.
+- **FR-005**: The system MUST reuse existing retry logic, timeout settings, and error handling for SMTP-based SES sending.
+- **FR-006**: The system MUST remove the dependency on the AWS SES SDK for email sending (the `ses:SendRawEmail` API call must no longer be used).
+- **FR-007**: The system MUST support sending test emails through the SES SMTP path to validate configuration.
+- **FR-008**: The system MUST log email send attempts and failures consistently, regardless of whether SMTP or SES SMTP is used.
+
+### Key Entities
+
+- **EmailConfig** (modified): The existing email configuration entity, where the SES provider path now uses SMTP credentials (username/password) instead of AWS access key/secret key, and derives the SMTP host from the region.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All emails sent via the SES provider path are delivered using SMTP, with zero calls to the AWS SES API.
+- **SC-002**: Email delivery success rate remains the same or improves compared to the SES API-based approach.
+- **SC-003**: No IAM `ses:SendRawEmail` permission is required for the email-sending user.
+- **SC-004**: Existing SES configurations can be migrated to SMTP-based sending with only credential updates (no full reconfiguration).
+
+## Assumptions
+
+- AWS SES SMTP credentials are distinct from AWS IAM access keys. The administrator will generate SMTP credentials from the AWS SES console (IAM user → SMTP credentials). These are a username and password pair.
+- The SES SMTP endpoint follows the standard AWS naming pattern: `email-smtp.{region}.amazonaws.com`.
+- The existing `sesAccessKey` and `sesSecretKey` fields in EmailConfig can be repurposed or replaced with SMTP username/password fields. The existing encrypted storage mechanism applies.
+- The AWS SES SDK dependency can be removed from the project since SES API calls will no longer be made for email sending.
+- All other email providers (standard SMTP) continue to work unchanged.

--- a/specs/071-ses-smtp-rewrite/tasks.md
+++ b/specs/071-ses-smtp-rewrite/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: SES SMTP Rewrite
+
+**Input**: Design documents from `/specs/071-ses-smtp-rewrite/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add SMTP helper methods to `EmailConfig` that both user stories depend on
+
+- [X] T001 [US1] Add `getSesSmtpHost()` method to `src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt` — returns `email-smtp.{sesRegion}.amazonaws.com`
+- [X] T002 [US1] Add `getSesSmtpProperties()` method to `src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt` — returns Jakarta Mail properties map (host, port 587, STARTTLS enabled, auth enabled)
+
+**Checkpoint**: EmailConfig now provides SMTP connection details derived from the SES region field
+
+---
+
+## Phase 2: User Story 1 — Send Emails via SMTP Instead of SES API (Priority: P1) 🎯 MVP
+
+**Goal**: Rewrite `SesEmailService` to send emails using Jakarta Mail SMTP instead of the AWS SES SDK `SendRawEmail` API
+
+**Independent Test**: Configure SES in admin UI with SMTP credentials, send a test email — email should be delivered via SMTP
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Rewrite `sendEmail()` in `src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt` — replace AWS SES `SendRawEmailRequest` with Jakarta Mail `Transport.send()` using SMTP properties from `EmailConfig.getSesSmtpProperties()` and credentials from `sesAccessKey`/`sesSecretKey`
+- [X] T004 [US1] Rewrite `sendTestEmail()` in `src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt` — use the new SMTP-based `sendEmail()` path instead of SES API
+- [X] T005 [US1] Rewrite `verifyConfiguration()` in `src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt` — replace `GetAccountSendingEnabledRequest` with Jakarta Mail `Transport.connect()` to validate SMTP credentials and endpoint reachability
+- [X] T006 [US1] Remove all AWS SDK imports from `src/backendng/src/main/kotlin/com/secman/service/SesEmailService.kt` — remove `software.amazon.awssdk.*` imports, replace with Jakarta Mail imports as needed
+- [X] T007 [US1] Remove AWS SES SDK dependencies from `src/backendng/build.gradle.kts` — remove `software.amazon.awssdk:ses:2.41.8` and `software.amazon.awssdk:auth:2.41.8`
+
+**Checkpoint**: SES email sending now uses SMTP. AWS SES SDK is fully removed. Build should compile cleanly.
+
+---
+
+## Phase 3: User Story 2 — Backward-Compatible Configuration (Priority: P2)
+
+**Goal**: Ensure existing SES configurations in the database continue to work and can be validated through the admin UI
+
+**Independent Test**: Load an existing SES configuration, update credentials, verify configuration via admin UI
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Verify `verifySesConfig()` in `src/backendng/src/main/kotlin/com/secman/service/EmailProviderConfigService.kt` works with the rewritten `SesEmailService.verifyConfiguration()` — the interface is unchanged, so this should work without code changes, but verify the call chain
+- [X] T009 [US2] Verify `sendEmailViaSes()` in `src/backendng/src/main/kotlin/com/secman/service/EmailSender.kt` delegates correctly to the rewritten `SesEmailService.sendEmail()` — no code changes expected, verify the call chain
+
+**Checkpoint**: Existing SES configurations load, validate, and send emails through the SMTP path without any manual reconfiguration beyond updating credentials.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Build verification and cleanup
+
+- [X] T010 Build project with `./gradlew build` — confirm no compilation errors after AWS SDK removal
+- [X] T011 Verify no AWS SES SDK imports remain with `grep -r "software.amazon.awssdk" src/backendng/src/main/kotlin/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (US1)**: Depends on Phase 1 (T001, T002) — `SesEmailService` needs `getSesSmtpHost()` and `getSesSmtpProperties()`
+- **Phase 3 (US2)**: Depends on Phase 2 — verification tasks require the rewritten service
+- **Phase 4 (Polish)**: Depends on Phase 2 and Phase 3
+
+### Within Phase 2
+
+- T003 depends on T001, T002 (needs SMTP properties)
+- T004 depends on T003 (reuses the new `sendEmail()`)
+- T005 can run in parallel with T004 (independent method)
+- T006 is done as part of T003–T005 (remove imports as methods are rewritten)
+- T007 should be done last in Phase 2 (removing deps before rewrite would break compilation)
+
+### Execution Order
+
+```
+T001, T002 → T003 → T004, T005 → T006 → T007 → T008, T009 → T010, T011
+```
+
+---
+
+## Notes
+
+- No new files are created — all changes are to existing files
+- No database schema changes — existing columns are repurposed
+- No frontend changes — admin UI fields remain the same
+- No test tasks included (per project constitution: tests only when explicitly requested)
+- `sanitizeEmailHeader()` in `SesEmailService.kt` must be preserved unchanged
+- The `EmailSender.sendEmailViaSes()` method should not need changes since it delegates to `SesEmailService.sendEmail()`

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -58,10 +58,6 @@ dependencies {
     implementation("io.micronaut.email:micronaut-email-javamail:2.11.0")
     implementation("org.eclipse.angus:angus-mail:2.0.5")
 
-    // Amazon SES
-    implementation("software.amazon.awssdk:ses:2.41.8")
-    implementation("software.amazon.awssdk:auth:2.41.8")
-
     // Email templates (Thymeleaf) - Feature 035
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")

--- a/src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/EmailConfig.kt
@@ -276,6 +276,34 @@ data class EmailConfig(
     }
 
     /**
+     * Get SES SMTP host derived from the configured SES region
+     * AWS SES SMTP endpoints follow the pattern: email-smtp.{region}.amazonaws.com
+     */
+    fun getSesSmtpHost(): String {
+        return "email-smtp.${sesRegion}.amazonaws.com"
+    }
+
+    /**
+     * Get SES SMTP configuration properties for Jakarta Mail
+     * Uses port 587 with STARTTLS as recommended by AWS
+     */
+    fun getSesSmtpProperties(): Map<String, String> {
+        val host = getSesSmtpHost()
+        return mapOf(
+            "mail.smtp.host" to host,
+            "mail.smtp.port" to "587",
+            "mail.smtp.auth" to "true",
+            "mail.smtp.starttls.enable" to "true",
+            "mail.smtp.starttls.required" to "true",
+            "mail.smtp.ssl.trust" to host,
+            "mail.smtp.ssl.protocols" to "TLSv1.2 TLSv1.3",
+            "mail.smtp.connectiontimeout" to "10000",
+            "mail.smtp.timeout" to "30000",
+            "mail.smtp.writetimeout" to "10000"
+        )
+    }
+
+    /**
      * Get IMAP configuration properties for JavaMail
      */
     fun getImapProperties(): Map<String, String>? {

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -61,6 +61,10 @@ class SecmanCli {
                             serversCommand.minDaysOpen = args[i + 1].toIntOrNull() ?: 30
                             i++
                         }
+                        args[i] == "--last-seen-days" && i + 1 < args.size -> {
+                            serversCommand.lastSeenDays = args[i + 1].toIntOrNull() ?: 0
+                            i++
+                        }
                         args[i] == "--limit" && i + 1 < args.size -> {
                             serversCommand.limit = args[i + 1].toIntOrNull() ?: 800
                             i++
@@ -280,6 +284,7 @@ class SecmanCli {
               --device-type <type>     Device type: SERVER, WORKSTATION, or ALL (default: SERVER)
               --severity <levels>      Severity filter (default: HIGH,CRITICAL)
               --min-days-open <num>    Minimum days open filter (default: 30)
+              --last-seen-days <num>   Only include devices seen within N days (default: 0 = all devices)
               --limit <num>            Page size for pagination (default: 800)
               --backend-url <url>      Backend API URL (default: http://localhost:8080)
               --save                   Save to database (requires --username and --password)

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt
@@ -52,6 +52,7 @@ class ServersCommand {
     var clientId: String? = null         // CrowdStrike client ID (optional override)
     var clientSecret: String? = null     // CrowdStrike client secret (optional override)
     var limit: Int = 800                 // Page size for pagination
+    var lastSeenDays: Int = 0            // Only include devices seen within N days (0 = all devices)
 
     /**
      * Execute the servers query command
@@ -72,8 +73,8 @@ class ServersCommand {
             System.out.println("Device type: ${parsedDeviceType.name}")
 
             if (verbose) {
-                log.info("Starting query with filters: deviceType={}, severity={}, minDaysOpen={}, hostnames={}",
-                    parsedDeviceType.name, severity, minDaysOpen, hostnames?.joinToString(",") ?: "ALL")
+                log.info("Starting query with filters: deviceType={}, severity={}, minDaysOpen={}, lastSeenDays={}, hostnames={}",
+                    parsedDeviceType.name, severity, minDaysOpen, lastSeenDays, hostnames?.joinToString(",") ?: "ALL")
             }
 
             // Load or override configuration
@@ -93,7 +94,7 @@ class ServersCommand {
             // Query CrowdStrike API with filters
             System.out.println("Querying CrowdStrike for ${parsedDeviceType.displayName()}...")
             if (verbose) {
-                System.out.println("Filters: device type=${parsedDeviceType.name}, severity=$severity, min days open=$minDaysOpen")
+                System.out.println("Filters: device type=${parsedDeviceType.name}, severity=$severity, min days open=$minDaysOpen, last seen days=${if (lastSeenDays > 0) lastSeenDays else "all"}")
                 if (hostnames != null) {
                     System.out.println("Hostnames: ${hostnames!!.joinToString(", ")}")
                 }
@@ -105,7 +106,8 @@ class ServersCommand {
                 severity = severity,
                 minDaysOpen = minDaysOpen,
                 config = config,
-                limit = limit
+                limit = limit,
+                lastSeenDays = lastSeenDays
             )
 
             System.out.println("Found ${response.vulnerabilities.size} vulnerabilities across ${parsedDeviceType.displayName()}")

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClient.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClient.kt
@@ -59,7 +59,8 @@ interface CrowdStrikeApiClient {
         severity: String = "HIGH,CRITICAL",
         minDaysOpen: Int = 30,
         config: FalconConfigDto,
-        limit: Int = 100
+        limit: Int = 100,
+        lastSeenDays: Int = 0
     ): CrowdStrikeQueryResponse
 
     /**


### PR DESCRIPTION
Replaces AWS SES API-based email sending with standard SMTP via Jakarta Mail, using SES SMTP credentials and endpoints derived from the configured region. Removes AWS SES SDK dependencies, updates EmailConfig with helper methods for SES SMTP, and rewrites SesEmailService to use SMTP for sending and verification. Also adds a 'last seen days' filter to CrowdStrike queries in the CLI and backend.