### PR TITLE
Add clickable CVE links with description popovers

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,15 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/bin/secman" beforeDir="false" afterPath="$PROJECT_DIR$/bin/secman" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/bin/secmanbackendsupport" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/bin/secmanng" beforeDir="false" afterPath="$PROJECT_DIR$/bin/secmanng" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli/src/main/kotlin/com/secman/cli/commands/ServersCommand.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/CrowdStrikeVulnerabilityDto.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/CrowdStrikeVulnerabilityDto.kt" afterDir="false" />
-    </list>
+    <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />

--- a/specs/072-cve-link-lookup/checklists/requirements.md
+++ b/specs/072-cve-link-lookup/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Clickable CVE Links with Description Lookup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- NVD API mentioned in Assumptions section as the chosen data source -- this is a business decision (which source to use), not an implementation detail
+- All 12 functional requirements are testable via the acceptance scenarios
+- No [NEEDS CLARIFICATION] markers -- all decisions have reasonable defaults documented in Assumptions

--- a/specs/072-cve-link-lookup/spec.md
+++ b/specs/072-cve-link-lookup/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Clickable CVE Links with Description Lookup
+
+**Feature Branch**: `072-cve-link-lookup`
+**Created**: 2026-01-30
+**Status**: Draft
+**Input**: User description: "in secman users can see CVE numbers, please ensure, that whereever a CVE number is shown the user can click on it and get a short description of the CVE. Use for this a reliable external datasource."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Click CVE to See Description (Priority: P1)
+
+A security analyst reviewing the vulnerability list wants to quickly understand what a CVE means without leaving secman. They hover over a CVE number (e.g., CVE-2024-1234) and a popover appears showing a short description of the vulnerability, its CVSS severity score, and a link to the full details on the National Vulnerability Database (NVD).
+
+**Why this priority**: This is the core feature. Without the description popover, the CVE numbers are opaque identifiers that force users to manually search external databases.
+
+**Independent Test**: Can be tested by hovering over any CVE ID in the Current Vulnerabilities table and verifying a popover with a description appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is viewing the Current Vulnerabilities table, **When** they hover over a CVE ID for more than 300ms, **Then** a popover appears showing: the CVE ID as header, a short English description (max 300 characters), and the CVSS score with severity badge.
+2. **Given** a user sees a CVE popover, **When** they click the CVE link, **Then** a new browser tab opens with the NVD detail page for that CVE.
+3. **Given** the external data source is unavailable, **When** a user hovers over a CVE ID, **Then** the popover shows a fallback message ("Unable to load CVE details. Click to view on NVD.") and clicking still opens the NVD page.
+
+---
+
+### User Story 2 - Consistent CVE Links Across All Views (Priority: P2)
+
+A user navigating between different secman views (vulnerability table, CrowdStrike lookup, asset details, exception requests, statistics) expects CVE numbers to behave the same everywhere -- always clickable, always showing the popover on hover.
+
+**Why this priority**: Consistency builds trust and reduces cognitive load. Users should not have to learn different interaction patterns depending on which page they are on.
+
+**Independent Test**: Navigate to each view that displays CVE IDs and verify the same clickable link + popover behavior appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** any page in secman that displays a CVE ID, **When** a user hovers over it, **Then** the same popover interaction is available as in the main vulnerability table.
+2. **Given** a CVE ID appears in the CrowdStrike Vulnerability Lookup results, **When** the user hovers over it, **Then** a description popover appears.
+3. **Given** a CVE ID appears in the Exception Approval Dashboard, **When** the user hovers over it, **Then** a description popover appears.
+
+---
+
+### User Story 3 - Fast Repeat Lookups (Priority: P3)
+
+A security analyst scrolling through a large vulnerability table encounters the same CVE ID multiple times (across different assets). After the first lookup, subsequent hovers over the same CVE should display the popover instantly without any loading delay.
+
+**Why this priority**: Performance directly impacts usability. A table with 500 rows might reference only 50 distinct CVEs -- caching prevents the system from making redundant requests.
+
+**Independent Test**: Hover over the same CVE ID twice in the same session and verify the second popover appears instantly without a loading spinner.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has already viewed the popover for CVE-2024-1234, **When** they hover over the same CVE ID again (on the same or different row), **Then** the popover appears instantly without showing a loading indicator.
+2. **Given** two users look up the same CVE within 24 hours, **When** the second user hovers over it, **Then** the server returns the cached description without contacting the external data source.
+
+---
+
+### Edge Cases
+
+- What happens when the CVE ID field is null or empty? The display shows a dash (`-`) with no link or hover behavior.
+- What happens when the CVE ID does not follow the standard format (e.g., a custom vulnerability ID like "CUSTOM-001")? The system displays it as plain text without a link or popover, since external databases only index standard CVE IDs.
+- What happens when the user's network is slow? The popover shows a loading spinner until data arrives (with a 5-second timeout), then falls back to the unavailable message.
+- What happens when the external data source is rate-limited? Cached descriptions continue to work. New lookups that fail are handled gracefully with the fallback message.
+- What happens when the user moves the mouse away before the popover loads? The popover request is effectively cancelled (the popover is hidden), preventing UI flicker.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display all CVE IDs as clickable links that open the NVD detail page in a new browser tab.
+- **FR-002**: System MUST show a popover with the CVE description when the user hovers over a CVE link for more than 300 milliseconds.
+- **FR-003**: The popover MUST display: the CVE ID, a short English description (truncated to 300 characters if longer), and the CVSS score with severity level when available.
+- **FR-004**: System MUST use a single reusable component for CVE display that is applied consistently across all views where CVE IDs appear (vulnerability tables, CrowdStrike lookup, asset details, exception workflows, statistics).
+- **FR-005**: System MUST fetch CVE descriptions from the NIST National Vulnerability Database (NVD) API as the external data source.
+- **FR-006**: System MUST cache CVE descriptions for at least 24 hours to reduce external API load and improve response times.
+- **FR-007**: System MUST degrade gracefully when the external data source is unavailable -- the CVE link remains clickable and the popover shows a fallback message.
+- **FR-008**: System MUST display null or empty CVE IDs as a plain dash (`-`) with no link or popover behavior.
+- **FR-009**: System MUST display non-standard vulnerability IDs (not matching CVE-YYYY-NNNNN format) as plain text without link or popover behavior.
+- **FR-010**: System MUST deduplicate concurrent requests for the same CVE ID so that multiple identical lookups result in only one external API call.
+- **FR-011**: System MUST show a loading indicator in the popover while the description is being fetched.
+- **FR-012**: System MUST cancel the popover display if the user moves the mouse away before the 300ms hover threshold is reached.
+
+### Key Entities
+
+- **CVE Description**: A cached representation of external CVE data. Key attributes: CVE ID, English description, CVSS severity level, CVSS numeric score, publication date. Sourced from NVD API. Cached with a 24-hour time-to-live.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every CVE ID displayed in the application is a clickable link that opens the NVD detail page.
+- **SC-002**: Users see a CVE description popover within 2 seconds of hovering (first lookup) and instantly for cached lookups.
+- **SC-003**: The feature works identically across all 7+ views that display CVE IDs.
+- **SC-004**: When the external data source is unavailable, the system continues to function with no errors visible to the user -- CVE links remain clickable and a clear fallback message is shown.
+- **SC-005**: Repeated lookups for the same CVE within a user session do not trigger additional network requests.
+
+## Assumptions
+
+- The NIST NVD API v2.0 (https://services.nvd.nist.gov/rest/json/cves/2.0/) is the chosen external data source. It is free, authoritative, and publicly accessible.
+- The public rate limit of 5 requests per 30 seconds is sufficient for normal usage when combined with caching. An optional API key can increase this to 50 requests per 30 seconds for production deployments.
+- CVE descriptions in English are sufficient (no internationalization needed for CVE data).
+- Only standard CVE IDs (format: CVE-YYYY-NNNNN+) are looked up. Custom or non-standard vulnerability identifiers are displayed as plain text.
+- The 300ms hover delay provides a good balance between responsiveness and avoiding unnecessary lookups from accidental mouse passes.

--- a/src/backendng/src/main/kotlin/com/secman/controller/CveLookupController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CveLookupController.kt
@@ -1,0 +1,52 @@
+package com.secman.controller
+
+import com.secman.dto.CveLookupDto
+import com.secman.service.CveLookupService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import org.slf4j.LoggerFactory
+
+/**
+ * REST controller for CVE lookup
+ *
+ * Proxies NVD API requests with caching to provide CVE descriptions
+ * for hover popovers in the frontend.
+ *
+ * Feature: 072-cve-link-lookup
+ */
+@Controller("/api/cve")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+class CveLookupController(
+    private val cveLookupService: CveLookupService
+) {
+    private val logger = LoggerFactory.getLogger(CveLookupController::class.java)
+
+    /**
+     * GET /api/cve/{cveId}
+     *
+     * Look up CVE details from NVD API (cached for 24h).
+     *
+     * @param cveId CVE identifier (e.g., "CVE-2023-12345")
+     * @return CVE details or 404 if not found
+     */
+    @Get("/{cveId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    fun lookupCve(cveId: String): HttpResponse<CveLookupDto> {
+        return try {
+            val result = cveLookupService.lookupCve(cveId)
+            if (result != null) {
+                HttpResponse.ok(result)
+            } else {
+                HttpResponse.notFound()
+            }
+        } catch (e: Exception) {
+            logger.error("Error looking up CVE: {}", cveId, e)
+            HttpResponse.serverError()
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/dto/CveLookupDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/CveLookupDto.kt
@@ -1,0 +1,18 @@
+package com.secman.dto
+
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Response DTO for CVE lookup from NVD API
+ *
+ * Feature: 072-cve-link-lookup
+ */
+@Serdeable
+data class CveLookupDto(
+    val cveId: String,
+    val description: String?,
+    val severity: String?,
+    val cvssScore: Double?,
+    val publishedDate: String?,
+    val references: List<String> = emptyList()
+)

--- a/src/backendng/src/main/kotlin/com/secman/service/CveLookupService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CveLookupService.kt
@@ -1,0 +1,203 @@
+package com.secman.service
+
+import com.secman.dto.CveLookupDto
+import io.micronaut.cache.annotation.Cacheable
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Service for looking up CVE details from NVD API v2.0
+ *
+ * Proxies requests to NVD to avoid CORS issues and centralize caching.
+ * Responses are cached for 24h via Micronaut's Caffeine cache.
+ *
+ * Feature: 072-cve-link-lookup
+ */
+@Singleton
+open class CveLookupService {
+
+    private val logger = LoggerFactory.getLogger(CveLookupService::class.java)
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+
+    private val cveIdPattern = Regex("^CVE-\\d{4}-\\d{4,}\$")
+
+    /**
+     * Look up CVE details from NVD API v2.0
+     *
+     * @param cveId CVE identifier (e.g., "CVE-2023-12345")
+     * @return CveLookupDto with CVE details, or null if not found or invalid
+     */
+    @Cacheable("cve_descriptions")
+    open fun lookupCve(cveId: String): CveLookupDto? {
+        if (!cveIdPattern.matches(cveId)) {
+            logger.debug("Invalid CVE ID format: {}", cveId)
+            return null
+        }
+
+        return try {
+            val url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=$cveId"
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", "application/json")
+                .GET()
+                .build()
+
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() != 200) {
+                logger.warn("NVD API returned status {} for CVE {}", response.statusCode(), cveId)
+                return null
+            }
+
+            parseNvdResponse(cveId, response.body())
+        } catch (e: Exception) {
+            logger.error("Error looking up CVE {}: {}", cveId, e.message)
+            null
+        }
+    }
+
+    private fun parseNvdResponse(cveId: String, responseBody: String): CveLookupDto? {
+        return try {
+            // Simple JSON parsing without Jackson dependency - parse NVD v2.0 response
+            val body = responseBody
+
+            // Extract description (English)
+            val description = extractEnglishDescription(body)
+
+            // Extract CVSS score and severity from v31 or v2
+            val cvssScore = extractCvssScore(body)
+            val severity = extractSeverity(body)
+
+            // Extract published date
+            val publishedDate = extractField(body, "published")
+
+            // Extract references (first 5)
+            val references = extractReferences(body)
+
+            CveLookupDto(
+                cveId = cveId,
+                description = description,
+                severity = severity,
+                cvssScore = cvssScore,
+                publishedDate = publishedDate,
+                references = references
+            )
+        } catch (e: Exception) {
+            logger.error("Error parsing NVD response for CVE {}: {}", cveId, e.message)
+            null
+        }
+    }
+
+    private fun extractEnglishDescription(json: String): String? {
+        // Find descriptions array and extract English description
+        val descriptionsIdx = json.indexOf("\"descriptions\"")
+        if (descriptionsIdx == -1) return null
+
+        // Find English description value
+        val langEnIdx = json.indexOf("\"lang\":\"en\"", descriptionsIdx)
+        if (langEnIdx == -1) return null
+
+        // Look for "value" near this lang entry (within the same object)
+        val valueIdx = json.indexOf("\"value\":\"", langEnIdx - 200)
+        if (valueIdx == -1 || valueIdx > langEnIdx + 200) {
+            // Try looking after lang
+            val valueAfterIdx = json.indexOf("\"value\":\"", langEnIdx)
+            if (valueAfterIdx == -1 || valueAfterIdx > langEnIdx + 200) return null
+            return extractJsonStringValue(json, valueAfterIdx)
+        }
+        return extractJsonStringValue(json, valueIdx)
+    }
+
+    private fun extractJsonStringValue(json: String, valueKeyIdx: Int): String? {
+        val valueStart = json.indexOf("\"value\":\"", valueKeyIdx)
+        if (valueStart == -1) return null
+        val contentStart = valueStart + "\"value\":\"".length
+        val contentEnd = findClosingQuote(json, contentStart)
+        if (contentEnd == -1) return null
+        return json.substring(contentStart, contentEnd).replace("\\\"", "\"").replace("\\n", " ")
+    }
+
+    private fun findClosingQuote(json: String, startIdx: Int): Int {
+        var i = startIdx
+        while (i < json.length) {
+            if (json[i] == '"' && (i == 0 || json[i - 1] != '\\')) {
+                return i
+            }
+            i++
+        }
+        return -1
+    }
+
+    private fun extractCvssScore(json: String): Double? {
+        // Try CVSS v3.1 first, then v3.0, then v2
+        for (key in listOf("\"cvssMetricV31\"", "\"cvssMetricV30\"", "\"cvssMetricV2\"")) {
+            val idx = json.indexOf(key)
+            if (idx != -1) {
+                val scoreIdx = json.indexOf("\"baseScore\":", idx)
+                if (scoreIdx != -1 && scoreIdx < idx + 500) {
+                    val numStart = scoreIdx + "\"baseScore\":".length
+                    val numEnd = json.indexOfAny(charArrayOf(',', '}', ' '), numStart)
+                    if (numEnd != -1) {
+                        return json.substring(numStart, numEnd).trim().toDoubleOrNull()
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun extractSeverity(json: String): String? {
+        // Try CVSS v3.1 first, then v3.0
+        for (key in listOf("\"cvssMetricV31\"", "\"cvssMetricV30\"")) {
+            val idx = json.indexOf(key)
+            if (idx != -1) {
+                val severityIdx = json.indexOf("\"baseSeverity\":\"", idx)
+                if (severityIdx != -1 && severityIdx < idx + 500) {
+                    val start = severityIdx + "\"baseSeverity\":\"".length
+                    val end = json.indexOf('"', start)
+                    if (end != -1) {
+                        return json.substring(start, end)
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun extractField(json: String, fieldName: String): String? {
+        val key = "\"$fieldName\":\""
+        val idx = json.indexOf(key)
+        if (idx == -1) return null
+        val start = idx + key.length
+        val end = json.indexOf('"', start)
+        if (end == -1) return null
+        return json.substring(start, end)
+    }
+
+    private fun extractReferences(json: String): List<String> {
+        val refs = mutableListOf<String>()
+        val refsIdx = json.indexOf("\"references\"")
+        if (refsIdx == -1) return refs
+
+        var searchFrom = refsIdx
+        while (refs.size < 5) {
+            val urlIdx = json.indexOf("\"url\":\"", searchFrom)
+            if (urlIdx == -1 || urlIdx > refsIdx + 5000) break
+            val start = urlIdx + "\"url\":\"".length
+            val end = json.indexOf('"', start)
+            if (end == -1) break
+            refs.add(json.substring(start, end))
+            searchFrom = end + 1
+        }
+        return refs
+    }
+}

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -119,6 +119,10 @@ micronaut:
     workgroup_memberships:
       maximum-size: 200
       expire-after-write: 10m
+    # CVE description cache (Feature: 072-cve-link-lookup)
+    cve_descriptions:
+      maximum-size: 5000
+      expire-after-write: 24h
     # MCP Access Control cache (Feature: 052-mcp-access-control)
     mcp_accessible_assets:
       maximum-size: 500

--- a/src/frontend/src/components/CrowdStrikeVulnerabilityLookup.tsx
+++ b/src/frontend/src/components/CrowdStrikeVulnerabilityLookup.tsx
@@ -31,6 +31,7 @@ import {
     getCacheIcon
 } from '../utils/cacheUtils';
 import { exportVulnerabilitiesToExcel } from '../utils/vulnerabilityExport';
+import CveLink from './CveLink';
 
 /**
  * AWS EC2 Instance ID validation regex
@@ -772,7 +773,7 @@ const CrowdStrikeVulnerabilityLookup: React.FC = () => {
                                                     {sortedVulnerabilities.map((vuln) => (
                                                         <tr key={vuln.id}>
                                                             <td>
-                                                                <code>{vuln.cveId || '-'}</code>
+                                                                <CveLink cveId={vuln.cveId} />
                                                             </td>
                                                             <td>
                                                                 <span className={`badge ${getSeverityBadgeClass(vuln.severity)}`}>

--- a/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
+++ b/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
@@ -27,6 +27,7 @@ import {
 } from '../services/vulnerabilityManagementService';
 import OverdueStatusBadge from './OverdueStatusBadge';
 import ExceptionRequestModal from './ExceptionRequestModal';
+import CveLink from './CveLink';
 import { isAdmin, hasRole } from '../utils/auth';
 
 const CurrentVulnerabilitiesTable: React.FC = () => {
@@ -645,7 +646,7 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
                                                         </td>
                                                         <td>{vuln.assetIp || '-'}</td>
                                                         <td>
-                                                            <code>{vuln.vulnerabilityId || '-'}</code>
+                                                            <CveLink cveId={vuln.vulnerabilityId} />
                                                         </td>
                                                         <td>
                                                             <span className={`badge ${getSeverityBadgeClass(vuln.cvssSeverity)}`}>

--- a/src/frontend/src/components/CveLink.tsx
+++ b/src/frontend/src/components/CveLink.tsx
@@ -1,0 +1,213 @@
+/**
+ * CveLink Component
+ *
+ * Renders a CVE ID as a clickable link to NVD.
+ * On hover (300ms delay), shows a popover with CVE description fetched from backend.
+ * Non-CVE IDs render as plain text.
+ *
+ * Feature: 072-cve-link-lookup
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { lookupCve, type CveLookupResult } from '../services/cveLookupService';
+
+interface CveLinkProps {
+  cveId: string | null | undefined;
+}
+
+const CVE_PATTERN = /^CVE-\d{4}-\d{4,}$/;
+
+const CveLink: React.FC<CveLinkProps> = ({ cveId }) => {
+  const [popoverData, setPopoverData] = useState<CveLookupResult | null>(null);
+  const [popoverVisible, setPopoverVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [popoverPosition, setPopoverPosition] = useState<'bottom' | 'top'>('bottom');
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  if (!cveId) {
+    return <span className="text-muted">-</span>;
+  }
+
+  const isCve = CVE_PATTERN.test(cveId);
+
+  if (!isCve) {
+    return <code>{cveId}</code>;
+  }
+
+  const nvdUrl = `https://nvd.nist.gov/vuln/detail/${cveId}`;
+
+  const showPopover = useCallback(async () => {
+    setPopoverVisible(true);
+
+    // Calculate position
+    if (linkRef.current) {
+      const rect = linkRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setPopoverPosition(spaceBelow < 200 ? 'top' : 'bottom');
+    }
+
+    if (popoverData) return; // Already loaded
+
+    setLoading(true);
+    const result = await lookupCve(cveId);
+    setPopoverData(result);
+    setLoading(false);
+  }, [cveId, popoverData]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    hoverTimerRef.current = setTimeout(showPopover, 300);
+  }, [showPopover]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    hideTimerRef.current = setTimeout(() => {
+      setPopoverVisible(false);
+    }, 200);
+  }, []);
+
+  const handlePopoverMouseEnter = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const handlePopoverMouseLeave = useCallback(() => {
+    hideTimerRef.current = setTimeout(() => {
+      setPopoverVisible(false);
+    }, 200);
+  }, []);
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    };
+  }, []);
+
+  const severityColor = (severity: string | null): string => {
+    switch (severity?.toUpperCase()) {
+      case 'CRITICAL': return '#dc3545';
+      case 'HIGH': return '#fd7e14';
+      case 'MEDIUM': return '#ffc107';
+      case 'LOW': return '#28a745';
+      default: return '#6c757d';
+    }
+  };
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-block' }}>
+      <a
+        ref={linkRef}
+        href={nvdUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          fontFamily: 'var(--bs-font-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace)',
+          fontSize: '0.875em',
+          textDecoration: 'none',
+          color: 'var(--bs-link-color, #0d6efd)',
+          cursor: 'pointer',
+        }}
+        title={`Open ${cveId} on NVD`}
+      >
+        {cveId}
+        <i className="bi bi-box-arrow-up-right ms-1" style={{ fontSize: '0.7em', opacity: 0.6 }}></i>
+      </a>
+
+      {popoverVisible && (
+        <div
+          ref={popoverRef}
+          onMouseEnter={handlePopoverMouseEnter}
+          onMouseLeave={handlePopoverMouseLeave}
+          style={{
+            position: 'absolute',
+            left: 0,
+            [popoverPosition === 'bottom' ? 'top' : 'bottom']: '100%',
+            marginTop: popoverPosition === 'bottom' ? '4px' : undefined,
+            marginBottom: popoverPosition === 'top' ? '4px' : undefined,
+            zIndex: 1050,
+            width: '360px',
+            maxWidth: '90vw',
+            backgroundColor: 'var(--bs-body-bg, #fff)',
+            border: '1px solid var(--bs-border-color, #dee2e6)',
+            borderRadius: '0.375rem',
+            boxShadow: '0 0.5rem 1rem rgba(0, 0, 0, 0.15)',
+            padding: '0.75rem',
+            fontSize: '0.85rem',
+            lineHeight: '1.4',
+          }}
+        >
+          {loading && (
+            <div className="text-center py-2">
+              <div className="spinner-border spinner-border-sm text-secondary" role="status">
+                <span className="visually-hidden">Loading...</span>
+              </div>
+              <span className="ms-2 text-muted">Loading CVE details...</span>
+            </div>
+          )}
+
+          {!loading && popoverData && (
+            <div>
+              <div className="d-flex justify-content-between align-items-center mb-2">
+                <strong>{cveId}</strong>
+                {popoverData.severity && (
+                  <span
+                    className="badge"
+                    style={{
+                      backgroundColor: severityColor(popoverData.severity),
+                      color: '#fff',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    {popoverData.severity}
+                    {popoverData.cvssScore != null && ` (${popoverData.cvssScore})`}
+                  </span>
+                )}
+              </div>
+
+              {popoverData.description ? (
+                <p className="mb-1" style={{ maxHeight: '120px', overflow: 'hidden', color: 'var(--bs-body-color)' }}>
+                  {popoverData.description.length > 300
+                    ? popoverData.description.substring(0, 300) + '...'
+                    : popoverData.description}
+                </p>
+              ) : (
+                <p className="text-muted mb-1">No description available.</p>
+              )}
+
+              {popoverData.publishedDate && (
+                <small className="text-muted">
+                  Published: {new Date(popoverData.publishedDate).toLocaleDateString()}
+                </small>
+              )}
+            </div>
+          )}
+
+          {!loading && !popoverData && (
+            <div className="text-muted">
+              <i className="bi bi-info-circle me-1"></i>
+              CVE details unavailable. Click the link to view on NVD.
+            </div>
+          )}
+        </div>
+      )}
+    </span>
+  );
+};
+
+export default CveLink;

--- a/src/frontend/src/components/ExceptionApprovalDashboard.tsx
+++ b/src/frontend/src/components/ExceptionApprovalDashboard.tsx
@@ -28,6 +28,7 @@ import {
 } from '../services/exceptionRequestService';
 import ExceptionStatusBadge from './ExceptionStatusBadge';
 import ApprovalDetailModal from './ApprovalDetailModal';
+import CveLink from './CveLink';
 
 const ExceptionApprovalDashboard: React.FC = () => {
   // Data states
@@ -361,7 +362,7 @@ const ExceptionApprovalDashboard: React.FC = () => {
                           return (
                             <tr key={request.id}>
                               <td>
-                                <code>{request.vulnerabilityCveId || 'Unknown'}</code>
+                                <CveLink cveId={request.vulnerabilityCveId} />
                               </td>
                               <td>{request.assetName}</td>
                               <td>{request.requestedByUsername}</td>
@@ -644,7 +645,7 @@ const ExceptionApprovalDashboard: React.FC = () => {
                                 <tbody>
                                   {statisticsData.topCVEs.map((cve, idx) => (
                                     <tr key={idx}>
-                                      <td><code>{cve.cveId}</code></td>
+                                      <td><CveLink cveId={cve.cveId} /></td>
                                       <td className="text-end">{cve.count}</td>
                                     </tr>
                                   ))}

--- a/src/frontend/src/components/ExceptionRequestModal.tsx
+++ b/src/frontend/src/components/ExceptionRequestModal.tsx
@@ -18,6 +18,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { createRequest, type CreateExceptionRequestDto, type ExceptionScope } from '../services/exceptionRequestService';
+import CveLink from './CveLink';
 
 interface ExceptionRequestModalProps {
     isOpen: boolean;
@@ -267,7 +268,7 @@ const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
                                     <div className="d-flex align-items-start">
                                         <i className="bi bi-shield-exclamation me-2 mt-1"></i>
                                         <div>
-                                            <strong>Vulnerability:</strong> {vulnerabilityCveId || 'Unknown CVE'}
+                                            <strong>Vulnerability:</strong> <CveLink cveId={vulnerabilityCveId} />
                                             <br />
                                             <strong>Asset:</strong> {assetName}
                                         </div>

--- a/src/frontend/src/components/OutdatedAssetDetail.tsx
+++ b/src/frontend/src/components/OutdatedAssetDetail.tsx
@@ -23,6 +23,7 @@ import {
   type VulnerabilitiesPage
 } from '../services/outdatedAssetsApi';
 import { formatDistanceToNow } from 'date-fns';
+import CveLink from './CveLink';
 
 interface OutdatedAssetDetailProps {
   assetId: number;
@@ -346,7 +347,7 @@ const OutdatedAssetDetail: React.FC<OutdatedAssetDetailProps> = ({ assetId }) =>
                         {vulnerabilities.map((vuln) => (
                           <tr key={vuln.id}>
                             <td>
-                              <strong>{vuln.vulnerabilityId}</strong>
+                              <CveLink cveId={vuln.vulnerabilityId} />
                               {vuln.vulnerableProductVersions && (
                                 <>
                                   <br />

--- a/src/frontend/src/components/VulnerabilityHistory.tsx
+++ b/src/frontend/src/components/VulnerabilityHistory.tsx
@@ -9,6 +9,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { getAssetVulnerabilities, type Vulnerability } from '../services/vulnerabilityService';
+import CveLink from './CveLink';
 
 interface VulnerabilityHistoryProps {
     assetId: number;
@@ -119,11 +120,7 @@ const VulnerabilityHistory: React.FC<VulnerabilityHistoryProps> = ({ assetId, as
                                                     {vulnerabilities.map((vuln, index) => (
                                                         <tr key={`${vuln.id}-${index}`}>
                                                             <td>
-                                                                {vuln.vulnerabilityId ? (
-                                                                    <code>{vuln.vulnerabilityId}</code>
-                                                                ) : (
-                                                                    <span className="text-muted">-</span>
-                                                                )}
+                                                                <CveLink cveId={vuln.vulnerabilityId} />
                                                             </td>
                                                             <td>
                                                                 {vuln.cvssSeverity ? (

--- a/src/frontend/src/components/statistics/MostCommonVulnerabilities.tsx
+++ b/src/frontend/src/components/statistics/MostCommonVulnerabilities.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import ExcelJS from 'exceljs';
 import { vulnerabilityStatisticsApi, type MostCommonVulnerabilityDto, type AffectedAssetsByCveDto } from '../../services/api/vulnerabilityStatisticsApi';
+import CveLink from '../CveLink';
 
 /**
  * Map severity levels to Scandinavian design system badge classes
@@ -238,7 +239,7 @@ export default function MostCommonVulnerabilities({ domain }: MostCommonVulnerab
                 >
                   <td className="align-middle">{index + 1}</td>
                   <td className="align-middle">
-                    <strong>{vuln.vulnerabilityId}</strong>
+                    <CveLink cveId={vuln.vulnerabilityId} />
                   </td>
                   <td className="align-middle">
                     <span className={severityBadgeClass(vuln.cvssSeverity)}>

--- a/src/frontend/src/services/cveLookupService.ts
+++ b/src/frontend/src/services/cveLookupService.ts
@@ -1,0 +1,67 @@
+/**
+ * CVE Lookup Service
+ *
+ * Fetches CVE descriptions from backend proxy (NVD API).
+ * Includes in-memory cache and request deduplication.
+ *
+ * Feature: 072-cve-link-lookup
+ */
+
+import { authenticatedGet } from '../utils/auth';
+
+export interface CveLookupResult {
+  cveId: string;
+  description: string | null;
+  severity: string | null;
+  cvssScore: number | null;
+  publishedDate: string | null;
+  references: string[];
+}
+
+const cache = new Map<string, CveLookupResult>();
+const pendingRequests = new Map<string, Promise<CveLookupResult | null>>();
+
+/**
+ * Look up CVE details with caching and request deduplication.
+ *
+ * @param cveId CVE identifier (e.g., "CVE-2023-12345")
+ * @returns CVE details or null if lookup fails
+ */
+export async function lookupCve(cveId: string): Promise<CveLookupResult | null> {
+  // Check in-memory cache first
+  const cached = cache.get(cveId);
+  if (cached) return cached;
+
+  // Deduplicate concurrent requests for the same CVE
+  const pending = pendingRequests.get(cveId);
+  if (pending) return pending;
+
+  const request = fetchCve(cveId);
+  pendingRequests.set(cveId, request);
+
+  try {
+    const result = await request;
+    if (result) {
+      cache.set(cveId, result);
+    }
+    return result;
+  } finally {
+    pendingRequests.delete(cveId);
+  }
+}
+
+async function fetchCve(cveId: string): Promise<CveLookupResult | null> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await authenticatedGet(`/api/cve/${encodeURIComponent(cveId)}`);
+    clearTimeout(timeoutId);
+
+    if (!response.ok) return null;
+
+    return await response.json();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Implements feature 072-cve-link-lookup: CVE IDs are now rendered as clickable links across all relevant frontend views, opening the NVD detail page in a new tab. On hover, a popover displays a short description, CVSS score, and severity, fetched from a new backend endpoint that proxies and caches NVD API responses for 24 hours. Includes backend controller, service, DTO, frontend CveLink component, and service with in-memory caching and request deduplication. Updates all tables and dashboards to use the new component. Adds specifications and requirements documentation.