### PR TITLE
chore(backend): update all backend dependencies to latest versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,11 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "2.3.0" apply false
     id("org.jetbrains.kotlin.plugin.allopen") version "2.3.0" apply false
     id("org.jetbrains.kotlin.plugin.jpa") version "2.3.0" apply false
-    id("com.google.devtools.ksp") version "2.3.0" apply false
-    id("io.micronaut.application") version "4.6.0" apply false
-    id("io.micronaut.library") version "4.6.0" apply false
-    id("io.micronaut.aot") version "4.6.0" apply false
-    id("com.gradleup.shadow") version "8.3.8" apply false
+    id("com.google.devtools.ksp") version "2.3.5" apply false
+    id("io.micronaut.application") version "4.6.1" apply false
+    id("io.micronaut.library") version "4.6.1" apply false
+    id("io.micronaut.aot") version "4.6.1" apply false
+    id("com.gradleup.shadow") version "8.3.9" apply false
 }
 
 subprojects {
@@ -23,5 +23,5 @@ ext {
     set("kotlinVersion", "2.3.0")
     set("micronautVersion", "4.10.7")
     set("jvmTarget", "21")
-    set("picocliVersion", "4.7.5")
+    set("picocliVersion", "4.7.7")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,11 +7,11 @@ pluginManagement {
         id("org.jetbrains.kotlin.jvm") version "2.3.0"
         id("org.jetbrains.kotlin.plugin.allopen") version "2.3.0"
         id("org.jetbrains.kotlin.plugin.jpa") version "2.2.2	0"
-        id("com.google.devtools.ksp") version "2.3.0" //2.1.0-1.0.28
-        id("io.micronaut.application") version "4.6.0"
-        id("io.micronaut.library") version "4.6.0"
-        id("io.micronaut.aot") version "4.6.0"
-        id("com.gradleup.shadow") version "8.3.8"
+        id("com.google.devtools.ksp") version "2.3.5"
+        id("io.micronaut.application") version "4.6.1"
+        id("io.micronaut.library") version "4.6.1"
+        id("io.micronaut.aot") version "4.6.1"
+        id("com.gradleup.shadow") version "8.3.9"
     }
 }
 

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client:3.5.7")
 
 	implementation("io.micronaut.flyway:micronaut-flyway:7.9.2")
-	runtimeOnly("org.flywaydb:flyway-core:11.20.2")
+	runtimeOnly("org.flywaydb:flyway-core:11.20.3")
 	
     // Security
     implementation("io.micronaut.security:micronaut-security-jwt:4.16.1")
@@ -74,12 +74,12 @@ dependencies {
     // MCP (Model Context Protocol) Dependencies
     // Note: Using JSON-RPC and reactive streams for MCP implementation
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
     implementation("io.micronaut.reactor:micronaut-reactor")
     implementation("io.micronaut.reactor:micronaut-reactor-http-client")
     
     // Logging
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.24")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.26")
     // Bridge Log4j to Logback (required for Apache POI)
     runtimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.25.3")
     // Logstash encoder for JSON logging (Feature 046)
@@ -123,7 +123,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:2.0.3")
     testImplementation("org.testcontainers:mariadb:1.21.4")
     testImplementation("org.testcontainers:junit-jupiter:1.21.4")
-    testImplementation("org.assertj:assertj-core:3.27.6")
+    testImplementation("org.assertj:assertj-core:3.27.7")
 }
 
 application {

--- a/src/cli/build.gradle.kts
+++ b/src/cli/build.gradle.kts
@@ -29,10 +29,10 @@ dependencies {
     // Database (required for EntityManager and JPA support)
     implementation("io.micronaut.sql:micronaut-hibernate-jpa")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
-    runtimeOnly("org.mariadb.jdbc:mariadb-java-client:3.5.3")
+    runtimeOnly("org.mariadb.jdbc:mariadb-java-client:3.5.7")
 
     // Picocli for CLI
-    implementation("info.picocli:picocli:4.7.5")
+    implementation("info.picocli:picocli:4.7.7")
     implementation("io.micronaut.picocli:micronaut-picocli")
     
     // Jackson for YAML/JSON
@@ -41,10 +41,10 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     
     // CSV export
-    implementation("org.apache.commons:commons-csv:1.11.0")
+    implementation("org.apache.commons:commons-csv:1.14.1")
 
     // AWS SDK for S3 (Feature 065 - S3 User Mapping Import)
-    implementation(platform("software.amazon.awssdk:bom:2.29.0"))
+    implementation(platform("software.amazon.awssdk:bom:2.41.18"))
     implementation("software.amazon.awssdk:s3")
     
     // Kotlin
@@ -59,11 +59,11 @@ dependencies {
     ksp("io.micronaut:micronaut-http-validation")
 
     // Test dependencies - Feature 056
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.3")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.11.3")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.3")
-    testImplementation("io.mockk:mockk:1.13.13")
-    testImplementation("org.assertj:assertj-core:3.26.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:6.0.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:6.0.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.2")
+    testImplementation("io.mockk:mockk:1.14.7")
+    testImplementation("org.assertj:assertj-core:3.27.7")
 }
 
 application {

--- a/src/shared/gradle.properties
+++ b/src/shared/gradle.properties
@@ -1,4 +1,4 @@
-micronautVersion=4.10.0
+micronautVersion=4.10.7
 kotlinVersion=2.3.0
 
 org.gradle.configuration-cache=true


### PR DESCRIPTION
Plugins:
- KSP: 2.3.0 → 2.3.5
- Micronaut Gradle Plugin: 4.6.0 → 4.6.1
- Shadow: 8.3.8 → 8.3.9
- Picocli: 4.7.5 → 4.7.7

Backend (backendng):
- flyway-core: 11.20.2 → 11.20.3
- logback-classic: 1.5.24 → 1.5.26
- kotlinx-serialization-json: 1.9.0 → 1.10.0
- assertj-core: 3.27.6 → 3.27.7

CLI:
- mariadb-java-client: 3.5.3 → 3.5.7
- commons-csv: 1.11.0 → 1.14.1
- AWS SDK BOM: 2.29.0 → 2.41.18
- JUnit: 5.11.3 → 6.0.2
- mockk: 1.13.13 → 1.14.7
- assertj-core: 3.26.3 → 3.27.7

Shared:
- micronautVersion: 4.10.0 → 4.10.7

https://claude.ai/code/session_01R4o5xSmKfAZM1nVwW2Me6L