### PR TITLE
Set default roles for new users to USER,VULN,REQ

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,5 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true,
+  "telemetry": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ fun findStateByValueWithRetry(stateToken: String): Optional<OAuthState> {
 - MariaDB 11.4 (existing `releases` table, `requirement_snapshot` table) (078-release-rework)
 - Kotlin 2.3.0 / Java 25 (backend), TypeScript / React 19 (frontend), Bash (e2e test) + Micronaut 4.10, Hibernate JPA, Astro 5.15, Bootstrap 5.3 (079-reqadmin-release-role)
 - MariaDB 11.4 (no schema changes needed - authorization-only change) (079-reqadmin-release-role)
+- MariaDB 11.4 (existing `user_roles` table, no schema changes) (080-default-user-roles)
 
 ## Recent Changes
 - 058-ai-norm-mapping: Added Kotlin 2.2.21 / Java 21 (backend), TypeScript/React 19 (frontend) + Micronaut 4.10, Hibernate JPA, Axios, Bootstrap 5.3

--- a/specs/080-default-user-roles/checklists/requirements.md
+++ b/specs/080-default-user-roles/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Default User Roles on Creation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation.
+- The spec correctly identifies that MCP does not create users (delegation model), reducing scope to OIDC and manual creation paths.
+- Key Entities section references role set change from {USER, VULN} to {USER, VULN, REQ} - this is domain-level description, not implementation detail.
+- Assumption documented that "USERS" in original request maps to "USER" role.

--- a/specs/080-default-user-roles/data-model.md
+++ b/specs/080-default-user-roles/data-model.md
@@ -1,0 +1,30 @@
+# Data Model: Default User Roles on Creation
+
+**Feature**: 080-default-user-roles
+**Date**: 2026-02-12
+
+## No Data Model Changes
+
+This feature modifies default values at the application layer only. No database schema, entity, or relationship changes are needed.
+
+### Existing Entities (unchanged)
+
+**User** (`users` table)
+- id: Long (PK)
+- username: String (unique)
+- email: String (unique)
+- passwordHash: String
+- roles: Set<Role> (ElementCollection → `user_roles` join table, EnumType.STRING)
+- authSource: AuthSource (LOCAL, OAUTH, HYBRID)
+
+**Role** (enum, stored as strings in `user_roles`)
+- USER, ADMIN, VULN, RELEASE_MANAGER, REQ, RISK, SECCHAMPION, REQADMIN
+
+### What Changes
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| OIDC user default roles | USER, VULN | USER, VULN, REQ |
+| Manual user default roles (no roles specified) | USER | USER, VULN, REQ |
+| Manual user with explicit roles | As specified | As specified (unchanged) |
+| Existing users | Unaffected | Unaffected |

--- a/specs/080-default-user-roles/plan.md
+++ b/specs/080-default-user-roles/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Default User Roles on Creation
+
+**Branch**: `080-default-user-roles` | **Date**: 2026-02-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/080-default-user-roles/spec.md`
+
+## Summary
+
+Change the default role set assigned to newly created users from {USER, VULN} (OIDC) / {USER} (manual) to {USER, VULN, REQ} across all creation paths. This is a two-location code change in the backend with no schema, API contract, or frontend modifications.
+
+## Technical Context
+
+**Language/Version**: Kotlin 2.3.0 / Java 25
+**Primary Dependencies**: Micronaut 4.10, Hibernate JPA
+**Storage**: MariaDB 11.4 (existing `user_roles` table, no schema changes)
+**Testing**: JUnit 5, Mockk (per constitution: tests only when user-requested)
+**Target Platform**: Linux server (JVM)
+**Project Type**: Web application (backend-only change)
+**Performance Goals**: N/A (no performance impact - role assignment at user creation time)
+**Constraints**: None - trivial change to default values
+**Scale/Scope**: 2 files modified, ~4 lines changed
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | Expanding default permissions is an intentional policy decision per user request. No new attack surface. RBAC enforcement unchanged. |
+| III. API-First | PASS | No API contract changes. Existing endpoints behave identically. |
+| IV. User-Requested Testing | PASS | No tests planned unless user requests them. |
+| V. RBAC | PASS | Role assignments still enforced via @Secured annotations. Adding REQ to defaults grants requirements access consistently. |
+| VI. Schema Evolution | PASS | No schema changes. `user_roles` table already supports all Role enum values. No Flyway migration needed. |
+
+**Gate result**: ALL PASS. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/080-default-user-roles/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (files to modify)
+
+```text
+src/backendng/src/main/kotlin/com/secman/
+├── service/
+│   └── OAuthService.kt          # Line ~969: OIDC default roles
+└── controller/
+    └── UserController.kt         # Lines ~137-138: Manual creation default roles
+```
+
+**Structure Decision**: Backend-only change. Two existing files modified in the existing project structure. No new files, no frontend changes, no new directories.
+
+## Complexity Tracking
+
+> No constitution violations. Table not needed.
+
+## Changes Detail
+
+### Change 1: OAuthService.kt — OIDC user creation (FR-001, FR-002)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt`
+**Method**: `createNewOidcUser()` (~line 969)
+
+**Current**:
+```kotlin
+roles = mutableSetOf(User.Role.USER, User.Role.VULN), // FR-001, FR-002: Default roles
+```
+
+**Target**:
+```kotlin
+roles = mutableSetOf(User.Role.USER, User.Role.VULN, User.Role.REQ), // Default roles: USER, VULN, REQ
+```
+
+Also update the audit logging call (~line 978):
+```kotlin
+// Current:
+auditRoleAssignment(savedUser, "USER,VULN", idpName)
+// Target:
+auditRoleAssignment(savedUser, "USER,VULN,REQ", idpName)
+```
+
+### Change 2: UserController.kt — Manual user creation (FR-001, FR-003)
+
+**File**: `src/backendng/src/main/kotlin/com/secman/controller/UserController.kt`
+**Method**: `create()` (~lines 137-138)
+
+**Current**:
+```kotlin
+if (roles.isEmpty()) {
+    roles.add(User.Role.USER)
+}
+```
+
+**Target**:
+```kotlin
+if (roles.isEmpty()) {
+    roles.addAll(setOf(User.Role.USER, User.Role.VULN, User.Role.REQ))
+}
+```
+
+### Requirement Traceability
+
+| Requirement | Implementation |
+|-------------|---------------|
+| FR-001: Default roles USER, VULN, REQ | Both Change 1 and Change 2 |
+| FR-002: OIDC creation path | Change 1 (OAuthService.kt) |
+| FR-003: Manual creation path | Change 2 (UserController.kt) |
+| FR-004: Admin explicit roles override | Already works - `roles.isEmpty()` check in UserController.kt |
+| FR-005: Existing users unaffected | No code touches existing user lookup/re-auth paths |
+| FR-006: Audit logging | Change 1 updates audit string; Change 2 already logs via admin notification |

--- a/specs/080-default-user-roles/quickstart.md
+++ b/specs/080-default-user-roles/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Default User Roles on Creation
+
+**Feature**: 080-default-user-roles
+**Branch**: `080-default-user-roles`
+
+## What This Feature Does
+
+Changes the default roles assigned to newly created users from {USER, VULN} to {USER, VULN, REQ}, so new users can immediately access requirements without admin intervention.
+
+## Files to Modify
+
+1. **`src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt`**
+   - Method: `createNewOidcUser()`
+   - Add `User.Role.REQ` to the default roles set
+   - Update audit log string to include REQ
+
+2. **`src/backendng/src/main/kotlin/com/secman/controller/UserController.kt`**
+   - Method: `create()`
+   - Change empty-roles default from `USER` to `USER, VULN, REQ`
+
+## Verification
+
+```bash
+# Build to verify compilation
+./gradlew build
+```
+
+After deploying:
+- Create a new user via OIDC login → verify roles include USER, VULN, REQ
+- Create a new user via admin API without roles → verify roles include USER, VULN, REQ
+- Create a new user via admin API with explicit roles → verify only specified roles are assigned
+- Verify existing users' roles are unchanged

--- a/specs/080-default-user-roles/research.md
+++ b/specs/080-default-user-roles/research.md
@@ -1,0 +1,34 @@
+# Research: Default User Roles on Creation
+
+**Feature**: 080-default-user-roles
+**Date**: 2026-02-12
+
+## Research Summary
+
+This feature requires no external research. All unknowns were resolved through codebase analysis.
+
+## Findings
+
+### Decision 1: User creation paths requiring changes
+
+- **Decision**: Two creation paths need modification: OIDC (OAuthService.kt) and manual admin creation (UserController.kt)
+- **Rationale**: Codebase analysis confirms these are the only two paths that create User entities. MCP uses delegation to existing users and does not create new accounts.
+- **Alternatives considered**: Centralizing default roles into a shared constant or config — rejected as over-engineering for a 2-location change. If a third creation path is added in the future, a constant can be extracted then.
+
+### Decision 2: Role name mapping
+
+- **Decision**: "USERS" from the user request maps to the `User.Role.USER` enum value
+- **Rationale**: The Role enum defines `USER` (not `USERS`). This is the basic authenticated user role. No other role matches the intent.
+- **Alternatives considered**: None — unambiguous mapping.
+
+### Decision 3: No schema migration needed
+
+- **Decision**: No Flyway migration or schema change required
+- **Rationale**: The `user_roles` table stores role values as strings via `@Enumerated(EnumType.STRING)`. The REQ enum value already exists and is used by other users. Adding REQ to default role sets only changes what gets inserted at creation time.
+- **Alternatives considered**: None — the schema already supports this.
+
+### Decision 4: Audit log string update
+
+- **Decision**: Update the hardcoded audit string in OAuthService.kt from "USER,VULN" to "USER,VULN,REQ"
+- **Rationale**: The `auditRoleAssignment` call logs which roles were assigned. It must reflect the new defaults for FR-006 compliance.
+- **Alternatives considered**: Dynamically generating the audit string from the roles set — reasonable but out of scope for this change.

--- a/specs/080-default-user-roles/spec.md
+++ b/specs/080-default-user-roles/spec.md
@@ -1,0 +1,76 @@
+# Feature Specification: Default User Roles on Creation
+
+**Feature Branch**: `080-default-user-roles`
+**Created**: 2026-02-12
+**Status**: Draft
+**Input**: User description: "Ensure that every new created user (via OIDC, via MCP) always has the roles VULN, USER, and REQ"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - OIDC User Gets Default Roles (Priority: P1)
+
+A new employee logs into secman for the first time via their organization's OIDC identity provider. Upon successful authentication, the system automatically creates their account with the default role set: USER, VULN, and REQ. The employee can immediately access vulnerability data and requirements without needing an administrator to manually assign roles.
+
+**Why this priority**: This is the most common user creation path. New employees currently only receive USER and VULN roles via OIDC, meaning they cannot access requirements until an admin manually grants REQ. This creates unnecessary onboarding friction and admin workload.
+
+**Independent Test**: Can be fully tested by logging in with a new OIDC user and verifying their assigned roles include USER, VULN, and REQ.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user does not yet exist in secman, **When** they authenticate via OIDC for the first time, **Then** their account is created with USER, VULN, and REQ roles assigned.
+2. **Given** a user already exists in secman with custom roles, **When** they re-authenticate via OIDC, **Then** their existing roles are preserved unchanged.
+3. **Given** a user does not yet exist in secman, **When** they authenticate via OIDC for the first time, **Then** the audit log records the role assignment including all three default roles.
+
+---
+
+### User Story 2 - Admin-Created User Gets Default Roles (Priority: P2)
+
+An administrator creates a new user account manually through the admin interface without specifying roles. The system assigns the default role set (USER, VULN, REQ) instead of just USER, ensuring consistency with the OIDC creation path.
+
+**Why this priority**: While less frequent than OIDC creation, manual user creation should follow the same default role policy to avoid inconsistency. Admins can still override roles when explicitly specified.
+
+**Independent Test**: Can be fully tested by creating a user through the admin API without specifying roles and verifying the assigned defaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** an administrator creates a new user without specifying roles, **When** the user is saved, **Then** the user receives USER, VULN, and REQ roles by default.
+2. **Given** an administrator creates a new user with explicitly specified roles (e.g., only ADMIN), **When** the user is saved, **Then** the user receives only the explicitly specified roles, not the defaults.
+
+---
+
+### Edge Cases
+
+- What happens when a user is created via OIDC and their identity provider claims include role information? The default roles should still be assigned as a minimum baseline; any additional role mapping from the IdP would be additive.
+- What happens when an existing user's roles have been reduced by an admin (e.g., REQ removed) and they re-authenticate via OIDC? Their current roles must be preserved as-is; the defaults only apply at initial account creation.
+- What happens when the MCP delegation targets a user that doesn't exist? MCP uses a delegation model that requires users to already exist, so the default roles would have been assigned at the user's original creation time (via OIDC or manual creation).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST assign the roles USER, VULN, and REQ to every newly created user account when no explicit roles are specified.
+- **FR-002**: The default role assignment MUST apply to users created via OIDC/OAuth first-time login.
+- **FR-003**: The default role assignment MUST apply to users created manually by administrators when no roles are explicitly provided.
+- **FR-004**: When an administrator explicitly specifies roles during user creation, the system MUST use the specified roles instead of the defaults.
+- **FR-005**: Existing users MUST NOT have their roles modified by this change, regardless of how they re-authenticate.
+- **FR-006**: The audit log MUST record the default role assignment for newly created users, including all three assigned roles.
+
+### Key Entities
+
+- **User**: Account record with username, email, authentication source, and a set of assigned roles. The default role set changes from {USER, VULN} to {USER, VULN, REQ}.
+- **Role**: A permission category that controls access to system features. The three default roles grant: basic access (USER), vulnerability data access (VULN), and requirements access (REQ).
+
+## Assumptions
+
+- "USERS" in the original request refers to the USER role (the basic authenticated user role).
+- MCP does not create users directly; it delegates to existing users. Therefore, MCP-created users are not a distinct creation path. Users accessed via MCP will have received their default roles at their original creation time.
+- The default role set is a system-wide policy, not configurable per identity provider.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of newly created users (via any creation path) receive the USER, VULN, and REQ roles when no explicit roles are specified.
+- **SC-002**: Zero existing user accounts have their roles modified by this change.
+- **SC-003**: Administrators can still override defaults by explicitly specifying roles during user creation, with 100% of explicit role specifications being honored.
+- **SC-004**: New users can access both vulnerability data and requirements immediately after their first login without admin intervention.

--- a/specs/080-default-user-roles/tasks.md
+++ b/specs/080-default-user-roles/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Default User Roles on Creation
+
+**Feature**: 080-default-user-roles
+**Date**: 2026-02-12
+
+## Phase 1: Core Implementation
+
+- [x] **T-001**: Update OIDC default roles in OAuthService.kt — Add `User.Role.REQ` to the default role set in `createNewOidcUser()` and update the audit log string from "USER,VULN" to "USER,VULN,REQ"
+- [x] **T-002**: Update manual creation default roles in UserController.kt — Change the empty-roles default from `{USER}` to `{USER, VULN, REQ}` in the `create()` method
+
+## Phase 2: Validation
+
+- [x] **T-003**: Build verification — Run `./gradlew build` to confirm compilation and existing tests pass

--- a/src/backendng/src/main/kotlin/com/secman/controller/UserController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/UserController.kt
@@ -133,9 +133,9 @@ open class UserController(
                 }
             }
             
-            // Default to USER role if none provided
+            // Default to USER, VULN, REQ roles if none provided
             if (roles.isEmpty()) {
-                roles.add(User.Role.USER)
+                roles.addAll(setOf(User.Role.USER, User.Role.VULN, User.Role.REQ))
             }
 
             val user = User(

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddUserTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddUserTool.kt
@@ -21,7 +21,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
  * - username (required): Unique username for the new user
  * - email (required): Unique email address for the new user
  * - password (required): Password for the new user (will be hashed)
- * - roles (optional): List of roles to assign (defaults to ["USER"])
+ * - roles (optional): List of roles to assign (defaults to ["USER", "VULN", "REQ"])
  *
  * Available roles: USER, ADMIN, VULN, RELEASE_MANAGER, REQ, RISK, SECCHAMPION
  */
@@ -55,7 +55,7 @@ class AddUserTool(
             "roles" to mapOf(
                 "type" to "array",
                 "items" to mapOf("type" to "string"),
-                "description" to "List of roles to assign. Available: USER, ADMIN, VULN, RELEASE_MANAGER, REQ, RISK, SECCHAMPION. Defaults to [USER]"
+                "description" to "List of roles to assign. Available: USER, ADMIN, VULN, RELEASE_MANAGER, REQ, RISK, SECCHAMPION. Defaults to [USER, VULN, REQ]"
             ),
             "mfaEnabled" to mapOf(
                 "type" to "boolean",
@@ -120,8 +120,8 @@ class AddUserTool(
         val roleStrings = arguments["roles"] as? List<String>
 
         if (roleStrings.isNullOrEmpty()) {
-            // Default to USER role if none provided
-            roles.add(User.Role.USER)
+            // Default to USER, VULN, REQ roles if none provided
+            roles.addAll(setOf(User.Role.USER, User.Role.VULN, User.Role.REQ))
         } else {
             for (roleString in roleStrings) {
                 try {

--- a/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
@@ -966,7 +966,7 @@ open class OAuthService(
             username = username,
             email = email,
             passwordHash = passwordEncoder.encode(UUID.randomUUID().toString())!!, // Random password for OIDC users
-            roles = mutableSetOf(User.Role.USER, User.Role.VULN), // FR-001, FR-002: Default roles
+            roles = mutableSetOf(User.Role.USER, User.Role.VULN, User.Role.REQ), // Default roles: USER, VULN, REQ
             authSource = User.AuthSource.OAUTH // Feature 051: Mark as OAuth user (cannot change password)
         )
 
@@ -974,7 +974,7 @@ open class OAuthService(
         logger.info("User created successfully: ${savedUser.id}, username: ${savedUser.username}")
 
         // FR-010: Audit logging
-        auditRoleAssignment(savedUser, "USER,VULN", idpName)
+        auditRoleAssignment(savedUser, "USER,VULN,REQ", idpName)
 
         // FR-011: Notify admins (async, best-effort per FR-012)
         notifyAdminsNewUser(savedUser, idpName)

--- a/tests/mcp-e2e-default-roles-test.sh
+++ b/tests/mcp-e2e-default-roles-test.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# MCP E2E Test: Default User Roles
+# Feature: 080-default-user-roles
+#
+# This script validates that creating a user via MCP add_user without
+# specifying roles automatically assigns the default roles: USER, VULN, REQ.
+#
+# Test flow:
+# 1. Create a user via MCP add_user WITHOUT specifying roles
+# 2. Verify the response contains exactly USER, VULN, REQ roles
+# 3. Clean up by deleting the test user
+#
+# Prerequisites:
+# - curl, jq, op (1Password CLI) installed
+# - Environment variables set with 1Password URIs:
+#   SECMAN_USERNAME, SECMAN_PASSWORD, SECMAN_API_KEY, SECMAN_TEST_DOMAIN
+#
+# Usage:
+#   ./tests/mcp-e2e-default-roles-test.sh
+#   DEBUG=1 ./tests/mcp-e2e-default-roles-test.sh  # Verbose output
+
+set -euo pipefail
+
+export SECMAN_USERNAME="op://test/secman/SECMAN_USERNAME"
+export SECMAN_PASSWORD="op://test/secman/SECMAN_PASSWORD"
+export SECMAN_API_KEY="op://test/secman/SECMAN_API_KEY"
+export SECMAN_TEST_DOMAIN="op://test/secman/SECMAN_TEST_DOMAIN"
+
+# Configuration
+BASE_URL="${SECMAN_BASE_URL:-http://localhost:8080}"
+TEST_USER_NAME="E2E_DEFAULT_ROLES_$(date +%s)"
+TEST_USER_EMAIL=""  # Set after SECMAN_TEST_DOMAIN is resolved
+
+# Expected default roles (sorted for comparison)
+EXPECTED_ROLES="REQ USER VULN"
+
+# State variables for cleanup
+API_KEY=""
+TEST_USER_ID=""
+CLEANUP_DONE=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $1" >&2; }
+log_error()   { echo -e "${RED}[FAIL]${NC} $1" >&2; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_debug()   { [[ "${DEBUG:-}" == "1" ]] && echo -e "${YELLOW}[DEBUG]${NC} $1" >&2 || true; }
+
+# Check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+
+    local missing=()
+    command -v curl &>/dev/null || missing+=("curl")
+    command -v jq   &>/dev/null || missing+=("jq")
+    command -v op   &>/dev/null || missing+=("op (1Password CLI)")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+
+    for var in SECMAN_USERNAME SECMAN_PASSWORD SECMAN_API_KEY SECMAN_TEST_DOMAIN; do
+        if [[ -z "${!var:-}" ]]; then
+            log_error "$var environment variable not set"
+            exit 1
+        fi
+    done
+
+    log_success "Prerequisites check passed"
+}
+
+# Resolve credentials from 1Password
+resolve_credentials() {
+    log_info "Resolving credentials from 1Password..."
+
+    resolve_op_var() {
+        local val="$1"
+        if [[ "$val" == op://* ]]; then
+            op read "$val" 2>/dev/null || { log_error "Failed to resolve $val from 1Password"; exit 1; }
+        else
+            echo "$val"
+        fi
+    }
+
+    RESOLVED_USERNAME=$(resolve_op_var "$SECMAN_USERNAME")
+    RESOLVED_PASSWORD=$(resolve_op_var "$SECMAN_PASSWORD")
+    API_KEY=$(resolve_op_var "$SECMAN_API_KEY")
+    RESOLVED_TEST_DOMAIN=$(resolve_op_var "$SECMAN_TEST_DOMAIN")
+
+    TEST_USER_EMAIL="e2e-default-roles-$(date +%s)@${RESOLVED_TEST_DOMAIN}"
+
+    log_success "Credentials resolved"
+}
+
+# MCP tool call helper
+mcp_call() {
+    local tool_name="$1"
+    local arguments="$2"
+    local user_email="${3:-${RESOLVED_USERNAME}}"
+    local request_id="e2e-$(date +%s)-$RANDOM"
+
+    log_debug "MCP call: $tool_name (as $user_email)"
+    log_debug "Arguments: $arguments"
+
+    local request_body
+    request_body=$(jq -n \
+        --arg id "$request_id" \
+        --arg name "$tool_name" \
+        --argjson args "$arguments" \
+        '{jsonrpc: "2.0", id: $id, method: "tools/call", params: {name: $name, arguments: $args}}')
+
+    local response
+    response=$(curl -s -w "\n%{http_code}" -X POST "${BASE_URL}/api/mcp/tools/call" \
+        -H "X-MCP-API-Key: ${API_KEY}" \
+        -H "Content-Type: application/json" \
+        -H "X-MCP-User-Email: ${user_email}" \
+        -d "$request_body")
+
+    local http_code
+    http_code=$(echo "$response" | tail -n1)
+    response=$(echo "$response" | sed '$d')
+
+    log_debug "HTTP status: $http_code"
+    log_debug "MCP response: $response"
+    echo "$response"
+}
+
+# Step 1: Create user WITHOUT roles
+create_test_user_without_roles() {
+    log_info "Step 1: Creating user via MCP add_user WITHOUT specifying roles..."
+    log_debug "Username: $TEST_USER_NAME / Email: $TEST_USER_EMAIL"
+
+    local args
+    args=$(jq -c -n \
+        --arg username "$TEST_USER_NAME" \
+        --arg email "$TEST_USER_EMAIL" \
+        --arg password "TestPass123!" \
+        '{username: $username, email: $email, password: $password}')
+
+    local response
+    response=$(mcp_call "add_user" "$args")
+
+    # Check for JSON-RPC error
+    local error_code
+    error_code=$(echo "$response" | jq -r '.error.code // empty')
+    if [[ -n "$error_code" ]]; then
+        log_error "Failed to create user: $(echo "$response" | jq -r '.error.message')"
+        exit 1
+    fi
+
+    TEST_USER_ID=$(echo "$response" | jq -r '.result.content.user.id // empty')
+    if [[ -z "$TEST_USER_ID" || "$TEST_USER_ID" == "null" ]]; then
+        log_error "Failed to get user ID from response"
+        log_debug "Response: $response"
+        exit 1
+    fi
+
+    log_success "Created user (ID: $TEST_USER_ID) without specifying roles"
+
+    # Return the response for role verification
+    echo "$response"
+}
+
+# Step 2: Verify default roles
+verify_default_roles() {
+    local response="$1"
+
+    log_info "Step 2: Verifying default roles are USER, VULN, REQ..."
+
+    # Extract roles array from response, sort for stable comparison
+    local actual_roles
+    actual_roles=$(echo "$response" | jq -r '.result.content.user.roles[]' 2>/dev/null | sort | tr '\n' ' ' | sed 's/ $//')
+
+    log_debug "Expected roles: $EXPECTED_ROLES"
+    log_debug "Actual roles:   $actual_roles"
+
+    if [[ "$actual_roles" == "$EXPECTED_ROLES" ]]; then
+        log_success "Default roles are correct: $actual_roles"
+    else
+        log_error "Role mismatch!"
+        log_error "  Expected: $EXPECTED_ROLES"
+        log_error "  Actual:   $actual_roles"
+        exit 1
+    fi
+
+    # Verify role count is exactly 3
+    local role_count
+    role_count=$(echo "$response" | jq '.result.content.user.roles | length')
+    if [[ "$role_count" -eq 3 ]]; then
+        log_success "Role count is correct: $role_count"
+    else
+        log_error "Expected 3 roles, got $role_count"
+        exit 1
+    fi
+}
+
+# Cleanup function
+cleanup() {
+    if [[ "$CLEANUP_DONE" == "true" ]]; then
+        return
+    fi
+    CLEANUP_DONE=true
+
+    log_info "Step 3: Cleaning up test data..."
+
+    if [[ -n "$TEST_USER_ID" && "$TEST_USER_ID" != "null" ]]; then
+        local args
+        args=$(jq -n --argjson userId "$TEST_USER_ID" '{userId: $userId}')
+        local response
+        response=$(mcp_call "delete_user" "$args" 2>/dev/null || true)
+        local error_code
+        error_code=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null || true)
+        if [[ -z "$error_code" ]]; then
+            log_info "Deleted test user (ID: $TEST_USER_ID)"
+        else
+            log_warn "Failed to delete user: $(echo "$response" | jq -r '.error.message' 2>/dev/null || echo 'unknown error')"
+        fi
+    fi
+
+    log_success "Cleanup completed"
+}
+
+# Main
+main() {
+    echo ""
+    echo "=== MCP E2E Test: Default User Roles (080-default-user-roles) ==="
+    echo ""
+
+    trap cleanup EXIT
+
+    check_prerequisites
+    resolve_credentials
+
+    local create_response
+    create_response=$(create_test_user_without_roles)
+    verify_default_roles "$create_response"
+
+    echo ""
+    echo "=== TEST PASSED ==="
+    echo ""
+}
+
+main "$@"


### PR DESCRIPTION
Assign REQ alongside USER and VULN as the default role set for newly created users. Updated OAuthService (OIDC path) to include REQ and adjusted its audit log, updated UserController and AddUserTool to apply USER,VULN,REQ when no roles are provided, and updated documentation/specs for feature 080-default-user-roles. Added an e2e test script (tests/mcp-e2e-default-roles-test.sh) and project-local .entire settings and .gitignore. No database schema changes required.

Entire-Checkpoint: f7035cb90827