### PR TITLE
Add MCP workgroup tools and E2E spec

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,17 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="94ada8b3-9f4e-473c-9fea-3bc9651b5bdd" name="Changes" comment="test change">
-      <change beforePath="$PROJECT_DIR$/.idea/compiler.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/compiler.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CLAUDE.md" beforeDir="false" afterPath="$PROJECT_DIR$/CLAUDE.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/MCP.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/MCP.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/.claude/settings.local.json" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/.claude/settings.local.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddVulnerabilityTool.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddVulnerabilityTool.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityServiceTest.kt" beforeDir="false" afterPath="$PROJECT_DIR$/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityServiceTest.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/frontend/src/components/McpApiKeyManagement.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/frontend/src/components/McpApiKeyManagement.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -82,37 +91,37 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_MARK_IGNORED_FILES_AS_EXCLUDED&quot;: &quot;true&quot;,
-    &quot;Gradle.OAuthServiceTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.backendng [build].executor&quot;: &quot;Run&quot;,
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;SHELLCHECK.PATH&quot;: &quot;/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.3/plugins/Shell Script/shellcheck&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/flake/sources/misc/secman&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Global Libraries&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.12135923&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.409894&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/flake/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_MARK_IGNORED_FILES_AS_EXCLUDED": "true",
+    "Gradle.OAuthServiceTest.executor": "Run",
+    "Gradle.backendng [build].executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "SHELLCHECK.PATH": "/Users/flake/Library/Application Support/JetBrains/IntelliJIdea2025.3/plugins/Shell Script/shellcheck",
+    "git-widget-placeholder": "074-mcp-e2e-test",
+    "junie.onboarding.icon.badge.shown": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/flake/sources/misc/secman",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Global Libraries",
+    "project.structure.proportion": "0.12135923",
+    "project.structure.side.proportion": "0.409894",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "ts.external.directory.path": "/Users/flake/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;mariadb&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "mariadb"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scripts/install/db" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,8 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing `email_configs` table) (071-ses-smtp-rewrite)
 - Kotlin 2.3.0 / Java 25 + Micronaut 4.10, Hibernate JPA, Apache POI 5.3 (SXSSFWorkbook) (073-memory-optimization)
 - MariaDB 11.4 (HikariCP connection pool, max 20 connections) (073-memory-optimization)
+- Kotlin 2.3.0 / Java 25 (backend), Bash (test script), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, curl, jq, 1Password CLI v2.x (074-mcp-e2e-test)
+- MariaDB 11.4 (existing tables: users, assets, vulnerabilities, workgroups, user_workgroups, asset_workgroups) (074-mcp-e2e-test)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,7 +1,7 @@
 # MCP (Model Context Protocol) Integration Guide
 
-**Last Updated:** 2026-01-14
-**Version:** 3.1
+**Last Updated:** 2026-02-04
+**Version:** 3.2
 
 This guide covers integrating Secman with AI assistants (Claude Desktop, Claude Code, ChatGPT, etc.) using the Model Context Protocol (MCP).
 
@@ -270,6 +270,7 @@ curl -X POST http://localhost:8080/api/mcp/admin/api-keys \
 | `VULNERABILITIES_READ` | Read vulnerability data | `get_vulnerabilities`, `get_all_vulnerabilities_detail`, `get_asset_most_vulnerabilities`, `get_overdue_assets`, `get_my_exception_requests`, `get_pending_exception_requests`, `create_exception_request`, `approve_exception_request`, `reject_exception_request`, `cancel_exception_request` |
 | `SCANS_READ` | Read scan history | `get_scans`, `get_asset_scan_results`, `search_products` |
 | `USER_ACTIVITY` | User management and mappings | `list_users`, `add_user`, `delete_user`, `import_user_mappings`, `list_user_mappings` (all require delegation) |
+| `WORKGROUPS_WRITE` | Workgroup management | `create_workgroup`, `delete_workgroup`, `assign_assets_to_workgroup`, `assign_users_to_workgroup` (all require delegation) |
 
 ### Managing Keys
 
@@ -588,6 +589,57 @@ Add a vulnerability to an asset. Creates the asset if it doesn't exist. **Requir
 | `owner` | string | No | Owner to assign to newly created asset |
 
 Returns vulnerability ID, asset details, and whether the asset/vulnerability were created or updated.
+
+### Workgroup Management
+
+#### `create_workgroup`
+Create a new workgroup. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Unique name for the workgroup (1-100 chars) |
+| `description` | string | No | Optional description (max 512 chars) |
+
+Returns workgroup ID, name, description, and success message.
+
+#### `delete_workgroup`
+Delete a workgroup by ID. Cascade removes user/asset associations. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workgroupId` | number | Yes | ID of the workgroup to delete |
+
+Returns deleted workgroup ID and name.
+
+#### `assign_assets_to_workgroup`
+Assign one or more assets to a workgroup. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workgroupId` | number | Yes | ID of the target workgroup |
+| `assetIds` | number[] | Yes | List of asset IDs to assign |
+
+Returns workgroup ID and count of assigned assets.
+
+#### `assign_users_to_workgroup`
+Assign one or more users to a workgroup. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workgroupId` | number | Yes | ID of the target workgroup |
+| `userIds` | number[] | Yes | List of user IDs to assign |
+
+Returns workgroup ID and count of assigned users.
+
+#### `delete_asset`
+Delete a specific asset by ID with cascade deletion. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `assetId` | number | Yes | ID of the asset to delete |
+| `forceTimeout` | boolean | No | Force deletion even if it may exceed timeout (default: false) |
+
+Returns deleted asset ID, name, counts of deleted vulnerabilities/exceptions/requests, and audit log ID.
 
 ### User Mapping Management
 

--- a/specs/074-mcp-e2e-test/checklists/requirements.md
+++ b/specs/074-mcp-e2e-test/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-04
+**Updated**: 2026-02-04 (post-clarification + UI feature)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Clarification session completed (2026-02-04): 2 questions asked and resolved
+- Clarifications added:
+  1. Test script language: Bash with `curl` and `jq`
+  2. Asset cleanup strategy: Targeted deletion by ID (new `delete_asset` MCP tool)
+- User Story 4 added: MCP key generation UI must display new tools
+- Requirements FR-019 through FR-021 added for UI updates
+- Success criteria SC-007 added for UI verification
+- MCP tool count: 5 new tools (create_workgroup, assign_assets_to_workgroup, assign_users_to_workgroup, delete_workgroup, delete_asset)
+- The specification is ready for `/speckit.plan`

--- a/specs/074-mcp-e2e-test/contracts/mcp-tools.yaml
+++ b/specs/074-mcp-e2e-test/contracts/mcp-tools.yaml
@@ -1,0 +1,212 @@
+# MCP Tool Contracts: Workgroup Management Tools
+# Feature: 074-mcp-e2e-test
+# Date: 2026-02-04
+#
+# These contracts define the input schemas and expected responses for new MCP tools.
+# MCP tools use JSON-RPC style invocation, not REST endpoints.
+
+tools:
+  - name: create_workgroup
+    operation: WRITE
+    description: "Create a new workgroup (ADMIN role required)"
+    authorization:
+      permission: WORKGROUPS_WRITE
+      requiresDelegation: true
+      requiredRole: ADMIN
+    inputSchema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Unique name for the workgroup"
+          maxLength: 255
+        description:
+          type: string
+          description: "Optional description of the workgroup"
+          maxLength: 1000
+      required:
+        - name
+    successResponse:
+      content:
+        id: number
+        name: string
+        description: string | null
+        message: string
+      example:
+        id: 42
+        name: "E2E-Test-Workgroup"
+        description: "Created for E2E testing"
+        message: "Workgroup created successfully"
+    errorResponses:
+      - code: DELEGATION_REQUIRED
+        message: "User delegation required for this operation"
+      - code: ADMIN_REQUIRED
+        message: "ADMIN role required to create workgroups"
+      - code: VALIDATION_ERROR
+        message: "Workgroup name is required"
+      - code: DUPLICATE_ERROR
+        message: "Workgroup with this name already exists"
+
+  - name: delete_workgroup
+    operation: DELETE
+    description: "Delete a workgroup by ID (ADMIN role required)"
+    authorization:
+      permission: WORKGROUPS_WRITE
+      requiresDelegation: true
+      requiredRole: ADMIN
+    inputSchema:
+      type: object
+      properties:
+        workgroupId:
+          type: integer
+          description: "ID of the workgroup to delete"
+      required:
+        - workgroupId
+    successResponse:
+      content:
+        id: number
+        message: string
+      example:
+        id: 42
+        message: "Workgroup deleted successfully"
+    errorResponses:
+      - code: DELEGATION_REQUIRED
+        message: "User delegation required for this operation"
+      - code: ADMIN_REQUIRED
+        message: "ADMIN role required to delete workgroups"
+      - code: NOT_FOUND
+        message: "Workgroup not found"
+      - code: VALIDATION_ERROR
+        message: "Workgroup ID is required"
+
+  - name: assign_assets_to_workgroup
+    operation: WRITE
+    description: "Assign one or more assets to a workgroup (ADMIN role required)"
+    authorization:
+      permission: WORKGROUPS_WRITE
+      requiresDelegation: true
+      requiredRole: ADMIN
+    inputSchema:
+      type: object
+      properties:
+        workgroupId:
+          type: integer
+          description: "ID of the target workgroup"
+        assetIds:
+          type: array
+          items:
+            type: integer
+          description: "List of asset IDs to assign"
+          minItems: 1
+      required:
+        - workgroupId
+        - assetIds
+    successResponse:
+      content:
+        workgroupId: number
+        assignedCount: number
+        message: string
+      example:
+        workgroupId: 42
+        assignedCount: 3
+        message: "3 assets assigned to workgroup"
+    errorResponses:
+      - code: DELEGATION_REQUIRED
+        message: "User delegation required for this operation"
+      - code: ADMIN_REQUIRED
+        message: "ADMIN role required to assign assets"
+      - code: NOT_FOUND
+        message: "Workgroup not found"
+      - code: VALIDATION_ERROR
+        message: "Asset IDs list is required and cannot be empty"
+      - code: PARTIAL_ERROR
+        message: "Some assets could not be assigned"
+
+  - name: assign_users_to_workgroup
+    operation: WRITE
+    description: "Assign one or more users to a workgroup (ADMIN role required)"
+    authorization:
+      permission: WORKGROUPS_WRITE
+      requiresDelegation: true
+      requiredRole: ADMIN
+    inputSchema:
+      type: object
+      properties:
+        workgroupId:
+          type: integer
+          description: "ID of the target workgroup"
+        userIds:
+          type: array
+          items:
+            type: integer
+          description: "List of user IDs to assign"
+          minItems: 1
+      required:
+        - workgroupId
+        - userIds
+    successResponse:
+      content:
+        workgroupId: number
+        assignedCount: number
+        message: string
+      example:
+        workgroupId: 42
+        assignedCount: 2
+        message: "2 users assigned to workgroup"
+    errorResponses:
+      - code: DELEGATION_REQUIRED
+        message: "User delegation required for this operation"
+      - code: ADMIN_REQUIRED
+        message: "ADMIN role required to assign users"
+      - code: NOT_FOUND
+        message: "Workgroup not found"
+      - code: VALIDATION_ERROR
+        message: "User IDs list is required and cannot be empty"
+      - code: PARTIAL_ERROR
+        message: "Some users could not be assigned"
+
+  - name: delete_asset
+    operation: DELETE
+    description: "Delete a specific asset by ID with cascade (ADMIN role required)"
+    authorization:
+      permission: ASSETS_READ  # Uses existing permission with admin check
+      requiresDelegation: true
+      requiredRole: ADMIN
+    inputSchema:
+      type: object
+      properties:
+        assetId:
+          type: integer
+          description: "ID of the asset to delete"
+      required:
+        - assetId
+    successResponse:
+      content:
+        id: number
+        name: string
+        message: string
+      example:
+        id: 123
+        name: "test-server-01"
+        message: "Asset deleted successfully"
+    errorResponses:
+      - code: DELEGATION_REQUIRED
+        message: "User delegation required for this operation"
+      - code: ADMIN_REQUIRED
+        message: "ADMIN role required to delete assets"
+      - code: NOT_FOUND
+        message: "Asset not found"
+      - code: VALIDATION_ERROR
+        message: "Asset ID is required"
+      - code: DELETE_FAILED
+        message: "Failed to delete asset due to cascade constraints"
+
+# Permission Extension
+permissions:
+  - name: WORKGROUPS_WRITE
+    description: "Manage workgroups via MCP (create, delete, assign users/assets)"
+    tools:
+      - create_workgroup
+      - delete_workgroup
+      - assign_assets_to_workgroup
+      - assign_users_to_workgroup

--- a/specs/074-mcp-e2e-test/data-model.md
+++ b/specs/074-mcp-e2e-test/data-model.md
@@ -1,0 +1,216 @@
+# Data Model: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Feature Branch**: `074-mcp-e2e-test`
+**Date**: 2026-02-04
+
+## Entities
+
+This feature primarily uses **existing entities** with no schema changes required. The MCP tools expose existing functionality through a new interface.
+
+### Existing Entities (Reference Only)
+
+#### User
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/User.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| username | String | Unique, not null | |
+| email | String | Unique, not null | |
+| password | String | Not null (hashed) | BCrypt encoded |
+| roles | Set<String> | Not null | USER, ADMIN, VULN, etc. |
+| workgroups | Set<Workgroup> | ManyToMany | Join table: user_workgroups |
+
+#### Asset
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/Asset.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| name | String | Unique, not null | Hostname/identifier |
+| type | String | Not null | SERVER, WORKSTATION, etc. |
+| ip | String | Nullable | IP address |
+| owner | String | Nullable | Asset owner |
+| description | String | Nullable | |
+| workgroups | Set<Workgroup> | ManyToMany | Join table: asset_workgroups |
+| vulnerabilities | Set<Vulnerability> | OneToMany | Cascade: none (manual delete) |
+
+#### Vulnerability
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/Vulnerability.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| cve | String | Not null | CVE identifier |
+| asset | Asset | ManyToOne, not null | FK to Asset |
+| criticality | String | Not null | CRITICAL, HIGH, MEDIUM, LOW |
+| detectedAt | LocalDateTime | Not null | When vulnerability was detected |
+| status | String | Not null | OPEN, REMEDIATED, etc. |
+
+#### Workgroup
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/Workgroup.kt`
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| id | Long | PK, auto-generated | |
+| name | String | Unique, not null | |
+| description | String | Nullable | |
+| criticality | String | Nullable | Business criticality |
+| users | Set<User> | ManyToMany | Join table: user_workgroups |
+| assets | Set<Asset> | ManyToMany | Join table: asset_workgroups |
+
+### New Domain Element: McpPermission (Enum Extension)
+
+**Location**: `src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt`
+
+**New Value to Add**:
+```kotlin
+enum class McpPermission {
+    // ... existing values ...
+    WORKGROUPS_WRITE,  // NEW: Grants workgroup management via MCP
+}
+```
+
+**Rationale**: Existing permissions don't cover workgroup management. Adding a dedicated permission maintains granular access control.
+
+## State Transitions
+
+### Test Script Workflow State Machine
+
+```
+┌─────────────┐
+│   START     │
+└──────┬──────┘
+       │
+       ▼
+┌─────────────────────────┐
+│  Resolve Credentials    │ (1Password → env vars)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Authenticate           │ (POST /api/auth/login → JWT)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Create TEST User       │ (add_user MCP tool)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Create Asset+Vuln      │ (add_vulnerability MCP tool)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Create Workgroup       │ (create_workgroup MCP tool)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Assign Asset           │ (assign_assets_to_workgroup)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Assign User            │ (assign_users_to_workgroup)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Switch User Context    │ (X-MCP-User-Email header)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  Verify Asset Access    │ (get_assets → expect 1 result)
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────────────────┐
+│  CLEANUP (always)       │
+│  - delete_workgroup     │
+│  - delete_asset         │
+│  - delete_user          │
+└──────────┬──────────────┘
+           │
+           ▼
+┌─────────────┐
+│    END      │
+└─────────────┘
+```
+
+## Validation Rules
+
+### MCP Tool Input Validation
+
+#### create_workgroup
+| Parameter | Type | Required | Validation |
+|-----------|------|----------|------------|
+| name | String | Yes | Non-empty, max 255 chars |
+| description | String | No | Max 1000 chars |
+
+#### delete_workgroup
+| Parameter | Type | Required | Validation |
+|-----------|------|----------|------------|
+| workgroupId | Long | Yes | Must exist, positive integer |
+
+#### assign_assets_to_workgroup
+| Parameter | Type | Required | Validation |
+|-----------|------|----------|------------|
+| workgroupId | Long | Yes | Must exist |
+| assetIds | List<Long> | Yes | Non-empty, all must exist |
+
+#### assign_users_to_workgroup
+| Parameter | Type | Required | Validation |
+|-----------|------|----------|------------|
+| workgroupId | Long | Yes | Must exist |
+| userIds | List<Long> | Yes | Non-empty, all must exist |
+
+#### delete_asset
+| Parameter | Type | Required | Validation |
+|-----------|------|----------|------------|
+| assetId | Long | Yes | Must exist, positive integer |
+
+## Relationships Diagram
+
+```
+┌─────────────┐       ┌─────────────────────┐       ┌─────────────┐
+│    User     │◄─────►│   user_workgroups   │◄─────►│  Workgroup  │
+│             │       │   (join table)      │       │             │
+└─────────────┘       └─────────────────────┘       └──────┬──────┘
+                                                          │
+                                                          │
+                      ┌─────────────────────┐             │
+                      │  asset_workgroups   │◄────────────┘
+                      │   (join table)      │
+                      └──────────┬──────────┘
+                                 │
+                                 ▼
+                      ┌─────────────────────┐
+                      │       Asset         │
+                      │                     │
+                      └──────────┬──────────┘
+                                 │
+                                 │ 1:N
+                                 ▼
+                      ┌─────────────────────┐
+                      │   Vulnerability     │
+                      │                     │
+                      └─────────────────────┘
+```
+
+## Access Control Model
+
+```
+User accesses Asset IF ANY of:
+├── User has ADMIN role (universal)
+├── Asset in User's workgroup(s)
+├── Asset manually created by User
+├── Asset discovered via User's scan upload
+├── Asset's cloudAccountId matches User's AWS mappings
+└── Asset's adDomain matches User's domain mappings
+```
+
+For this E2E test, we verify the **workgroup path**: assigning User to Workgroup containing Asset grants access.

--- a/specs/074-mcp-e2e-test/plan.md
+++ b/specs/074-mcp-e2e-test/plan.md
@@ -1,0 +1,179 @@
+# Implementation Plan: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Branch**: `074-mcp-e2e-test` | **Date**: 2026-02-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/074-mcp-e2e-test/spec.md`
+
+## Summary
+
+Implement 5 new MCP tools for workgroup management (`create_workgroup`, `delete_workgroup`, `assign_assets_to_workgroup`, `assign_users_to_workgroup`, `delete_asset`), update the MCP key generation UI to display the new WORKGROUPS_WRITE permission, and create an E2E Bash test script that validates the complete user-asset-workgroup access control workflow using 1Password for credential management.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25 (backend), Bash (test script), TypeScript/React 19 (frontend)
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA, curl, jq, 1Password CLI v2.x
+**Storage**: MariaDB 11.4 (existing tables: users, assets, vulnerabilities, workgroups, user_workgroups, asset_workgroups)
+**Testing**: E2E Bash script with assertions, manual verification for UI
+**Target Platform**: Linux/macOS server (localhost for test script)
+**Project Type**: Web application (backend + frontend)
+**Performance Goals**: Test script completes in under 2 minutes
+**Constraints**: No credential leakage in logs, proper authorization checks
+**Scale/Scope**: Single E2E test scenario, 5 new MCP tools, 1 UI permission addition
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | ✅ PASS | Authorization checks in all tools, no credential logging, security review required |
+| III. API-First | ✅ PASS | MCP tools follow existing JSON-RPC patterns, contracts defined |
+| IV. User-Requested Testing | ✅ PASS | Test script is explicitly requested in spec requirements |
+| V. RBAC | ✅ PASS | All tools require ADMIN role via delegation, @Secured on MCP endpoint |
+| VI. Schema Evolution | ✅ PASS | No schema changes - only new enum value in McpPermission |
+
+**Gate Result**: PASS - No violations detected.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/074-mcp-e2e-test/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output - MCP patterns research
+├── data-model.md        # Phase 1 output - Entity documentation
+├── quickstart.md        # Phase 1 output - Manual testing guide
+├── contracts/           # Phase 1 output
+│   └── mcp-tools.yaml   # MCP tool contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/backendng/src/main/kotlin/com/secman/
+├── mcp/
+│   ├── tools/
+│   │   ├── CreateWorkgroupTool.kt      # NEW: Create workgroup MCP tool
+│   │   ├── DeleteWorkgroupTool.kt      # NEW: Delete workgroup MCP tool
+│   │   ├── AssignAssetsToWorkgroupTool.kt    # NEW: Assign assets MCP tool
+│   │   ├── AssignUsersToWorkgroupTool.kt     # NEW: Assign users MCP tool
+│   │   └── DeleteAssetTool.kt          # NEW: Delete single asset MCP tool
+│   └── McpToolRegistry.kt              # MODIFY: Register new tools
+├── domain/
+│   └── McpPermission.kt                # MODIFY: Add WORKGROUPS_WRITE
+└── service/
+    ├── WorkgroupService.kt             # EXISTING: Reuse methods
+    └── AssetCascadeDeleteService.kt    # EXISTING: Reuse for asset deletion
+
+src/frontend/src/components/
+└── McpApiKeyManagement.tsx             # MODIFY: Add WORKGROUPS_WRITE permission
+
+tests/
+└── mcp-e2e-workgroup-test.sh           # NEW: E2E test script
+```
+
+**Structure Decision**: Web application pattern - backend Kotlin services with React frontend. Test script in repository-root `tests/` folder as specified in FR-015.
+
+## Implementation Components
+
+### Component 1: New MCP Tools (Backend)
+
+**Files to Create**:
+1. `CreateWorkgroupTool.kt` - Implements McpTool interface, calls WorkgroupService.createWorkgroup()
+2. `DeleteWorkgroupTool.kt` - Implements McpTool interface, calls WorkgroupService.deleteWorkgroup()
+3. `AssignAssetsToWorkgroupTool.kt` - Implements McpTool interface, calls WorkgroupService.assignAssetsToWorkgroup()
+4. `AssignUsersToWorkgroupTool.kt` - Implements McpTool interface, calls WorkgroupService.assignUsersToWorkgroup()
+5. `DeleteAssetTool.kt` - Implements McpTool interface, calls AssetCascadeDeleteService.deleteAsset()
+
+**Pattern to Follow**: See research.md for detailed McpTool implementation pattern including authorization checks.
+
+### Component 2: Permission & Registry Updates (Backend)
+
+**Files to Modify**:
+1. `McpPermission.kt` - Add `WORKGROUPS_WRITE` enum value
+2. `McpToolRegistry.kt` - Inject and register all 5 new tools, add authorization mapping
+
+### Component 3: Frontend UI Update
+
+**Files to Modify**:
+1. `McpApiKeyManagement.tsx` - Add `'WORKGROUPS_WRITE'` to `availablePermissions` array
+
+### Component 4: E2E Test Script
+
+**File to Create**:
+- `tests/mcp-e2e-workgroup-test.sh`
+
+**Script Structure**:
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Trap for cleanup on failure
+trap cleanup EXIT
+
+# Functions
+check_prerequisites()
+resolve_credentials()
+authenticate()
+create_test_user()
+create_test_asset_with_vulnerability()
+create_test_workgroup()
+assign_asset_to_workgroup()
+assign_user_to_workgroup()
+verify_access_as_test_user()
+cleanup()
+
+# Main execution
+main()
+```
+
+## Dependencies
+
+### Build Dependencies (Existing)
+- Micronaut 4.10 DI framework
+- Hibernate JPA ORM
+- Kotlin coroutines
+
+### Runtime Dependencies (Test Script)
+- curl (HTTP client)
+- jq (JSON parser)
+- op (1Password CLI v2.x)
+
+### Service Dependencies
+- WorkgroupService (existing)
+- AssetCascadeDeleteService (existing)
+- UserService (existing, via AddUserTool/DeleteUserTool)
+
+## Security Considerations
+
+1. **Authorization**: All new tools require ADMIN role via user delegation
+2. **Credential Protection**: Test script uses 1Password CLI, never echoes secrets
+3. **Input Validation**: All tool inputs validated against schema before processing
+4. **Audit Trail**: Operations logged via existing audit infrastructure
+5. **Access Control**: Workgroup assignment respects RBAC model
+
+## Complexity Tracking
+
+> No complexity violations detected. All implementations follow existing patterns.
+
+| Aspect | Approach | Justification |
+|--------|----------|---------------|
+| 5 new MCP tools | Standard McpTool pattern | Consistent with 41 existing tools |
+| 1 enum addition | McpPermission extension | Follows existing permission model |
+| 1 UI array entry | Simple array addition | Minimal change, no new components |
+| Bash test script | curl + jq | Aligns with existing E2E patterns |
+
+## Phase 1 Artifacts Generated
+
+- [x] research.md - MCP patterns and implementation details
+- [x] data-model.md - Entity documentation and relationships
+- [x] contracts/mcp-tools.yaml - MCP tool contracts
+- [x] quickstart.md - Manual testing guide
+
+## Next Steps
+
+Run `/speckit.tasks` to generate the implementation task list.

--- a/specs/074-mcp-e2e-test/quickstart.md
+++ b/specs/074-mcp-e2e-test/quickstart.md
@@ -1,0 +1,242 @@
+# Quickstart: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Feature Branch**: `074-mcp-e2e-test`
+**Date**: 2026-02-04
+
+## Prerequisites
+
+### Required Tools
+- `curl` - HTTP client (usually pre-installed)
+- `jq` - JSON processor (`brew install jq` on macOS)
+- `op` - 1Password CLI v2.x (`brew install 1password-cli`)
+
+### 1Password Setup
+```bash
+# Login to 1Password
+op signin
+
+# Verify access to vault
+op vault list
+```
+
+### Environment Variables
+Set these in your shell profile or before running the test:
+```bash
+export SECMAN_USERNAME="op://test/secman/SECMAN_USERNAME"
+export SECMAN_PASSWORD="op://test/secman/SECMAN_PASSWORD"
+export SECMAN_API_KEY="op://test/secman/SECMAN_API_KEY"
+```
+
+### Running Secman Backend
+Ensure the backend is running on localhost:
+```bash
+cd src/backendng
+./gradlew run
+```
+
+## Running the E2E Test
+
+### Quick Run
+```bash
+# From repository root
+./tests/mcp-e2e-workgroup-test.sh
+```
+
+### With Verbose Output
+```bash
+DEBUG=1 ./tests/mcp-e2e-workgroup-test.sh
+```
+
+### Expected Output
+```
+=== MCP E2E Test: User-Asset-Workgroup Workflow ===
+[INFO] Checking prerequisites...
+[INFO] Resolving credentials from 1Password...
+[INFO] Authenticating to secman...
+[INFO] Step 1: Creating TEST user with VULN role...
+[INFO] Step 2: Creating test asset with CRITICAL vulnerability...
+[INFO] Step 3: Creating test workgroup...
+[INFO] Step 4: Assigning asset to workgroup...
+[INFO] Step 5: Assigning TEST user to workgroup...
+[INFO] Step 6: Switching to TEST user context...
+[INFO] Step 7: Verifying asset access...
+[PASS] TEST user sees exactly 1 asset
+[INFO] Step 8: Cleanup...
+[INFO] Deleted workgroup
+[INFO] Deleted asset
+[INFO] Deleted user
+=== TEST PASSED ===
+```
+
+## Manual Testing Guide
+
+### Step 1: Authenticate
+```bash
+# Resolve credentials
+USERNAME=$(op read "op://test/secman/SECMAN_USERNAME")
+PASSWORD=$(op read "op://test/secman/SECMAN_PASSWORD")
+
+# Get JWT token
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" | jq -r '.token')
+```
+
+### Step 2: Create User via MCP
+```bash
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "add_user",
+    "arguments": {
+      "username": "TEST",
+      "email": "test@example.com",
+      "password": "TestPass123!",
+      "roles": ["VULN"]
+    }
+  }' | jq
+```
+
+### Step 3: Create Asset with Vulnerability via MCP
+```bash
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "add_vulnerability",
+    "arguments": {
+      "hostname": "e2e-test-server",
+      "cve": "CVE-2024-0001",
+      "criticality": "CRITICAL",
+      "daysOpen": 10
+    }
+  }' | jq
+```
+
+### Step 4: Create Workgroup via MCP (NEW)
+```bash
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "create_workgroup",
+    "arguments": {
+      "name": "E2E-Test-Workgroup",
+      "description": "Workgroup for E2E testing"
+    }
+  }' | jq
+```
+
+### Step 5: Assign Asset to Workgroup via MCP (NEW)
+```bash
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "assign_assets_to_workgroup",
+    "arguments": {
+      "workgroupId": <WORKGROUP_ID>,
+      "assetIds": [<ASSET_ID>]
+    }
+  }' | jq
+```
+
+### Step 6: Assign User to Workgroup via MCP (NEW)
+```bash
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "assign_users_to_workgroup",
+    "arguments": {
+      "workgroupId": <WORKGROUP_ID>,
+      "userIds": [<USER_ID>]
+    }
+  }' | jq
+```
+
+### Step 7: Verify Access as TEST User
+```bash
+# Switch delegation to TEST user
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: test@example.com" \
+  -d '{
+    "name": "get_assets",
+    "arguments": {}
+  }' | jq '.content.assets | length'
+# Expected output: 1
+```
+
+### Step 8: Cleanup via MCP (NEW)
+```bash
+# Delete workgroup
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "delete_workgroup",
+    "arguments": {"workgroupId": <WORKGROUP_ID>}
+  }' | jq
+
+# Delete asset
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "delete_asset",
+    "arguments": {"assetId": <ASSET_ID>}
+  }' | jq
+
+# Delete user
+curl -s -X POST http://localhost:8080/api/mcp/tools/call \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-User-Email: admin@example.com" \
+  -d '{
+    "name": "delete_user",
+    "arguments": {"userId": <USER_ID>}
+  }' | jq
+```
+
+## Troubleshooting
+
+### 1Password CLI Issues
+```bash
+# Check if signed in
+op whoami
+
+# Re-authenticate if needed
+op signin
+```
+
+### Backend Not Reachable
+```bash
+# Check if backend is running
+curl -s http://localhost:8080/health | jq
+
+# Start backend if needed
+cd src/backendng && ./gradlew run
+```
+
+### Permission Denied Errors
+- Ensure API key has `WORKGROUPS_WRITE` permission
+- Ensure user delegation is properly set via `X-MCP-User-Email` header
+- Ensure delegated user has ADMIN role
+
+### Stale Test Data
+If a previous test run failed:
+```bash
+# Manually clean up via admin UI or API
+# Or run with cleanup-first flag (if implemented)
+./tests/mcp-e2e-workgroup-test.sh --cleanup-first
+```

--- a/specs/074-mcp-e2e-test/research.md
+++ b/specs/074-mcp-e2e-test/research.md
@@ -1,0 +1,178 @@
+# Research: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Feature Branch**: `074-mcp-e2e-test`
+**Date**: 2026-02-04
+
+## Research Questions Resolved
+
+### 1. MCP Tool Implementation Pattern
+
+**Decision**: Follow the existing McpTool interface pattern with @Singleton annotation and McpToolRegistry registration.
+
+**Rationale**: 41 existing tools follow this pattern consistently. The registry uses lazy initialization with authorization mapping.
+
+**Alternatives Considered**:
+- Spring-style annotations: Rejected - project uses Micronaut DI
+- Dynamic tool loading: Rejected - introduces complexity without benefit
+
+**Key Implementation Pattern**:
+```kotlin
+@Singleton
+class NewTool @Inject constructor(
+    private val service: SomeService
+) : McpTool {
+    override val name = "tool_name"
+    override val description = "Description (ADMIN role required)"
+    override val operation = McpOperation.WRITE
+    override val inputSchema = mapOf(...)
+
+    override suspend fun execute(
+        arguments: Map<String, Any>,
+        context: McpExecutionContext
+    ): McpToolResult {
+        // Check delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "...")
+        }
+        // Check admin role
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "...")
+        }
+        // Input validation
+        // Business logic
+        // Return result
+    }
+}
+```
+
+### 2. Workgroup Service Availability
+
+**Decision**: Reuse existing WorkgroupService methods directly from new MCP tools.
+
+**Rationale**: WorkgroupService already provides all needed functionality:
+- `createWorkgroup(name, description?, criticality?)`
+- `deleteWorkgroup(id)` with cascade
+- `assignUsersToWorkgroup(workgroupId, userIds)`
+- `assignAssetsToWorkgroup(workgroupId, assetIds)`
+- `listAllWorkgroups()`
+
+**Alternatives Considered**:
+- Create new methods: Rejected - existing methods are comprehensive
+- Bypass service layer: Rejected - violates architecture principles
+
+### 3. Asset Deletion Method
+
+**Decision**: Use existing `AssetCascadeDeleteService.deleteAsset()` for single asset deletion.
+
+**Rationale**: This method already handles:
+- Pessimistic locking (prevents concurrent deletion)
+- Cascade deletion (exception requests → exceptions → vulnerabilities → asset)
+- Audit logging
+
+**Alternatives Considered**:
+- Direct repository delete: Rejected - skips cascade and audit
+- New deletion method: Rejected - existing method is comprehensive
+
+### 4. MCP Key Generation UI Structure
+
+**Decision**: Add new permissions to `availablePermissions` array in `McpApiKeyManagement.tsx`.
+
+**Rationale**: The UI uses a hardcoded array for permission checkboxes. New permissions must be added to this array for UI visibility.
+
+**Key Findings**:
+- Location: `/src/frontend/src/components/McpApiKeyManagement.tsx`
+- Current permissions: REQUIREMENTS_READ/WRITE, ASSESSMENTS_READ/WRITE, ASSETS_READ, VULNERABILITIES_READ, SCANS_READ, TAGS_READ, SYSTEM_INFO, USER_ACTIVITY
+- Permission checkboxes rendered in 2-column grid
+
+**Note**: Tool list is NOT hardcoded in UI - tools are queried dynamically via `/api/mcp/capabilities`. Only permissions need UI update.
+
+### 5. E2E Test Script Pattern
+
+**Decision**: Follow existing E2E test pattern from `docs/E2E_EXCEPTION_WORKFLOW_TEST.md` using Bash with curl and jq.
+
+**Rationale**:
+- Aligns with clarification answer (Bash + curl + jq)
+- Existing pattern proven in similar E2E tests
+- Minimal dependencies (curl, jq, op CLI)
+
+**Script Structure**:
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Prerequisites check
+# 1Password credential resolution
+# Authentication
+# Test workflow execution
+# Assertions
+# Cleanup (with trap for failure handling)
+```
+
+### 6. McpPermission Enum Status
+
+**Decision**: Add new permission `WORKGROUPS_WRITE` to McpPermission enum.
+
+**Rationale**: Existing permissions don't cover workgroup management. Creating a dedicated permission follows the granular permission model.
+
+**Location**: `/src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt`
+
+## File Locations Summary
+
+### Backend (New MCP Tools)
+| File | Purpose |
+|------|---------|
+| `src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateWorkgroupTool.kt` | Create workgroup tool |
+| `src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteWorkgroupTool.kt` | Delete workgroup tool |
+| `src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignAssetsToWorkgroupTool.kt` | Assign assets tool |
+| `src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignUsersToWorkgroupTool.kt` | Assign users tool |
+| `src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAssetTool.kt` | Delete single asset tool |
+| `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt` | Tool registration (modify) |
+| `src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt` | Permission enum (modify) |
+
+### Existing Services (Reuse)
+| File | Purpose |
+|------|---------|
+| `src/backendng/src/main/kotlin/com/secman/service/WorkgroupService.kt` | Workgroup business logic |
+| `src/backendng/src/main/kotlin/com/secman/service/AssetCascadeDeleteService.kt` | Asset deletion with cascade |
+
+### Frontend (UI Update)
+| File | Purpose |
+|------|---------|
+| `src/frontend/src/components/McpApiKeyManagement.tsx` | Add WORKGROUPS_WRITE permission |
+
+### Test Script
+| File | Purpose |
+|------|---------|
+| `tests/mcp-e2e-workgroup-test.sh` | E2E test script |
+
+## Dependencies
+
+### Backend Dependencies (Already Available)
+- Micronaut 4.10 - DI framework
+- Hibernate JPA - ORM
+- Kotlin coroutines - Async execution
+
+### Test Script Dependencies
+- `curl` - HTTP client
+- `jq` - JSON parser
+- `op` - 1Password CLI v2.x
+
+## Authorization Model
+
+### Permission Hierarchy
+```
+WORKGROUPS_WRITE (new) - Grants access to:
+  - create_workgroup
+  - delete_workgroup
+  - assign_assets_to_workgroup
+  - assign_users_to_workgroup
+
+ASSETS_READ (existing) + context check - Grants access to:
+  - delete_asset (with isAdmin check)
+```
+
+### Access Control Flow
+1. API key must have required permission
+2. User delegation must be active for ADMIN operations
+3. Delegated user must have ADMIN role
+4. Context authorization check in each tool

--- a/specs/074-mcp-e2e-test/spec.md
+++ b/specs/074-mcp-e2e-test/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Feature Branch**: `074-mcp-e2e-test`
+**Created**: 2026-02-04
+**Status**: Draft
+**Input**: User description: "MCP E2E test script for complete user-asset-workgroup workflow using 1Password credentials"
+
+## Clarifications
+
+### Session 2026-02-04
+
+- Q: What language/technology should be used for the test script? → A: Bash script with `curl` and `jq` for MCP HTTP calls
+- Q: How should the test asset be cleaned up without affecting other assets? → A: Delete specific test asset by ID using targeted deletion
+- Addition: New MCP tools must be reflected in the MCP key generation UI for permission selection
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Complete MCP Workflow Validation (Priority: P1)
+
+A developer needs to validate the complete MCP workflow for user access control by running an automated E2E test script. The script creates test data (user, asset, vulnerability, workgroup), verifies access control works correctly, and cleans up after itself.
+
+**Why this priority**: This is the core deliverable - validating that MCP operations work correctly together and that workgroup-based access control functions as expected.
+
+**Independent Test**: Can be fully tested by running the test script against a local secman instance. Success is measured by the script completing without errors and the TEST user seeing exactly one asset.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running secman instance with ADMIN credentials available via environment variables, **When** the test script runs, **Then** a TEST user with VULN role is created successfully
+2. **Given** the TEST user exists, **When** an asset is added with a CRITICAL vulnerability (10 days open), **Then** the asset and vulnerability are created and linked correctly
+3. **Given** the asset exists, **When** a workgroup is created and the asset is assigned to it, **Then** the workgroup contains the asset
+4. **Given** the workgroup exists with the asset, **When** the TEST user is assigned to the workgroup, **Then** the TEST user has access to the asset
+5. **Given** the TEST user is assigned to the workgroup, **When** switching to TEST user context and listing assets, **Then** exactly one asset is returned (the test asset)
+6. **Given** test data exists, **When** cleanup runs, **Then** all test-created entities are removed (user, asset, workgroup)
+
+---
+
+### User Story 2 - Missing MCP Tool Implementation (Priority: P1)
+
+The test script requires MCP operations that do not currently exist. These missing operations must be implemented before the test can run entirely through MCP.
+
+**Why this priority**: Without these tools, the test script cannot be "all driven via MCP" as required.
+
+**Independent Test**: Each new MCP tool can be tested independently by calling it via the MCP protocol and verifying the operation succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workgroup name and description, **When** calling `create_workgroup` MCP tool, **Then** a new workgroup is created and its ID returned
+2. **Given** a workgroup ID and asset IDs, **When** calling `assign_assets_to_workgroup` MCP tool, **Then** the assets are assigned to the workgroup
+3. **Given** a workgroup ID and user IDs, **When** calling `assign_users_to_workgroup` MCP tool, **Then** the users are assigned to the workgroup
+4. **Given** a workgroup ID, **When** calling `delete_workgroup` MCP tool, **Then** the workgroup is deleted
+
+---
+
+### User Story 3 - Secure Credential Management (Priority: P2)
+
+The test script uses 1Password CLI to securely retrieve credentials rather than storing them in plain text. Environment variables reference 1Password secret URIs.
+
+**Why this priority**: Security best practice - credentials should never be hardcoded or stored in plain text in test scripts.
+
+**Independent Test**: Can be tested by configuring 1Password URIs and verifying the script retrieves credentials successfully before making API calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** environment variables `SECMAN_USERNAME`, `SECMAN_PASSWORD`, `SECMAN_API_KEY` set with 1Password URIs (e.g., `op://test/secman/SECMAN_USERNAME`), **When** the test script starts, **Then** credentials are resolved using `op run` or `op read`
+2. **Given** 1Password credentials are resolved, **When** authenticating to secman, **Then** authentication succeeds and a session token is obtained
+3. **Given** 1Password is not available or credentials are missing, **When** the test script starts, **Then** a clear error message is shown explaining the missing prerequisites
+
+---
+
+### User Story 4 - MCP Key Generation UI Update (Priority: P1)
+
+When new MCP tools are added, the MCP key generation UI must be updated to display these tools so users can select appropriate permissions when creating API keys.
+
+**Why this priority**: Without UI updates, users cannot grant permissions for the new workgroup management tools when generating MCP keys, making the tools unusable in practice.
+
+**Independent Test**: Can be tested by navigating to the MCP key generation UI and verifying all new tools appear in the tool selection list.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new MCP tools are implemented, **When** a user navigates to the MCP key generation UI, **Then** the new workgroup tools (`create_workgroup`, `assign_assets_to_workgroup`, `assign_users_to_workgroup`, `delete_workgroup`) are visible in the tool list
+2. **Given** the new `delete_asset` tool is implemented, **When** a user navigates to the MCP key generation UI, **Then** the `delete_asset` tool is visible in the tool list
+3. **Given** a user selects workgroup management tools, **When** generating an MCP key, **Then** the generated key includes permissions for the selected tools
+
+---
+
+### Edge Cases
+
+- What happens when the TEST user already exists from a previous failed run? The script should handle cleanup gracefully or detect and remove stale test data at startup.
+- What happens when 1Password CLI (`op`) is not installed? The script should fail fast with a clear error message.
+- What happens when the secman backend is not reachable? The script should timeout with a meaningful error.
+- What happens when a workgroup with the same name exists? The script should use unique names (e.g., with timestamp) or clean up first.
+- What happens if cleanup fails midway? Partial cleanup should be handled gracefully with warnings about remaining artifacts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**New MCP Tools:**
+- **FR-001**: System MUST provide MCP tool `create_workgroup` that creates a workgroup with specified name and description (ADMIN role required)
+- **FR-002**: System MUST provide MCP tool `assign_assets_to_workgroup` that assigns assets to a workgroup by IDs (ADMIN role required)
+- **FR-003**: System MUST provide MCP tool `assign_users_to_workgroup` that assigns users to a workgroup by IDs (ADMIN role required)
+- **FR-004**: System MUST provide MCP tool `delete_workgroup` that removes a workgroup by ID (ADMIN role required)
+- **FR-004a**: System MUST provide MCP tool `delete_asset` that removes a specific asset by ID (ADMIN role required)
+
+**Test Script Workflow:**
+- **FR-005**: Test script MUST use 1Password CLI to resolve credentials from environment variable URIs
+- **FR-006**: Test script MUST authenticate using provided credentials before performing MCP operations
+- **FR-007**: Test script MUST create a user named "TEST" with VULN role via MCP
+- **FR-008**: Test script MUST create an asset via MCP (using `add_vulnerability` which auto-creates assets)
+- **FR-009**: Test script MUST add a CRITICAL vulnerability to the asset that is 10 days old via MCP
+- **FR-010**: Test script MUST create a workgroup and assign the asset to it via MCP
+- **FR-011**: Test script MUST assign the TEST user to the workgroup via MCP
+- **FR-012**: Test script MUST switch MCP context to TEST user and list visible assets
+- **FR-013**: Test script MUST verify TEST user sees exactly one asset (the test asset)
+- **FR-014**: Test script MUST clean up all test data after execution by deleting specific entities by ID (user via `delete_user`, asset via `delete_asset`, workgroup via `delete_workgroup`)
+
+**MCP Key Generation UI:**
+- **FR-019**: MCP key generation UI MUST display all new workgroup tools (`create_workgroup`, `assign_assets_to_workgroup`, `assign_users_to_workgroup`, `delete_workgroup`) in the tool selection list
+- **FR-020**: MCP key generation UI MUST display the `delete_asset` tool in the tool selection list
+- **FR-021**: MCP key generation UI MUST allow users to select/deselect individual new tools when configuring key permissions
+
+**Test Script Requirements:**
+- **FR-015**: Test script MUST be stored in the `tests` folder
+- **FR-016**: Test script MUST exit with code 0 on success, non-zero on failure
+- **FR-017**: Test script MUST not log or echo credential values to output
+- **FR-018**: Test script MUST be implemented as a Bash script using `curl` for HTTP calls and `jq` for JSON parsing
+
+### Key Entities
+
+- **User**: Test user with VULN role, identified by username and email
+- **Asset**: Test asset with a name, type, and associated vulnerability
+- **Vulnerability**: CRITICAL severity vulnerability linked to the asset, with detection date 10 days in the past
+- **Workgroup**: Container that groups users and assets for access control purposes
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Test script completes full workflow (create, verify, cleanup) in under 2 minutes on localhost
+- **SC-002**: All 5 new MCP tools (create_workgroup, assign_assets_to_workgroup, assign_users_to_workgroup, delete_workgroup, delete_asset) are implemented and callable
+- **SC-003**: TEST user, when listing assets via MCP, sees exactly 1 asset after workgroup assignment
+- **SC-004**: After cleanup, no test artifacts remain in the system (user, asset, workgroup all deleted)
+- **SC-005**: Test script works with 1Password-referenced environment variables without exposing credentials in logs
+- **SC-006**: Security review confirms no credential leakage, proper authorization checks, and input validation in new MCP tools
+- **SC-007**: MCP key generation UI displays all 5 new tools and allows permission selection
+
+## Assumptions
+
+- `curl` and `jq` are installed on the test machine for HTTP calls and JSON parsing
+- 1Password CLI (`op`) version 2.x is installed and configured on the test machine
+- The secman backend is running and accessible at localhost (default configuration)
+- The ADMIN user credentials stored in 1Password have sufficient permissions to create users, assets, and workgroups
+- MCP endpoint is available at the standard secman API path
+- Test user email will use `test@example.com` format
+- Existing `add_user`, `add_vulnerability`, `delete_user`, and `get_assets` MCP tools function correctly
+- User delegation via `X-MCP-User-Email` header is the mechanism for switching user context in MCP

--- a/specs/074-mcp-e2e-test/tasks.md
+++ b/specs/074-mcp-e2e-test/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: MCP E2E Test - User-Asset-Workgroup Workflow
+
+**Input**: Design documents from `/specs/074-mcp-e2e-test/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Permission Infrastructure)
+
+**Purpose**: Add the WORKGROUPS_WRITE permission that all new MCP tools will require
+
+- [x] T001 [US2] Add `WORKGROUPS_WRITE` enum value to `src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt`
+
+**Checkpoint**: Permission enum ready - MCP tool implementation can begin
+
+---
+
+## Phase 2: User Story 2 - MCP Tool Implementation (Priority: P1) 🎯 MVP
+
+**Goal**: Implement 5 new MCP tools for workgroup management and asset deletion
+
+**Independent Test**: Each tool can be tested via curl calls to `/api/mcp/tools/call`
+
+### Implementation for User Story 2
+
+- [x] T002 [P] [US2] Create `CreateWorkgroupTool.kt` in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` implementing McpTool interface with WorkgroupService.createWorkgroup()
+- [x] T003 [P] [US2] Create `DeleteWorkgroupTool.kt` in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` implementing McpTool interface with WorkgroupService.deleteWorkgroup()
+- [x] T004 [P] [US2] Create `AssignAssetsToWorkgroupTool.kt` in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` implementing McpTool interface with WorkgroupService.assignAssetsToWorkgroup()
+- [x] T005 [P] [US2] Create `AssignUsersToWorkgroupTool.kt` in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` implementing McpTool interface with WorkgroupService.assignUsersToWorkgroup()
+- [x] T006 [P] [US2] Create `DeleteAssetTool.kt` in `src/backendng/src/main/kotlin/com/secman/mcp/tools/` implementing McpTool interface with AssetCascadeDeleteService.deleteAsset()
+- [x] T007 [US2] Register all 5 new tools in `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt` - inject tools and add to tools map
+- [x] T008 [US2] Add authorization mappings for new tools in McpToolRegistry.isToolAuthorized() mapping tool names to WORKGROUPS_WRITE permission
+- [x] T009 [US2] Verify backend compiles with `./gradlew build` from `src/backendng/`
+
+**Checkpoint**: All 5 MCP tools are implemented and registered - can be tested via MCP protocol
+
+---
+
+## Phase 3: User Story 4 - MCP Key Generation UI (Priority: P1)
+
+**Goal**: Update frontend to display WORKGROUPS_WRITE permission in MCP key generation
+
+**Independent Test**: Navigate to MCP API Keys page and verify new permission checkbox appears
+
+**Note**: Can run in parallel with Phase 2 (US2) after T001 completes
+
+### Implementation for User Story 4
+
+- [x] T010 [US4] Add `'WORKGROUPS_WRITE'` to `availablePermissions` array in `src/frontend/src/components/McpApiKeyManagement.tsx`
+- [x] T011 [US4] Verify frontend builds with `npm run build` from `src/frontend/`
+
+**Checkpoint**: UI displays new permission - users can grant workgroup management access to API keys
+
+---
+
+## Phase 4: User Story 1 + User Story 3 - E2E Test Script (Priority: P1/P2)
+
+**Goal**: Create Bash test script with 1Password credential management that validates the complete workflow
+
+**Independent Test**: Run `./tests/mcp-e2e-workgroup-test.sh` against local secman instance
+
+**Dependencies**: Requires Phase 2 (US2) to be complete - test script calls the new MCP tools
+
+### Implementation for User Stories 1 & 3
+
+- [x] T012 [US1/US3] Create `tests/` directory at repository root if not exists
+- [x] T013 [US1/US3] Create `tests/mcp-e2e-workgroup-test.sh` with shebang and `set -euo pipefail`
+- [x] T014 [US3] Implement `check_prerequisites()` function - verify curl, jq, op CLI are available
+- [x] T015 [US3] Implement `resolve_credentials()` function - use `op read` to resolve 1Password URIs from SECMAN_USERNAME, SECMAN_PASSWORD, SECMAN_API_KEY environment variables
+- [x] T016 [US1] Implement `authenticate()` function - POST to /api/auth/login and extract JWT token
+- [x] T017 [US1] Implement `mcp_call()` helper function - curl wrapper for MCP tool calls with auth headers
+- [x] T018 [US1] Implement `create_test_user()` function - call add_user MCP tool for TEST user with VULN role
+- [x] T019 [US1] Implement `create_test_asset_with_vulnerability()` function - call add_vulnerability MCP tool (auto-creates asset)
+- [x] T020 [US1] Implement `create_test_workgroup()` function - call create_workgroup MCP tool
+- [x] T021 [US1] Implement `assign_asset_to_workgroup()` function - call assign_assets_to_workgroup MCP tool
+- [x] T022 [US1] Implement `assign_user_to_workgroup()` function - call assign_users_to_workgroup MCP tool
+- [x] T023 [US1] Implement `verify_access_as_test_user()` function - switch X-MCP-User-Email header to test@example.com and call get_assets, assert count equals 1
+- [x] T024 [US1] Implement `cleanup()` function - call delete_workgroup, delete_asset, delete_user MCP tools in order
+- [x] T025 [US1] Add `trap cleanup EXIT` for cleanup on failure
+- [x] T026 [US1] Implement `main()` function orchestrating full workflow with progress output
+- [x] T027 [US1/US3] Ensure no credential values are echoed to output (FR-017)
+- [x] T028 [US1] Make script executable with `chmod +x tests/mcp-e2e-workgroup-test.sh`
+
+**Checkpoint**: E2E test script complete - validates entire user-asset-workgroup workflow
+
+---
+
+## Phase 5: Polish & Validation
+
+**Purpose**: Final verification and security review
+
+- [x] T029 Verify full backend build passes: `./gradlew build` from `src/backendng/`
+- [x] T030 [P] Verify frontend build passes: `npm run build` from `src/frontend/`
+- [ ] T031 Run E2E test script against local instance and verify all assertions pass
+- [x] T032 Security review: Verify authorization checks in all 5 new MCP tools
+- [x] T033 Security review: Verify test script does not log credentials
+- [x] T034 Update `docs/MCP.md` to document new workgroup management tools
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (T001)           ─┬─► Phase 2 (T002-T009) ─► Phase 4 (T012-T028) ─► Phase 5
+                         │
+                         └─► Phase 3 (T010-T011) ─────────────────────────►
+```
+
+- **Phase 1**: No dependencies - start immediately
+- **Phase 2 (US2)**: Depends on T001 (permission enum)
+- **Phase 3 (US4)**: Depends on T001 (permission enum) - can run parallel to Phase 2
+- **Phase 4 (US1/US3)**: Depends on Phase 2 completion (needs MCP tools to exist)
+- **Phase 5**: Depends on Phases 2, 3, and 4
+
+### Parallel Opportunities
+
+**After T001 completes**, launch in parallel:
+- T002, T003, T004, T005, T006 (all MCP tool implementations - different files)
+- T010 (frontend update - different codebase)
+
+**Within Phase 4**, some test script functions can be developed in parallel but must be integrated sequentially.
+
+---
+
+## Implementation Strategy
+
+### Recommended Order (Single Developer)
+
+1. T001 → Permission enum
+2. T002-T006 (parallel) → All 5 MCP tools
+3. T007-T008 → Registry updates
+4. T009 → Backend build verification
+5. T010-T011 → Frontend update
+6. T012-T028 → Test script
+7. T029-T034 → Final validation
+
+### Task Summary
+
+| Phase | Tasks | Story | Description |
+|-------|-------|-------|-------------|
+| 1 | T001 | US2 | Permission infrastructure |
+| 2 | T002-T009 | US2 | 5 MCP tools + registry |
+| 3 | T010-T011 | US4 | Frontend UI update |
+| 4 | T012-T028 | US1/US3 | E2E test script |
+| 5 | T029-T034 | All | Validation & security |
+
+**Total Tasks**: 34
+**Completed**: 33
+**Remaining**: 1 (T031: E2E test run - requires running backend)

--- a/src/backendng/.claude/settings.local.json
+++ b/src/backendng/.claude/settings.local.json
@@ -13,7 +13,13 @@
       "Bash(git checkout:*)",
       "Bash(git branch:*)",
       "Bash(./.specify/scripts/bash/check-prerequisites.sh:*)",
-      "Bash(./.specify/scripts/bash/setup-plan.sh:*)"
+      "Bash(./.specify/scripts/bash/setup-plan.sh:*)",
+      "Bash(git fetch:*)",
+      "Bash(grep:*)",
+      "Bash(./.specify/scripts/bash/update-agent-context.sh:*)",
+      "Bash(DEBUG=1 ./tests/mcp-e2e-workgroup-test.sh:*)",
+      "Bash(op read:*)",
+      "Bash(./tests/mcp-e2e-workgroup-test.sh:*)"
     ],
     "deny": []
   }

--- a/src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/McpPermission.kt
@@ -78,7 +78,13 @@ enum class McpPermission {
     /**
      * Read vulnerability data - allows get_vulnerabilities tool
      */
-    VULNERABILITIES_READ;
+    VULNERABILITIES_READ,
+
+    /**
+     * Manage workgroups - allows create_workgroup, delete_workgroup, assign_assets_to_workgroup,
+     * assign_users_to_workgroup MCP tools (admin only)
+     */
+    WORKGROUPS_WRITE;
 
     /**
      * Get display name for UI
@@ -100,6 +106,7 @@ enum class McpPermission {
             ASSETS_READ -> "Read Assets"
             SCANS_READ -> "Read Scans"
             VULNERABILITIES_READ -> "Read Vulnerabilities"
+            WORKGROUPS_WRITE -> "Manage Workgroups"
         }
     }
 
@@ -123,6 +130,7 @@ enum class McpPermission {
             ASSETS_READ -> "View and search asset inventory"
             SCANS_READ -> "View scan data and results"
             VULNERABILITIES_READ -> "View vulnerability information"
+            WORKGROUPS_WRITE -> "Create, delete, and manage workgroup memberships (admin only)"
         }
     }
 
@@ -131,7 +139,7 @@ enum class McpPermission {
      */
     fun requiresAdmin(): Boolean {
         return when (this) {
-            AUDIT_READ, USER_ACTIVITY, SYSTEM_INFO -> true
+            AUDIT_READ, USER_ACTIVITY, SYSTEM_INFO, WORKGROUPS_WRITE -> true
             else -> false
         }
     }

--- a/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/AddVulnerabilityResponseDto.kt
@@ -10,6 +10,7 @@ import io.micronaut.serde.annotation.Serdeable
 data class AddVulnerabilityResponseDto(
     val success: Boolean,
     val message: String,
+    val assetId: Long,
     val assetName: String,
     val assetCreated: Boolean,
     val vulnerabilityId: String,

--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -62,7 +62,13 @@ class McpToolRegistry(
     @Inject private val startAlignmentTool: StartAlignmentTool,
     @Inject private val submitReviewTool: SubmitReviewTool,
     @Inject private val getAlignmentStatusTool: GetAlignmentStatusTool,
-    @Inject private val finalizeAlignmentTool: FinalizeAlignmentTool
+    @Inject private val finalizeAlignmentTool: FinalizeAlignmentTool,
+    // Feature 074: MCP Tools for Workgroup Management
+    @Inject private val createWorkgroupTool: CreateWorkgroupTool,
+    @Inject private val deleteWorkgroupTool: DeleteWorkgroupTool,
+    @Inject private val assignAssetsToWorkgroupTool: AssignAssetsToWorkgroupTool,
+    @Inject private val assignUsersToWorkgroupTool: AssignUsersToWorkgroupTool,
+    @Inject private val deleteAssetTool: DeleteAssetTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -121,7 +127,13 @@ class McpToolRegistry(
             startAlignmentTool,
             submitReviewTool,
             getAlignmentStatusTool,
-            finalizeAlignmentTool
+            finalizeAlignmentTool,
+            // Feature 074: MCP Tools for Workgroup Management
+            createWorkgroupTool,
+            deleteWorkgroupTool,
+            assignAssetsToWorkgroupTool,
+            assignUsersToWorkgroupTool,
+            deleteAssetTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -336,6 +348,14 @@ class McpToolRegistry(
             }
             "get_alignment_status" -> {
                 permissions.contains(McpPermission.REQUIREMENTS_READ) // Any authenticated user with delegation
+            }
+
+            // Feature 074: MCP Tools for Workgroup Management (ADMIN only via User Delegation)
+            "create_workgroup", "delete_workgroup", "assign_assets_to_workgroup", "assign_users_to_workgroup" -> {
+                permissions.contains(McpPermission.WORKGROUPS_WRITE) // ADMIN role checked in tool execute()
+            }
+            "delete_asset" -> {
+                permissions.contains(McpPermission.ASSETS_READ) // ADMIN role checked in tool execute()
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddVulnerabilityTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddVulnerabilityTool.kt
@@ -136,6 +136,7 @@ class AddVulnerabilityTool(
             val result = mapOf(
                 "success" to response.success,
                 "vulnerabilityId" to response.vulnerabilityId,
+                "assetId" to response.assetId,
                 "assetName" to response.assetName,
                 "assetCreated" to response.assetCreated,
                 "vulnerabilityCreated" to isNewVuln,

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignAssetsToWorkgroupTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignAssetsToWorkgroupTool.kt
@@ -1,0 +1,97 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.WorkgroupService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for assigning assets to a workgroup.
+ * Feature: 074-mcp-e2e-test
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - workgroupId (required): ID of the target workgroup
+ * - assetIds (required): List of asset IDs to assign
+ */
+@Singleton
+class AssignAssetsToWorkgroupTool(
+    @Inject private val workgroupService: WorkgroupService
+) : McpTool {
+
+    override val name = "assign_assets_to_workgroup"
+    override val description = "Assign one or more assets to a workgroup (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "workgroupId" to mapOf(
+                "type" to "number",
+                "description" to "The ID of the target workgroup"
+            ),
+            "assetIds" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "number"),
+                "description" to "List of asset IDs to assign to the workgroup"
+            )
+        ),
+        "required" to listOf("workgroupId", "assetIds")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to assign assets to workgroups"
+            )
+        }
+
+        // Extract and validate required parameters
+        val workgroupId = (arguments["workgroupId"] as? Number)?.toLong()
+        if (workgroupId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "workgroupId is required and must be a valid number")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val assetIdsRaw = arguments["assetIds"] as? List<*>
+        if (assetIdsRaw.isNullOrEmpty()) {
+            return McpToolResult.error("VALIDATION_ERROR", "assetIds is required and cannot be empty")
+        }
+
+        val assetIds = try {
+            assetIdsRaw.map { (it as Number).toLong() }
+        } catch (e: Exception) {
+            return McpToolResult.error("VALIDATION_ERROR", "assetIds must be a list of valid numbers")
+        }
+
+        try {
+            workgroupService.assignAssetsToWorkgroup(workgroupId, assetIds)
+
+            val result = mapOf(
+                "workgroupId" to workgroupId,
+                "assignedCount" to assetIds.size,
+                "assetIds" to assetIds,
+                "message" to "${assetIds.size} asset(s) assigned to workgroup $workgroupId"
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("NOT_FOUND", e.message ?: "Workgroup or asset not found")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to assign assets to workgroup: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignUsersToWorkgroupTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssignUsersToWorkgroupTool.kt
@@ -1,0 +1,97 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.WorkgroupService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for assigning users to a workgroup.
+ * Feature: 074-mcp-e2e-test
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - workgroupId (required): ID of the target workgroup
+ * - userIds (required): List of user IDs to assign
+ */
+@Singleton
+class AssignUsersToWorkgroupTool(
+    @Inject private val workgroupService: WorkgroupService
+) : McpTool {
+
+    override val name = "assign_users_to_workgroup"
+    override val description = "Assign one or more users to a workgroup (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "workgroupId" to mapOf(
+                "type" to "number",
+                "description" to "The ID of the target workgroup"
+            ),
+            "userIds" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "number"),
+                "description" to "List of user IDs to assign to the workgroup"
+            )
+        ),
+        "required" to listOf("workgroupId", "userIds")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to assign users to workgroups"
+            )
+        }
+
+        // Extract and validate required parameters
+        val workgroupId = (arguments["workgroupId"] as? Number)?.toLong()
+        if (workgroupId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "workgroupId is required and must be a valid number")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val userIdsRaw = arguments["userIds"] as? List<*>
+        if (userIdsRaw.isNullOrEmpty()) {
+            return McpToolResult.error("VALIDATION_ERROR", "userIds is required and cannot be empty")
+        }
+
+        val userIds = try {
+            userIdsRaw.map { (it as Number).toLong() }
+        } catch (e: Exception) {
+            return McpToolResult.error("VALIDATION_ERROR", "userIds must be a list of valid numbers")
+        }
+
+        try {
+            workgroupService.assignUsersToWorkgroup(workgroupId, userIds)
+
+            val result = mapOf(
+                "workgroupId" to workgroupId,
+                "assignedCount" to userIds.size,
+                "userIds" to userIds,
+                "message" to "${userIds.size} user(s) assigned to workgroup $workgroupId"
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("NOT_FOUND", e.message ?: "Workgroup or user not found")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to assign users to workgroup: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateWorkgroupTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateWorkgroupTool.kt
@@ -1,0 +1,96 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.WorkgroupService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for creating a new workgroup.
+ * Feature: 074-mcp-e2e-test
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - name (required): Unique name for the workgroup
+ * - description (optional): Description of the workgroup
+ */
+@Singleton
+class CreateWorkgroupTool(
+    @Inject private val workgroupService: WorkgroupService
+) : McpTool {
+
+    override val name = "create_workgroup"
+    override val description = "Create a new workgroup (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "name" to mapOf(
+                "type" to "string",
+                "description" to "Unique name for the workgroup (1-100 characters)"
+            ),
+            "description" to mapOf(
+                "type" to "string",
+                "description" to "Optional description of the workgroup (max 512 characters)"
+            )
+        ),
+        "required" to listOf("name")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to create workgroups"
+            )
+        }
+
+        // Extract and validate required parameters
+        val name = (arguments["name"] as? String)?.trim()
+        if (name.isNullOrBlank()) {
+            return McpToolResult.error("VALIDATION_ERROR", "Workgroup name is required")
+        }
+
+        if (name.length > 100) {
+            return McpToolResult.error("VALIDATION_ERROR", "Workgroup name must be 100 characters or less")
+        }
+
+        val description = (arguments["description"] as? String)?.trim()
+        if (description != null && description.length > 512) {
+            return McpToolResult.error("VALIDATION_ERROR", "Description must be 512 characters or less")
+        }
+
+        try {
+            val workgroup = workgroupService.createWorkgroup(
+                name = name,
+                description = description
+            )
+
+            val result = mapOf(
+                "id" to workgroup.id,
+                "name" to workgroup.name,
+                "description" to workgroup.description,
+                "message" to "Workgroup '${workgroup.name}' created successfully"
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("DUPLICATE_ERROR", e.message ?: "Workgroup creation failed")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to create workgroup: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAssetTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAssetTool.kt
@@ -1,0 +1,116 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.AssetCascadeDeleteService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for deleting a specific asset by ID.
+ * Feature: 074-mcp-e2e-test
+ *
+ * ADMIN role is required via User Delegation.
+ * Uses AssetCascadeDeleteService for cascade deletion of:
+ * - Vulnerability exception requests
+ * - ASSET-type vulnerability exceptions
+ * - Vulnerabilities
+ * - Asset
+ *
+ * Input parameters:
+ * - assetId (required): ID of the asset to delete
+ * - forceTimeout (optional): Force deletion even if it may exceed timeout (default: false)
+ */
+@Singleton
+class DeleteAssetTool(
+    @Inject private val assetCascadeDeleteService: AssetCascadeDeleteService
+) : McpTool {
+
+    override val name = "delete_asset"
+    override val description = "Delete a specific asset by ID with cascade deletion (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.DELETE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "assetId" to mapOf(
+                "type" to "number",
+                "description" to "The ID of the asset to delete"
+            ),
+            "forceTimeout" to mapOf(
+                "type" to "boolean",
+                "description" to "Force deletion even if it may exceed timeout (default: false)"
+            )
+        ),
+        "required" to listOf("assetId")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to delete assets"
+            )
+        }
+
+        // Extract and validate required parameters
+        val assetId = (arguments["assetId"] as? Number)?.toLong()
+        if (assetId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "assetId is required and must be a valid number")
+        }
+
+        val forceTimeout = arguments["forceTimeout"] as? Boolean ?: false
+
+        // Get username from delegation context
+        val username = context.delegatedUserEmail ?: "mcp-system"
+
+        try {
+            val deletionResult = assetCascadeDeleteService.deleteAsset(
+                assetId = assetId,
+                username = username,
+                forceTimeout = forceTimeout
+            )
+
+            val result = mapOf(
+                "id" to deletionResult.assetId,
+                "name" to deletionResult.assetName,
+                "vulnerabilitiesDeleted" to deletionResult.deletedVulnerabilities,
+                "exceptionsDeleted" to deletionResult.deletedExceptions,
+                "requestsDeleted" to deletionResult.deletedRequests,
+                "auditLogId" to deletionResult.auditLogId,
+                "message" to "Asset '${deletionResult.assetName}' (ID: $assetId) deleted successfully"
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: AssetCascadeDeleteService.AssetNotFoundException) {
+            return McpToolResult.error("NOT_FOUND", "Asset with ID $assetId not found")
+        } catch (e: AssetCascadeDeleteService.TimeoutWarningException) {
+            return McpToolResult.error(
+                "TIMEOUT_WARNING",
+                "Estimated deletion time (${e.estimatedSeconds}s) exceeds timeout. Use forceTimeout=true to proceed anyway.",
+                mapOf(
+                    "assetId" to e.assetId,
+                    "assetName" to e.assetName,
+                    "estimatedSeconds" to e.estimatedSeconds
+                )
+            )
+        } catch (e: jakarta.persistence.PessimisticLockException) {
+            return McpToolResult.error(
+                "LOCKED",
+                "Asset is currently being modified by another operation. Please try again."
+            )
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to delete asset: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteWorkgroupTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteWorkgroupTool.kt
@@ -1,0 +1,83 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.WorkgroupService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for deleting a workgroup.
+ * Feature: 074-mcp-e2e-test
+ *
+ * ADMIN role is required via User Delegation.
+ * Cascade deletion of user and asset associations is handled by JPA.
+ *
+ * Input parameters:
+ * - workgroupId (required): ID of the workgroup to delete
+ */
+@Singleton
+class DeleteWorkgroupTool(
+    @Inject private val workgroupService: WorkgroupService
+) : McpTool {
+
+    override val name = "delete_workgroup"
+    override val description = "Delete a workgroup by ID (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.DELETE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "workgroupId" to mapOf(
+                "type" to "number",
+                "description" to "The ID of the workgroup to delete"
+            )
+        ),
+        "required" to listOf("workgroupId")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Require User Delegation
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        // Require ADMIN role
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to delete workgroups"
+            )
+        }
+
+        // Extract and validate required parameters
+        val workgroupId = (arguments["workgroupId"] as? Number)?.toLong()
+        if (workgroupId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "workgroupId is required and must be a valid number")
+        }
+
+        try {
+            // Get workgroup info before deletion
+            val workgroup = workgroupService.getWorkgroupById(workgroupId)
+            val workgroupName = workgroup.name
+
+            workgroupService.deleteWorkgroup(workgroupId)
+
+            val result = mapOf(
+                "id" to workgroupId,
+                "name" to workgroupName,
+                "message" to "Workgroup '$workgroupName' (ID: $workgroupId) deleted successfully"
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("NOT_FOUND", e.message ?: "Workgroup not found")
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to delete workgroup: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/McpToolPermissionService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/McpToolPermissionService.kt
@@ -213,6 +213,13 @@ class McpToolPermissionService(
             "add_vulnerability" -> {
                 permissions.contains(McpPermission.VULNERABILITIES_READ)
             }
+            // Feature 074: MCP Tools for Workgroup Management
+            "create_workgroup", "delete_workgroup", "assign_assets_to_workgroup", "assign_users_to_workgroup" -> {
+                permissions.contains(McpPermission.WORKGROUPS_WRITE)
+            }
+            "delete_asset" -> {
+                permissions.contains(McpPermission.ASSETS_READ)
+            }
             else -> false
         }
     }

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -1111,6 +1111,7 @@ open class VulnerabilityService(
         return AddVulnerabilityResponseDto(
             success = true,
             message = message,
+            assetId = asset.id!!,
             assetName = asset.name,
             assetCreated = assetCreated,
             vulnerabilityId = request.cve,

--- a/src/backendng/src/main/resources/email-templates/admin-summary.html
+++ b/src/backendng/src/main/resources/email-templates/admin-summary.html
@@ -1,122 +1,146 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SecMan Admin Summary</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-        }
-        .header {
-            background-color: #0d6efd;
-            color: white;
-            padding: 20px;
-            text-align: center;
-            border-radius: 5px 5px 0 0;
-        }
-        .content {
-            background-color: #f8f9fa;
-            padding: 20px;
-            border-radius: 0 0 5px 5px;
-        }
-        .stats-box {
-            background-color: white;
-            border-radius: 5px;
-            padding: 20px;
-            margin: 20px 0;
-        }
-        .stat-item {
-            display: flex;
-            justify-content: space-between;
-            padding: 12px 0;
-            border-bottom: 1px solid #e9ecef;
-        }
-        .stat-item:last-child {
-            border-bottom: none;
-        }
-        .stat-label {
-            font-weight: bold;
-            color: #495057;
-        }
-        .stat-value {
-            font-size: 1.2em;
-            color: #0d6efd;
-            font-weight: bold;
-        }
-        .info-box {
-            background-color: #cfe2ff;
-            border-left: 4px solid #0d6efd;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .footer {
-            text-align: center;
-            color: #6c757d;
-            font-size: 12px;
-            margin-top: 30px;
-            padding-top: 20px;
-            border-top: 1px solid #ddd;
-        }
-    </style>
-</head>
-<body>
-    <div class="header">
-        <h1>SecMan Admin Summary</h1>
-    </div>
-
-    <div class="content">
-        <p>Hello Administrator,</p>
-
-        <div class="info-box">
-            <strong>System Statistics Report</strong><br>
-            Generated on: ${executionDate}
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>SecMan Admin Summary</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                line-height: 1.6;
+                color: #333;
+                max-width: 600px;
+                margin: 0 auto;
+                padding: 20px;
+            }
+            .header {
+                background-color: #0d6efd;
+                color: white;
+                padding: 20px;
+                text-align: center;
+                border-radius: 5px 5px 0 0;
+            }
+            .content {
+                background-color: #f8f9fa;
+                padding: 20px;
+                border-radius: 0 0 5px 5px;
+            }
+            .stats-box {
+                background-color: white;
+                border-radius: 5px;
+                padding: 20px;
+                margin: 20px 0;
+            }
+            .stat-item {
+                display: flex;
+                justify-content: space-between;
+                padding: 12px 0;
+                border-bottom: 1px solid #e9ecef;
+            }
+            .stat-item:last-child {
+                border-bottom: none;
+            }
+            .stat-label {
+                font-weight: bold;
+                color: #495057;
+            }
+            .stat-value {
+                font-size: 1.2em;
+                color: #0d6efd;
+                font-weight: bold;
+            }
+            .info-box {
+                background-color: #cfe2ff;
+                border-left: 4px solid #0d6efd;
+                padding: 15px;
+                margin: 20px 0;
+            }
+            .footer {
+                text-align: center;
+                color: #6c757d;
+                font-size: 12px;
+                margin-top: 30px;
+                padding-top: 20px;
+                border-top: 1px solid #ddd;
+            }
+        </style>
+    </head>
+    <body>
+        <img
+            src="https://secman.covestro.net/SecManLogo.png"
+            alt="SecMan Logo"
+        />
+        <div class="header">
+            <h1>SecMan Admin Summary</h1>
         </div>
 
-        <div class="stats-box">
-            <h3 style="margin-top: 0;">Current System Statistics</h3>
+        <div class="content">
+            <p>Hello Administrator,</p>
 
-            <div class="stat-item">
-                <span class="stat-label">Total Users</span>
-                <span class="stat-value">${userCount}</span>
+            <div class="info-box">
+                <strong>System Statistics Report</strong><br />
+                Generated on: ${executionDate}
             </div>
 
-            <div class="stat-item">
-                <span class="stat-label">Total Vulnerabilities</span>
-                <span class="stat-value">${vulnerabilityCount}</span>
+            <div class="stats-box">
+                <h3 style="margin-top: 0">Current System Statistics</h3>
+
+                <div class="stat-item">
+                    <span class="stat-label">Total Users</span>
+                    <span class="stat-value">${userCount}</span>
+                </div>
+
+                <div class="stat-item">
+                    <span class="stat-label">Total Vulnerabilities</span>
+                    <span class="stat-value">${vulnerabilityCount}</span>
+                </div>
+
+                <div class="stat-item">
+                    <span class="stat-label">Total Assets</span>
+                    <span class="stat-value">${assetCount}</span>
+                </div>
             </div>
 
-            <div class="stat-item">
-                <span class="stat-label">Total Assets</span>
-                <span class="stat-value">${assetCount}</span>
+            <div style="text-align: center; margin: 25px 0">
+                <a
+                    href="${vulnerabilityStatisticsUrl}"
+                    style="
+                        display: inline-block;
+                        background-color: #0d6efd;
+                        color: white;
+                        padding: 12px 30px;
+                        text-decoration: none;
+                        border-radius: 5px;
+                        font-weight: bold;
+                        font-size: 1.1em;
+                    "
+                    >View Vulnerability Statistics</a
+                >
             </div>
+
+            <div class="stats-box">
+                <h3 style="margin-top: 0">Top 10 Most Affected Products</h3>
+                ${topProductsHtml}
+            </div>
+
+            <div class="stats-box">
+                <h3 style="margin-top: 0">Top 10 Most Affected Servers</h3>
+                ${topServersHtml}
+            </div>
+
+            <p>
+                This is an automated summary of your SecMan instance. Review
+                these statistics regularly to ensure your security posture
+                remains strong.
+            </p>
         </div>
 
-        <div style="text-align: center; margin: 25px 0;">
-            <a href="${vulnerabilityStatisticsUrl}" style="display: inline-block; background-color: #0d6efd; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold; font-size: 1.1em;">View Vulnerability Statistics</a>
+        <div class="footer">
+            <p>
+                This is an automated notification from the Security Management
+                System.
+            </p>
+            <p>Please do not reply to this email.</p>
         </div>
-
-        <div class="stats-box">
-            <h3 style="margin-top: 0;">Top 10 Most Affected Products</h3>
-            ${topProductsHtml}
-        </div>
-
-        <div class="stats-box">
-            <h3 style="margin-top: 0;">Top 10 Most Affected Servers</h3>
-            ${topServersHtml}
-        </div>
-
-        <p>This is an automated summary of your SecMan instance. Review these statistics regularly to ensure your security posture remains strong.</p>
-    </div>
-
-    <div class="footer">
-        <p>This is an automated notification from the Security Management System.</p>
-        <p>Please do not reply to this email.</p>
-    </div>
-</body>
+    </body>
 </html>

--- a/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityServiceTest.kt
@@ -1,5 +1,6 @@
 package com.secman.service
 
+import com.secman.config.MemoryOptimizationConfig
 import com.secman.domain.Asset
 import com.secman.domain.Vulnerability
 import com.secman.dto.AddVulnerabilityRequestDto
@@ -46,6 +47,9 @@ class VulnerabilityServiceTest {
     @MockK
     private lateinit var entityManager: jakarta.persistence.EntityManager
 
+    @MockK
+    private lateinit var memoryConfig: MemoryOptimizationConfig
+
     private lateinit var vulnerabilityService: VulnerabilityService
 
     @BeforeEach
@@ -59,7 +63,8 @@ class VulnerabilityServiceTest {
                 vulnerabilityExceptionRepository = vulnerabilityExceptionRepository,
                 vulnerabilityConfigService = vulnerabilityConfigService,
                 assetRepository = assetRepository,
-                entityManager = entityManager
+                entityManager = entityManager,
+                memoryConfig = memoryConfig
             )
         )
 

--- a/src/frontend/src/components/McpApiKeyManagement.tsx
+++ b/src/frontend/src/components/McpApiKeyManagement.tsx
@@ -51,7 +51,8 @@ const McpApiKeyManagement: React.FC = () => {
     'SCANS_READ',
     'TAGS_READ',
     'SYSTEM_INFO',
-    'USER_ACTIVITY'
+    'USER_ACTIVITY',
+    'WORKGROUPS_WRITE'  // Feature 074: Workgroup management via MCP
   ];
 
   useEffect(() => {

--- a/tests/mcp-e2e-workgroup-test.sh
+++ b/tests/mcp-e2e-workgroup-test.sh
@@ -1,0 +1,488 @@
+#!/bin/bash
+# MCP E2E Test: User-Asset-Workgroup Workflow
+# Feature: 074-mcp-e2e-test
+#
+# This script validates the complete MCP workflow for user access control:
+# 1. Create a TEST user with VULN role
+# 2. Create an asset with a CRITICAL vulnerability (10 days old)
+# 3. Create a workgroup and assign the asset
+# 4. Assign the TEST user to the workgroup
+# 5. Verify TEST user can see exactly one asset
+# 6. Clean up all test data
+#
+# Prerequisites:
+# - curl, jq, op (1Password CLI) installed
+# - Environment variables set with 1Password URIs:
+#   SECMAN_USERNAME, SECMAN_PASSWORD, SECMAN_API_KEY
+#
+# Usage:
+#   ./tests/mcp-e2e-workgroup-test.sh
+#   DEBUG=1 ./tests/mcp-e2e-workgroup-test.sh  # Verbose output
+
+set -euo pipefail
+
+export SECMAN_USERNAME="op://test/secman/SECMAN_USERNAME"
+export SECMAN_PASSWORD="op://test/secman/SECMAN_PASSWORD"
+export SECMAN_API_KEY="op://test/secman/SECMAN_API_KEY"
+
+# Configuration
+BASE_URL="${SECMAN_BASE_URL:-http://localhost:8080}"
+TEST_USER_NAME="E2E_TEST_USER_$(date +%s)"
+TEST_USER_EMAIL="e2e-test-$(date +%s)@schmall.io"
+TEST_ASSET_NAME="E2E_TEST_ASSET_$(date +%s)"
+TEST_WORKGROUP_NAME="E2E-TEST-WORKGROUP-$(date +%s)"
+TEST_CVE="CVE-2024-$(printf '%05d' $((RANDOM % 99999)))"
+
+# State variables for cleanup
+ADMIN_TOKEN=""
+API_KEY=""
+TEST_USER_ID=""
+TEST_ASSET_ID=""
+TEST_WORKGROUP_ID=""
+CLEANUP_DONE=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions - all write to stderr to avoid contaminating stdout (for command substitution)
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[PASS]${NC} $1" >&2
+}
+
+log_error() {
+    echo -e "${RED}[FAIL]${NC} $1" >&2
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
+}
+
+log_debug() {
+    if [[ "${DEBUG:-}" == "1" ]]; then
+        echo -e "${YELLOW}[DEBUG]${NC} $1" >&2
+    fi
+}
+
+# Check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+
+    local missing=()
+
+    if ! command -v curl &> /dev/null; then
+        missing+=("curl")
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        missing+=("jq")
+    fi
+
+    if ! command -v op &> /dev/null; then
+        missing+=("op (1Password CLI)")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_info "Install missing tools and try again."
+        exit 1
+    fi
+
+    # Check environment variables
+    if [[ -z "${SECMAN_USERNAME:-}" ]]; then
+        log_error "SECMAN_USERNAME environment variable not set"
+        exit 1
+    fi
+
+    if [[ -z "${SECMAN_PASSWORD:-}" ]]; then
+        log_error "SECMAN_PASSWORD environment variable not set"
+        exit 1
+    fi
+
+    if [[ -z "${SECMAN_API_KEY:-}" ]]; then
+        log_error "SECMAN_API_KEY environment variable not set"
+        log_info "Create an MCP API key via the UI with these settings:"
+        log_info "  - Permissions: WORKGROUPS_WRITE, ASSETS_READ, VULNERABILITIES_READ"
+        log_info "  - User Delegation: ENABLED"
+        log_info "  - Allowed Domains: @example.com (to match test user email)"
+        exit 1
+    fi
+
+    log_success "Prerequisites check passed"
+}
+
+# Resolve credentials from 1Password
+resolve_credentials() {
+    log_info "Resolving credentials from 1Password..."
+
+    # Check if credentials are 1Password URIs or plain values
+    if [[ "${SECMAN_USERNAME}" == op://* ]]; then
+        RESOLVED_USERNAME=$(op read "${SECMAN_USERNAME}" 2>/dev/null) || {
+            log_error "Failed to resolve SECMAN_USERNAME from 1Password"
+            exit 1
+        }
+    else
+        RESOLVED_USERNAME="${SECMAN_USERNAME}"
+    fi
+
+    if [[ "${SECMAN_PASSWORD}" == op://* ]]; then
+        RESOLVED_PASSWORD=$(op read "${SECMAN_PASSWORD}" 2>/dev/null) || {
+            log_error "Failed to resolve SECMAN_PASSWORD from 1Password"
+            exit 1
+        }
+    else
+        RESOLVED_PASSWORD="${SECMAN_PASSWORD}"
+    fi
+
+    # API key is required for MCP calls
+    if [[ "${SECMAN_API_KEY}" == op://* ]]; then
+        API_KEY=$(op read "${SECMAN_API_KEY}" 2>/dev/null) || {
+            log_error "Failed to resolve SECMAN_API_KEY from 1Password"
+            exit 1
+        }
+    else
+        API_KEY="${SECMAN_API_KEY}"
+    fi
+
+    log_success "Credentials resolved"
+}
+
+# Authenticate to secman
+authenticate() {
+    log_info "Authenticating to secman..."
+
+    local response
+    response=$(curl -s -X POST "${BASE_URL}/api/auth/login" \
+        -H "Content-Type: application/json" \
+        -d "{\"username\":\"${RESOLVED_USERNAME}\",\"password\":\"${RESOLVED_PASSWORD}\"}")
+
+    log_debug "Auth response: $response"
+
+    ADMIN_TOKEN=$(echo "$response" | jq -r '.token // empty')
+
+    if [[ -z "$ADMIN_TOKEN" ]]; then
+        log_error "Authentication failed"
+        log_debug "Response: $response"
+        exit 1
+    fi
+
+    log_success "Authenticated successfully"
+}
+
+# MCP tool call helper
+mcp_call() {
+    local tool_name="$1"
+    local arguments="$2"
+    local user_email="${3:-${RESOLVED_USERNAME}}"
+    local request_id="e2e-$(date +%s)-$RANDOM"
+
+    log_debug "MCP call: $tool_name (as $user_email)"
+    log_debug "Arguments: $arguments"
+
+    # Build the JSON-RPC request properly using jq
+    local request_body
+    request_body=$(jq -n \
+        --arg id "$request_id" \
+        --arg name "$tool_name" \
+        --argjson args "$arguments" \
+        '{jsonrpc: "2.0", id: $id, method: "tools/call", params: {name: $name, arguments: $args}}') || {
+        log_error "Failed to construct JSON request body"
+        log_debug "Tool: $tool_name, Args: $arguments"
+        echo "{}"
+        return 1
+    }
+
+    log_debug "Request body: $request_body"
+
+    local http_code
+    local response
+    response=$(curl -s -w "\n%{http_code}" -X POST "${BASE_URL}/api/mcp/tools/call" \
+        -H "X-MCP-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -H "X-MCP-User-Email: ${user_email}" \
+        -d "$request_body")
+
+    # Extract HTTP status code from the last line
+    http_code=$(echo "$response" | tail -n1)
+    response=$(echo "$response" | sed '$d')
+
+    log_debug "HTTP status: $http_code"
+    log_debug "MCP response: $response"
+    echo "$response"
+}
+
+# Create test user with VULN role
+create_test_user() {
+    log_info "Step 1: Creating TEST user with VULN role..."
+    log_debug "Creating user: $TEST_USER_NAME / $TEST_USER_EMAIL"
+
+    local response
+    local args
+    args=$(jq -c -n --arg username "$TEST_USER_NAME" --arg email "$TEST_USER_EMAIL" --arg password "TestPass123" \
+        '{username: $username, email: $email, password: $password, roles: ["VULN"]}')
+    log_debug "Constructed args: $args"
+    response=$(mcp_call "add_user" "$args")
+    log_debug "After mcp_call, response=$response"
+
+    # Check for error (JSON-RPC format)
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to create test user: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    # Extract user ID from JSON-RPC result
+    TEST_USER_ID=$(echo "$response" | jq -r '.result.content.user.id // empty')
+
+    if [[ -z "$TEST_USER_ID" || "$TEST_USER_ID" == "null" ]]; then
+        log_error "Failed to get test user ID from response"
+        log_debug "Response: $response"
+        exit 1
+    fi
+
+    log_success "Created TEST user (ID: $TEST_USER_ID, Email: $TEST_USER_EMAIL)"
+}
+
+# Create test asset with vulnerability
+create_test_asset_with_vulnerability() {
+    log_info "Step 2: Creating test asset with CRITICAL vulnerability (10 days old)..."
+
+    local response
+    local args
+    args=$(jq -n --arg hostname "$TEST_ASSET_NAME" --arg cve "$TEST_CVE" \
+        '{hostname: $hostname, cve: $cve, criticality: "CRITICAL", daysOpen: 10}')
+    response=$(mcp_call "add_vulnerability" "$args")
+
+    # Check for error (JSON-RPC format)
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to create test asset: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    # Extract asset ID from JSON-RPC result (assetId is returned as a number)
+    TEST_ASSET_ID=$(echo "$response" | jq -r '.result.content.assetId // empty')
+
+    if [[ -z "$TEST_ASSET_ID" || "$TEST_ASSET_ID" == "null" ]]; then
+        log_error "Failed to get test asset ID from response"
+        log_debug "Response: $response"
+        exit 1
+    fi
+
+    log_success "Created test asset (ID: $TEST_ASSET_ID) with vulnerability $TEST_CVE"
+}
+
+# Create test workgroup
+create_test_workgroup() {
+    log_info "Step 3: Creating test workgroup..."
+
+    local response
+    local args
+    args=$(jq -n --arg name "$TEST_WORKGROUP_NAME" \
+        '{name: $name, description: "E2E test workgroup for MCP workflow validation"}')
+    response=$(mcp_call "create_workgroup" "$args")
+
+    # Check for error (JSON-RPC format)
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to create workgroup: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    # Extract workgroup ID from JSON-RPC result
+    TEST_WORKGROUP_ID=$(echo "$response" | jq -r '.result.content.id // empty')
+
+    if [[ -z "$TEST_WORKGROUP_ID" || "$TEST_WORKGROUP_ID" == "null" ]]; then
+        log_error "Failed to get workgroup ID from response"
+        log_debug "Response: $response"
+        exit 1
+    fi
+
+    log_success "Created workgroup (ID: $TEST_WORKGROUP_ID)"
+}
+
+# Assign asset to workgroup
+assign_asset_to_workgroup() {
+    log_info "Step 4: Assigning asset to workgroup..."
+
+    local response
+    local args
+    args=$(jq -n --argjson workgroupId "$TEST_WORKGROUP_ID" --argjson assetId "$TEST_ASSET_ID" \
+        '{workgroupId: $workgroupId, assetIds: [$assetId]}')
+    response=$(mcp_call "assign_assets_to_workgroup" "$args")
+
+    # Check for error
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to assign asset to workgroup: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    log_success "Asset assigned to workgroup"
+}
+
+# Assign user to workgroup
+assign_user_to_workgroup() {
+    log_info "Step 5: Assigning TEST user to workgroup..."
+
+    local response
+    local args
+    args=$(jq -n --argjson workgroupId "$TEST_WORKGROUP_ID" --argjson userId "$TEST_USER_ID" \
+        '{workgroupId: $workgroupId, userIds: [$userId]}')
+    response=$(mcp_call "assign_users_to_workgroup" "$args")
+
+    # Check for error
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to assign user to workgroup: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    log_success "TEST user assigned to workgroup"
+}
+
+# Verify TEST user can see exactly one asset
+verify_access_as_test_user() {
+    log_info "Step 6: Switching to TEST user context and verifying asset access..."
+
+    local response
+    response=$(mcp_call "get_assets" "{}" "${TEST_USER_EMAIL}")
+
+    # Check for error (JSON-RPC format)
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to get assets as TEST user: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    # Extract asset count from JSON-RPC result
+    local asset_count
+    asset_count=$(echo "$response" | jq -r '.result.content.assets | length // 0')
+
+    log_debug "TEST user can see $asset_count asset(s)"
+
+    if [[ "$asset_count" -eq 1 ]]; then
+        log_success "TEST user sees exactly 1 asset (expected)"
+
+        # Verify it's our test asset
+        local visible_asset_id
+        visible_asset_id=$(echo "$response" | jq -r '.result.content.assets[0].id // empty')
+
+        if [[ "$visible_asset_id" == "$TEST_ASSET_ID" ]]; then
+            log_success "Verified: TEST user sees the correct test asset (ID: $TEST_ASSET_ID)"
+        else
+            log_warn "TEST user sees asset ID $visible_asset_id, expected $TEST_ASSET_ID"
+        fi
+    else
+        log_error "TEST user sees $asset_count assets, expected exactly 1"
+        log_debug "Response: $response"
+        exit 1
+    fi
+}
+
+# Cleanup function
+cleanup() {
+    if [[ "$CLEANUP_DONE" == "true" ]]; then
+        return
+    fi
+    CLEANUP_DONE=true
+
+    log_info "Step 7: Cleaning up test data..."
+
+    local had_errors=false
+
+    # Delete user first (cascades user_workgroups entries)
+    if [[ -n "$TEST_USER_ID" && "$TEST_USER_ID" != "null" ]]; then
+        local response
+        local args
+        args=$(jq -n --argjson userId "$TEST_USER_ID" '{userId: $userId}')
+        response=$(mcp_call "delete_user" "$args" 2>/dev/null || true)
+        local error_code
+        error_code=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null || true)
+        if [[ -z "$error_code" ]]; then
+            log_info "Deleted user (ID: $TEST_USER_ID)"
+        else
+            log_warn "Failed to delete user: $(echo "$response" | jq -r '.error.message' 2>/dev/null || echo 'unknown error')"
+            had_errors=true
+        fi
+    fi
+
+    # Delete asset (cascades asset_workgroups entries and vulnerabilities)
+    if [[ -n "$TEST_ASSET_ID" && "$TEST_ASSET_ID" != "null" ]]; then
+        local response
+        local args
+        args=$(jq -n --argjson assetId "$TEST_ASSET_ID" '{assetId: $assetId, forceTimeout: true}')
+        response=$(mcp_call "delete_asset" "$args" 2>/dev/null || true)
+        local error_code
+        error_code=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null || true)
+        if [[ -z "$error_code" ]]; then
+            log_info "Deleted asset (ID: $TEST_ASSET_ID)"
+        else
+            log_warn "Failed to delete asset: $(echo "$response" | jq -r '.error.message' 2>/dev/null || echo 'unknown error')"
+            had_errors=true
+        fi
+    fi
+
+    # Delete workgroup (user_workgroups and asset_workgroups entries already removed)
+    if [[ -n "$TEST_WORKGROUP_ID" && "$TEST_WORKGROUP_ID" != "null" ]]; then
+        local response
+        local args
+        args=$(jq -n --argjson workgroupId "$TEST_WORKGROUP_ID" '{workgroupId: $workgroupId}')
+        response=$(mcp_call "delete_workgroup" "$args" 2>/dev/null || true)
+        local error_code
+        error_code=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null || true)
+        if [[ -z "$error_code" ]]; then
+            log_info "Deleted workgroup (ID: $TEST_WORKGROUP_ID)"
+        else
+            log_warn "Failed to delete workgroup: $(echo "$response" | jq -r '.error.message' 2>/dev/null || echo 'unknown error')"
+            had_errors=true
+        fi
+    fi
+
+    if [[ "$had_errors" == "true" ]]; then
+        log_warn "Some cleanup tasks had errors - manual cleanup may be required"
+    else
+        log_success "Cleanup completed"
+    fi
+}
+
+# Main function
+main() {
+    echo ""
+    echo "=== MCP E2E Test: User-Asset-Workgroup Workflow ==="
+    echo ""
+
+    # Set trap for cleanup on exit (success or failure)
+    trap cleanup EXIT
+
+    # Execute test workflow
+    check_prerequisites
+    resolve_credentials
+    authenticate
+    create_test_user
+    create_test_asset_with_vulnerability
+    create_test_workgroup
+    assign_asset_to_workgroup
+    assign_user_to_workgroup
+    verify_access_as_test_user
+
+    echo ""
+    echo "=== TEST PASSED ==="
+    echo ""
+}
+
+# Run main
+main "$@"


### PR DESCRIPTION
Implement MCP workgroup management and add E2E test spec and tooling. Adds five new MCP tools (create_workgroup, delete_workgroup, assign_assets_to_workgroup, assign_users_to_workgroup, delete_asset), contracts, data model, research/plan/quickstart, and a Bash E2E test script (tests/mcp-e2e-workgroup-test.sh). Updates backend registry/permissions: adds WORKGROUPS_WRITE to McpPermission, registers tools in McpToolRegistry, and adjusts related services/DTOs/tests. Updates frontend McpApiKeyManagement to expose the new permission and documents (docs/MCP.md, CLAUDE.md) to describe the new APIs. Also includes IDE workspace and minor template/test adjustments. These changes enable automated validation of the user→asset→workgroup access-control workflow via MCP and the associated key/permission UI support.