### PR TITLE
fix(auth): eliminate dual-token problem by completing HttpOnly cookie migration

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt
@@ -145,12 +145,13 @@ class OAuthController(
                 is OAuthService.CallbackResult.Success -> {
                     logger.info("OAuth login successful for user: {}", result.user.username)
 
-                    // Create user info JSON
+                    // Create user info JSON (non-sensitive metadata only, token is in HttpOnly cookie)
                     val userInfoJson = """{"id":${result.user.id},"username":"${result.user.username}","email":"${result.user.email}","roles":[${result.user.roles.joinToString(",") { "\"$it\"" }}]}"""
 
-                    // Pass token and user data as URL parameters as expected by the frontend
+                    // Only pass user metadata in URL - JWT is delivered solely via HttpOnly cookie
+                    // This prevents token exposure in browser history, proxy logs, and referrer headers
                     val encodedUser = java.net.URLEncoder.encode(userInfoJson, "UTF-8")
-                    val redirectUrl = "$frontendBaseUrl/login/success?token=${result.token}&user=$encodedUser"
+                    val redirectUrl = "$frontendBaseUrl/login/success?user=$encodedUser"
 
                     logger.debug("Redirecting to: {}", redirectUrl)
                     // Set HttpOnly cookie for authentication (same as local login)

--- a/src/frontend/debug-login.js
+++ b/src/frontend/debug-login.js
@@ -32,7 +32,7 @@ import { chromium } from 'playwright';
     console.log('Current URL:', page.url());
     console.log('LocalStorage:', await page.evaluate(() => {
       return {
-        authToken: localStorage.getItem('authToken'),
+        authToken: localStorage.getItem('authToken') || '(migrated to HttpOnly cookie)',
         user: localStorage.getItem('user')
       };
     }));

--- a/src/frontend/src/components/ClassificationRuleManager.tsx
+++ b/src/frontend/src/components/ClassificationRuleManager.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { getAuthHeaders } from '../utils/auth';
 import { csrfPost } from '../utils/csrf';
 
 // Define an interface for the user data expected from the backend
@@ -118,7 +117,7 @@ const ClassificationRuleManager: React.FC = () => {
     setLoading(true);
     try {
       const response = await fetch('/api/classification/rules', {
-        headers: getAuthHeaders()
+        credentials: 'include',
       });
       if (response.ok) {
         const data = await response.json();
@@ -167,9 +166,9 @@ const ClassificationRuleManager: React.FC = () => {
       const response = await fetch(url, {
         method,
         headers: {
-          ...getAuthHeaders(),
           'Content-Type': 'application/json'
         },
+        credentials: 'include',
         body: JSON.stringify({
           name: selectedRule.name,
           description: selectedRule.description,
@@ -203,7 +202,7 @@ const ClassificationRuleManager: React.FC = () => {
     try {
       const response = await fetch(`/api/classification/rules/${ruleId}`, {
         method: 'DELETE',
-        headers: getAuthHeaders()
+        credentials: 'include',
       });
 
       if (response.ok) {
@@ -227,9 +226,9 @@ const ClassificationRuleManager: React.FC = () => {
       const response = await fetch('/api/classification/test', {
         method: 'POST',
         headers: {
-          ...getAuthHeaders(),
           'Content-Type': 'application/json'
         },
+        credentials: 'include',
         body: JSON.stringify({
           input: testInput,
           ruleId: selectedRule?.id
@@ -252,7 +251,7 @@ const ClassificationRuleManager: React.FC = () => {
   const exportRules = async () => {
     try {
       const response = await fetch('/api/classification/rules/export', {
-        headers: getAuthHeaders()
+        credentials: 'include',
       });
 
       if (response.ok) {

--- a/src/frontend/src/components/FalconConfigManagement.tsx
+++ b/src/frontend/src/components/FalconConfigManagement.tsx
@@ -50,10 +50,7 @@ const FalconConfigManagement = () => {
             setLoading(true);
             setError(null);
             
-            const token = localStorage.getItem('authToken');
-            const response = await axios.get('/api/falcon-config', {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            const response = await axios.get('/api/falcon-config');
             
             setConfigs(response.data);
         } catch (err: any) {
@@ -70,10 +67,7 @@ const FalconConfigManagement = () => {
             setError(null);
             setSuccess(null);
             
-            const token = localStorage.getItem('authToken');
-            await axios.post('/api/falcon-config', formData, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            await axios.post('/api/falcon-config', formData);
             
             setSuccess('Falcon configuration created successfully');
             setShowCreateForm(false);
@@ -93,8 +87,6 @@ const FalconConfigManagement = () => {
             setError(null);
             setSuccess(null);
             
-            const token = localStorage.getItem('authToken');
-            
             // Only send fields that are not masked
             const updateData: any = {
                 cloudRegion: formData.cloudRegion
@@ -108,9 +100,7 @@ const FalconConfigManagement = () => {
                 updateData.clientSecret = formData.clientSecret;
             }
             
-            await axios.put(`/api/falcon-config/${editingConfig.id}`, updateData, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            await axios.put(`/api/falcon-config/${editingConfig.id}`, updateData);
             
             setSuccess('Falcon configuration updated successfully');
             setEditingConfig(null);
@@ -130,10 +120,7 @@ const FalconConfigManagement = () => {
             setError(null);
             setSuccess(null);
             
-            const token = localStorage.getItem('authToken');
-            await axios.delete(`/api/falcon-config/${id}`, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            await axios.delete(`/api/falcon-config/${id}`);
             
             setSuccess('Falcon configuration deleted successfully');
             await loadConfigs();
@@ -147,10 +134,7 @@ const FalconConfigManagement = () => {
             setError(null);
             setSuccess(null);
             
-            const token = localStorage.getItem('authToken');
-            await axios.post(`/api/falcon-config/${id}/activate`, {}, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            await axios.post(`/api/falcon-config/${id}/activate`, {});
             
             setSuccess('Falcon configuration activated successfully');
             await loadConfigs();

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -29,9 +29,11 @@ const Header = () => {
             });
             if (response.ok) {
                 // Clear client-side authentication data
-                // Note: The HttpOnly cookie is cleared by the server response
+                // Note: The HttpOnly secman_auth cookie is cleared by the server response
                 localStorage.removeItem('user');
-                localStorage.removeItem('authToken'); // Legacy cleanup
+                // Clean up legacy token storage from previous versions
+                localStorage.removeItem('authToken');
+                document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 
                 window.currentUser = null;
                 setUser(null);

--- a/src/frontend/src/components/Login.tsx
+++ b/src/frontend/src/components/Login.tsx
@@ -59,11 +59,11 @@ const Login = () => {
         // Clear any stale authentication data before starting fresh OAuth flow
         // This prevents issues with cached OAuth states in corporate AAD environments
         console.log('[OAuth] Clearing stale authentication data...');
-        localStorage.removeItem('authToken');
+        localStorage.removeItem('authToken'); // Legacy cleanup
         localStorage.removeItem('user');
         sessionStorage.clear(); // Clear any cached OAuth-related data
 
-        // Delete auth cookies to ensure fresh OAuth flow
+        // Delete legacy auth cookies to ensure fresh OAuth flow
         document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 
         // Generate a fresh login nonce to ensure state uniqueness

--- a/src/frontend/src/components/McpDashboard.tsx
+++ b/src/frontend/src/components/McpDashboard.tsx
@@ -60,14 +60,12 @@ const McpDashboard: React.FC = () => {
 
   const fetchDashboardData = async () => {
     try {
-      const token = localStorage.getItem('authToken');
-
-      // Fetch system statistics
+      // Authentication via HttpOnly secman_auth cookie (sent automatically with credentials: 'include')
       const statsResponse = await fetch('/api/mcp/admin/statistics', {
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
-        }
+        },
+        credentials: 'include',
       });
 
       if (statsResponse.ok) {
@@ -78,9 +76,9 @@ const McpDashboard: React.FC = () => {
       // Fetch recent activity
       const activityResponse = await fetch('/api/mcp/admin/audit-logs?pageSize=10', {
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
-        }
+        },
+        credentials: 'include',
       });
 
       if (activityResponse.ok) {

--- a/src/frontend/src/layouts/Layout.astro
+++ b/src/frontend/src/layouts/Layout.astro
@@ -97,6 +97,11 @@ const requiresRedirect = !user && !isPublicPage;
             // Define a global variable to hold user info
             window.currentUser = null;
 
+            // Migration cleanup: remove legacy authToken from localStorage and cookies.
+            // Authentication is now handled solely via the HttpOnly secman_auth cookie.
+            localStorage.removeItem('authToken');
+            document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+
             async function checkAuthAndRedirect() {
                 if (isPublicPage) {
                     // Don't redirect if on a public page like /login or /about

--- a/src/frontend/src/pages/login/success.astro
+++ b/src/frontend/src/pages/login/success.astro
@@ -41,32 +41,36 @@
 
     <script>
         // Extract URL parameters
+        // Note: JWT token is delivered solely via HttpOnly cookie (secman_auth) set by backend.
+        // Only user metadata is passed in the URL for client-side state.
         const urlParams = new URLSearchParams(window.location.search);
-        const token = urlParams.get('token');
         const userJson = urlParams.get('user');
 
-        if (token && userJson) {
+        if (userJson) {
             try {
                 // Decode and parse user data
                 const userData = JSON.parse(decodeURIComponent(userJson));
-                
-                // Store authentication data
-                localStorage.setItem('authToken', token);
 
-                // Also store token in a cookie for server-side middleware access
-                document.cookie = `authToken=${token}; path=/; max-age=86400; SameSite=Strict`;
+                // Clean up any legacy token storage from previous versions
+                localStorage.removeItem('authToken');
+                document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 
+                // Store user metadata only (non-sensitive, for UI display and role checks)
+                // Authentication is handled entirely via the HttpOnly secman_auth cookie
                 localStorage.setItem('user', JSON.stringify(userData));
 
                 // Set global user state for Header component
                 window.currentUser = userData;
                 window.dispatchEvent(new CustomEvent('userLoaded'));
-                
+
+                // Clean sensitive data from URL before redirect (prevents token in browser history)
+                window.history.replaceState({}, '', '/login/success');
+
                 // Small delay to ensure data is stored, then redirect
                 setTimeout(() => {
                     window.location.href = '/';
-                }, 1000);
-                
+                }, 500);
+
             } catch (error) {
                 console.error('Error processing login success:', error);
                 alert('Login successful, but there was an error processing your data. Redirecting to login...');
@@ -75,7 +79,7 @@
                 }, 2000);
             }
         } else {
-            console.error('Missing token or user data');
+            console.error('Missing user data in OAuth callback');
             alert('Login data missing. Redirecting to login...');
             setTimeout(() => {
                 window.location.href = '/login';

--- a/src/frontend/src/services/api/vulnerabilityStatisticsApi.ts
+++ b/src/frontend/src/services/api/vulnerabilityStatisticsApi.ts
@@ -20,16 +20,9 @@ const API_BASE_URL = import.meta.env.PUBLIC_API_URL ||
     : 'http://localhost:8080'); // Use localhost in development
 
 /**
- * Get JWT token from localStorage for authentication
- * Note: The app uses localStorage.getItem('authToken'), not sessionStorage.getItem('jwtToken')
- */
-function getAuthHeader(): Record<string, string> {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-/**
- * Create axios instance with base configuration
+ * Create axios instance with base configuration.
+ * Authentication is handled via the HttpOnly secman_auth cookie,
+ * sent automatically with withCredentials: true (set globally in csrf.ts).
  */
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -213,7 +206,7 @@ class VulnerabilityStatisticsApi {
   async getAvailableDomains(): Promise<AvailableDomainsDto> {
     const response = await apiClient.get<AvailableDomainsDto>(
       '/api/vulnerability-statistics/available-domains',
-      { headers: getAuthHeader() }
+      {}
     );
     return response.data;
   }
@@ -234,7 +227,7 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<MostCommonVulnerabilityDto[]>(
       '/api/vulnerability-statistics/most-common',
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
@@ -254,7 +247,7 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<MostVulnerableProductDto[]>(
       '/api/vulnerability-statistics/most-vulnerable-products',
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
@@ -275,7 +268,7 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<SeverityDistributionDto>(
       '/api/vulnerability-statistics/severity-distribution',
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
@@ -296,7 +289,7 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<TopAssetByVulnerabilitiesDto[]>(
       '/api/vulnerability-statistics/top-assets',
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
@@ -315,7 +308,7 @@ class VulnerabilityStatisticsApi {
   async getVulnerabilitiesByAssetType(): Promise<VulnerabilityByAssetTypeDto[]> {
     const response = await apiClient.get<VulnerabilityByAssetTypeDto[]>(
       '/api/vulnerability-statistics/by-asset-type',
-      { headers: getAuthHeader() }
+      {}
     );
     return response.data;
   }
@@ -335,10 +328,7 @@ class VulnerabilityStatisticsApi {
   async getTemporalTrends(days: 30 | 60 | 90 = 30): Promise<TemporalTrendsDto> {
     const response = await apiClient.get<TemporalTrendsDto>(
       '/api/vulnerability-statistics/temporal-trends',
-      {
-        headers: getAuthHeader(),
-        params: { days }
-      }
+      { params: { days } }
     );
     return response.data;
   }
@@ -358,7 +348,7 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<AffectedAssetsByCveDto>(
       `/api/vulnerability-statistics/affected-assets/${encodeURIComponent(cveId)}`,
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
@@ -378,11 +368,11 @@ class VulnerabilityStatisticsApi {
     const params = domain ? { domain } : {};
     const response = await apiClient.get<AssetsByProductDto>(
       `/api/vulnerability-statistics/assets-by-product/${encodeURIComponent(product)}`,
-      { headers: getAuthHeader(), params }
+      { params }
     );
     return response.data;
   }
 }
 
 export const vulnerabilityStatisticsApi = new VulnerabilityStatisticsApi();
-export { getAuthHeader, apiClient };
+export { apiClient };

--- a/src/frontend/src/services/domainVulnsService.ts
+++ b/src/frontend/src/services/domainVulnsService.ts
@@ -96,17 +96,13 @@ export async function getDomainVulns(): Promise<DomainVulnsSummary> {
  * @throws Error if sync fails
  */
 export async function syncDomainFromCrowdStrike(domain: string): Promise<DomainSyncResult> {
-  const token = localStorage.getItem('authToken');
-  if (!token) {
-    throw new Error('Not authenticated');
-  }
-
+  // Authentication via HttpOnly secman_auth cookie (sent automatically with credentials: 'include')
   const response = await fetch(`/api/domain-vulns/sync/${encodeURIComponent(domain)}`, {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
-    }
+    },
+    credentials: 'include',
   });
 
   if (!response.ok) {

--- a/src/frontend/src/services/maintenanceBannerService.ts
+++ b/src/frontend/src/services/maintenanceBannerService.ts
@@ -51,14 +51,8 @@ export async function getActiveBanners(): Promise<MaintenanceBanner[]> {
  * @returns Promise resolving to array of all banners
  */
 export async function getAllBanners(): Promise<MaintenanceBanner[]> {
-  const token = localStorage.getItem('authToken');
   const response = await axios.get<MaintenanceBanner[]>(
-    `${API_BASE}/maintenance-banners`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    }
+    `${API_BASE}/maintenance-banners`
   );
   return response.data;
 }
@@ -70,14 +64,8 @@ export async function getAllBanners(): Promise<MaintenanceBanner[]> {
  * @returns Promise resolving to banner details
  */
 export async function getBannerById(id: number): Promise<MaintenanceBanner> {
-  const token = localStorage.getItem('authToken');
   const response = await axios.get<MaintenanceBanner>(
-    `${API_BASE}/maintenance-banners/${id}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    }
+    `${API_BASE}/maintenance-banners/${id}`
   );
   return response.data;
 }
@@ -89,13 +77,11 @@ export async function getBannerById(id: number): Promise<MaintenanceBanner> {
  * @returns Promise resolving to created banner
  */
 export async function createBanner(request: MaintenanceBannerRequest): Promise<MaintenanceBanner> {
-  const token = localStorage.getItem('authToken');
   const response = await axios.post<MaintenanceBanner>(
     `${API_BASE}/maintenance-banners`,
     request,
     {
       headers: {
-        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json'
       }
     }
@@ -111,13 +97,11 @@ export async function createBanner(request: MaintenanceBannerRequest): Promise<M
  * @returns Promise resolving to updated banner
  */
 export async function updateBanner(id: number, request: MaintenanceBannerRequest): Promise<MaintenanceBanner> {
-  const token = localStorage.getItem('authToken');
   const response = await axios.put<MaintenanceBanner>(
     `${API_BASE}/maintenance-banners/${id}`,
     request,
     {
       headers: {
-        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json'
       }
     }
@@ -132,13 +116,5 @@ export async function updateBanner(id: number, request: MaintenanceBannerRequest
  * @returns Promise resolving when deletion is complete
  */
 export async function deleteBanner(id: number): Promise<void> {
-  const token = localStorage.getItem('authToken');
-  await axios.delete(
-    `${API_BASE}/maintenance-banners/${id}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    }
-  );
+  await axios.delete(`${API_BASE}/maintenance-banners/${id}`);
 }

--- a/src/frontend/src/services/normMappingService.ts
+++ b/src/frontend/src/services/normMappingService.ts
@@ -1,4 +1,4 @@
-import { getAuthToken } from '../utils/auth';
+// Authentication is handled via HttpOnly secman_auth cookie with credentials: 'include'
 
 /**
  * Service for AI-Powered Norm Mapping API operations
@@ -140,17 +140,12 @@ export interface FailedRequirementInfo {
 export async function suggestMappings(
   request?: NormMappingSuggestionRequest
 ): Promise<NormMappingSuggestionResponse> {
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated');
-  }
-
   const response = await fetch('/api/norm-mapping/suggest', {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    credentials: 'include',
     body: JSON.stringify(request || {}),
   });
 
@@ -189,17 +184,12 @@ export async function suggestMappings(
 export async function applyMappings(
   request: ApplyMappingsRequest
 ): Promise<ApplyMappingsResponse> {
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated');
-  }
-
   const response = await fetch('/api/norm-mapping/apply', {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    credentials: 'include',
     body: JSON.stringify(request),
   });
 
@@ -234,17 +224,12 @@ export async function applyMappings(
  * @throws Error if API call fails or user is not authenticated
  */
 export async function getUnmappedCount(): Promise<number> {
-  const token = getAuthToken();
-  if (!token) {
-    throw new Error('Not authenticated');
-  }
-
   const response = await fetch('/api/norm-mapping/unmapped-count', {
     method: 'GET',
     headers: {
-      'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    credentials: 'include',
   });
 
   if (!response.ok) {

--- a/src/frontend/src/services/notificationService.ts
+++ b/src/frontend/src/services/notificationService.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { getAuthToken } from '../utils/auth';
 
 // API base URL - uses relative URLs in production to avoid CORS issues
 const API_BASE_URL = import.meta.env.PUBLIC_API_URL ||
@@ -43,12 +42,7 @@ export interface PagedResponse<T> {
  * Get current user's notification preferences
  */
 export async function getUserPreferences(): Promise<NotificationPreference> {
-  const token = getAuthToken();
-  const response = await axios.get(`${API_BASE_URL}/api/notification-preferences`, {
-    headers: {
-      Authorization: `Bearer ${token}`
-    }
-  });
+  const response = await axios.get(`${API_BASE_URL}/api/notification-preferences`);
   return response.data;
 }
 
@@ -58,13 +52,11 @@ export async function getUserPreferences(): Promise<NotificationPreference> {
 export async function updateUserPreferences(
   request: UpdatePreferenceRequest
 ): Promise<NotificationPreference> {
-  const token = getAuthToken();
   const response = await axios.put(
     `${API_BASE_URL}/api/notification-preferences`,
     request,
     {
       headers: {
-        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json'
       }
     }
@@ -85,12 +77,8 @@ export async function listNotificationLogs(params: {
   endDate?: string;
   sort?: string;
 }): Promise<PagedResponse<NotificationLog>> {
-  const token = getAuthToken();
   const response = await axios.get(`${API_BASE_URL}/api/notification-logs`, {
     params,
-    headers: {
-      Authorization: `Bearer ${token}`
-    }
   });
   return response.data;
 }
@@ -106,14 +94,9 @@ export async function exportNotificationLogs(params: {
   startDate?: string;
   endDate?: string;
 }): Promise<void> {
-  const token = getAuthToken();
-
-  // Use axios to properly send Authorization header with the request
+  // Authentication via HttpOnly cookie (withCredentials set globally)
   const response = await axios.get(`${API_BASE_URL}/api/notification-logs/export`, {
     params,
-    headers: {
-      Authorization: `Bearer ${token}`
-    },
     responseType: 'blob' // Important: handle binary data
   });
 

--- a/src/frontend/src/services/vulnerabilityService.ts
+++ b/src/frontend/src/services/vulnerabilityService.ts
@@ -46,24 +46,14 @@ export async function uploadVulnerabilityFile(
     formData.append('xlsxFile', file);
     formData.append('scanDate', scanDate);
 
-    // Get JWT token from localStorage (stored by Login component)
-    const token = localStorage.getItem('authToken');
-    console.log('[VulnerabilityService] JWT token present:', !!token);
-
-    if (!token) {
-        console.error('[VulnerabilityService] No JWT token found in localStorage');
-        throw new Error('Not authenticated. Please log in.');
-    }
-
     const url = '/api/import/upload-vulnerability-xlsx';
     console.log('[VulnerabilityService] Calling API:', url);
 
     try {
+        // Authentication via HttpOnly secman_auth cookie (sent automatically with credentials: 'include')
         const response = await fetch(url, {
             method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${token}`
-            },
+            credentials: 'include',
             body: formData
         });
 
@@ -100,20 +90,15 @@ export async function uploadVulnerabilityFile(
 export async function getAssetVulnerabilities(
     assetId: number
 ): Promise<Vulnerability[]> {
-    // Get JWT token from localStorage (stored by Login component)
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-        throw new Error('Not authenticated. Please log in.');
-    }
-
+    // Authentication via HttpOnly secman_auth cookie (sent automatically with credentials: 'include')
     const response = await fetch(
         `/api/assets/${assetId}/vulnerabilities`,
         {
             method: 'GET',
             headers: {
-                'Authorization': `Bearer ${token}`,
                 'Content-Type': 'application/json'
-            }
+            },
+            credentials: 'include',
         }
     );
 

--- a/src/frontend/src/utils/csrf.ts
+++ b/src/frontend/src/utils/csrf.ts
@@ -1,25 +1,31 @@
 import axios from 'axios';
-import { getAuthToken } from './auth';
 
 /**
- * Configure axios to automatically include CSRF tokens in all requests.
+ * Configure axios to automatically include CSRF tokens and credentials in all requests.
  * This should be called once when the application starts.
+ *
+ * Authentication is handled via the HttpOnly secman_auth cookie, which is sent
+ * automatically with withCredentials: true. No manual Authorization header needed.
  */
 export function setupCSRFProtection() {
+  // Enable withCredentials globally so the HttpOnly secman_auth cookie
+  // is sent with every axios request automatically
+  axios.defaults.withCredentials = true;
+
   // Get the CSRF token from meta tag
   const getCSRFToken = () => {
     const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
     if (token) {
       return token;
     }
-    
+
     // Fallback: Get from cookies
     const csrfCookie = document.cookie.split(';')
       .find(cookie => cookie.trim().startsWith('PLAY_CSRF_TOKEN='));
     if (csrfCookie) {
       return csrfCookie.split('=')[1];
     }
-    
+
     return '';
   };
 
@@ -34,11 +40,6 @@ export function setupCSRFProtection() {
         config.headers['Csrf-Token'] = token;
       }
 
-      // Attach Authorization header for JWT-protected endpoints
-      const authToken = getAuthToken();
-      if (authToken && !('Authorization' in config.headers)) {
-        (config.headers as any)['Authorization'] = `Bearer ${authToken}`;
-      }
       return config;
     },
     error => Promise.reject(error)
@@ -47,7 +48,8 @@ export function setupCSRFProtection() {
 
 /**
  * Makes a POST request with CSRF protection and optional file upload.
- * 
+ * Authentication is handled via HttpOnly cookie (withCredentials is set globally).
+ *
  * @param url The URL to send the request to
  * @param data The data to send (can be a FormData object for file uploads)
  * @param config Optional axios config overrides
@@ -55,13 +57,11 @@ export function setupCSRFProtection() {
  */
 export async function csrfPost(url: string, data: any, config: any = {}) {
   const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-  const authToken = getAuthToken();
-  
+
   return axios.post(url, data, {
     headers: {
       // Use only the header name that matches the backend configuration
       'Csrf-Token': token,
-      ...(authToken ? { 'Authorization': `Bearer ${authToken}` } : {}),
       ...(config.headers || {})
     },
     ...config
@@ -70,20 +70,19 @@ export async function csrfPost(url: string, data: any, config: any = {}) {
 
 /**
  * Makes a DELETE request with CSRF protection.
- * 
+ * Authentication is handled via HttpOnly cookie (withCredentials is set globally).
+ *
  * @param url The URL to send the request to
  * @param config Optional axios config overrides
  * @returns Promise with the axios response
  */
 export async function csrfDelete(url: string, config: any = {}) {
   const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-  const authToken = getAuthToken();
-  
+
   return axios.delete(url, {
     headers: {
       // Use only the header name that matches the backend configuration
       'Csrf-Token': token,
-      ...(authToken ? { 'Authorization': `Bearer ${authToken}` } : {}),
       ...(config.headers || {})
     },
     ...config


### PR DESCRIPTION
The OAuth callback flow was creating two tokens: a backend-set HttpOnly
cookie (secman_auth) and a frontend-set JS-accessible cookie + localStorage
entry (authToken). This caused divergent token lifetimes, stale auth
headers after token refresh, and JWT exposure in browser history/proxy logs.

Backend:
- Remove JWT from OAuth redirect URL query parameters (OAuthController.kt)
- Token is now delivered solely via HttpOnly secman_auth cookie

Frontend core:
- success.astro: Stop storing JWT in localStorage/cookie, only store user metadata
- auth.ts: Remove getAuthToken(), getAuthHeaders() - no JS token access needed
- csrf.ts: Remove Bearer header injection, set axios.defaults.withCredentials globally
- Layout.astro: Add legacy authToken cleanup on startup for existing sessions
- Header.tsx: Add authToken cookie cleanup on logout
- Login.tsx: Update comments for legacy cleanup clarity

Frontend services (migrate from manual Bearer headers to cookie-based auth):
- notificationService.ts, normMappingService.ts, vulnerabilityService.ts
- maintenanceBannerService.ts, domainVulnsService.ts
- vulnerabilityStatisticsApi.ts
- FalconConfigManagement.tsx, McpDashboard.tsx, ClassificationRuleManager.tsx

Single source of truth: secman_auth HttpOnly cookie is now the only auth token.
All fetch() calls use credentials:'include', all axios calls use withCredentials:true.

https://claude.ai/code/session_01VtXmD7w5osH1d1j44dReQi