### PR TITLE
Add AWS Account Sharing feature for directional asset visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@
 - **Metadata**: groups, cloudAccountId, cloudInstanceId, adDomain, osVersion
 - **Relations**: vulnerabilities, scanResults, workgroups, manualCreator, scanUploader
 
+### AWS Account Sharing
+- **Core**: id, sourceUser, targetUser, createdBy, createdAt
+- **Semantics**: Directional, non-transitive sharing of AWS account visibility between users
+- **Access**: ADMIN-only management via REST API, MCP tools, and admin UI
+
 ## Unified Access Control
 
 Users access assets if **ANY** is true:
@@ -28,6 +33,7 @@ Users access assets if **ANY** is true:
 4. Asset discovered via user's scan upload
 5. Asset's cloudAccountId matches user's AWS mappings (UserMapping)
 6. Asset's adDomain matches user's domain mappings (case-insensitive, UserMapping)
+7. Asset's cloudAccountId matches shared AWS accounts via AwsAccountSharing (directional, non-transitive)
 
 
 ## API Endpoints
@@ -51,6 +57,9 @@ Users access assets if **ANY** is true:
 **Auth**: POST /api/auth/login, GET /oauth/{authorize,callback}
 
 **User Mappings**: GET /api/user-mappings/{current,applied-history} (ADMIN), POST/PUT/DELETE /api/user-mappings[/{id}] (ADMIN)
+
+**AWS Account Sharing**: GET/POST /api/aws-account-sharing (ADMIN), DELETE /api/aws-account-sharing/{id} (ADMIN)
+- MCP tools: `list_aws_account_sharing`, `create_aws_account_sharing`, `delete_aws_account_sharing` (all require ADMIN + User Delegation)
 
 **Identity Providers**: GET /api/identity-providers[/{enabled,{id}}], POST/PUT/DELETE /api/identity-providers[/{id}], POST /api/identity-providers/{id}/test
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -269,7 +269,7 @@ curl -X POST http://localhost:8080/api/mcp/admin/api-keys \
 | `ASSETS_READ` | Read asset inventory | `get_assets`, `get_all_assets_detail`, `get_asset_profile`, `get_asset_complete_profile` |
 | `VULNERABILITIES_READ` | Read vulnerability data | `get_vulnerabilities`, `get_all_vulnerabilities_detail`, `get_asset_most_vulnerabilities`, `get_overdue_assets`, `get_my_exception_requests`, `get_pending_exception_requests`, `create_exception_request`, `approve_exception_request`, `reject_exception_request`, `cancel_exception_request` |
 | `SCANS_READ` | Read scan history | `get_scans`, `get_asset_scan_results`, `search_products` |
-| `USER_ACTIVITY` | User management and mappings | `list_users`, `add_user`, `delete_user`, `import_user_mappings`, `list_user_mappings` (all require delegation) |
+| `USER_ACTIVITY` | User management and mappings | `list_users`, `add_user`, `delete_user`, `import_user_mappings`, `list_user_mappings`, `list_aws_account_sharing`, `create_aws_account_sharing`, `delete_aws_account_sharing` (all require delegation) |
 | `WORKGROUPS_WRITE` | Workgroup management | `create_workgroup`, `delete_workgroup`, `assign_assets_to_workgroup`, `assign_users_to_workgroup` (all require delegation) |
 
 ### Managing Keys
@@ -713,6 +713,59 @@ List user mappings with pagination and filtering. **Requires ADMIN role and User
 - `totalElements`: Total number of mappings
 - `totalPages`: Total number of pages
 
+### AWS Account Sharing
+
+#### `list_aws_account_sharing`
+List AWS account sharing rules with pagination. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page` | number | No | Page number (0-indexed, default: 0) |
+| `size` | number | No | Page size (default: 20, max: 100) |
+
+**Returns:**
+- `content`: List of sharing rule DTOs containing:
+  - `id`: Sharing rule ID
+  - `sourceUserId`: ID of the user whose AWS accounts are shared
+  - `sourceUserEmail`: Email of the source user
+  - `sourceUserUsername`: Username of the source user
+  - `targetUserId`: ID of the user who receives visibility
+  - `targetUserEmail`: Email of the target user
+  - `targetUserUsername`: Username of the target user
+  - `createdById`: ID of the admin who created the rule
+  - `createdByUsername`: Username of the admin
+  - `sharedAwsAccountCount`: Number of AWS accounts being shared
+  - `createdAt`: Creation timestamp
+  - `updatedAt`: Last update timestamp
+- `page`, `size`, `totalElements`, `totalPages`
+
+#### `create_aws_account_sharing`
+Create a new AWS account sharing rule. **Requires ADMIN role and User Delegation.**
+
+Sharing is directional (source -> target) and non-transitive.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sourceUserId` | number | Yes | ID of the user whose AWS accounts will be shared |
+| `targetUserId` | number | Yes | ID of the user who will receive visibility |
+
+**Validations:**
+- Source and target users must be different
+- Both users must exist
+- Source user must have at least one AWS account mapping
+- No duplicate sharing rules allowed
+
+**Returns:** Created sharing rule DTO with message.
+
+#### `delete_aws_account_sharing`
+Delete an AWS account sharing rule. **Requires ADMIN role and User Delegation.**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | number | Yes | ID of the sharing rule to delete |
+
+**Returns:** Success confirmation message.
+
 ### Release Management
 
 #### `list_releases`
@@ -873,6 +926,11 @@ All MCP operations are logged with:
 - "Validate mappings before import" → `import_user_mappings` with `dryRun: true`
 - "List all user mappings" → `list_user_mappings`
 - "Find mappings for user@company.com" → `list_user_mappings` with `email: "user@company.com"`
+
+**AWS Account Sharing:**
+- "List all sharing rules" → `list_aws_account_sharing`
+- "Share user 5's AWS accounts with user 12" → `create_aws_account_sharing` with `sourceUserId: 5, targetUserId: 12`
+- "Remove sharing rule 3" → `delete_aws_account_sharing` with `id: 3`
 
 **Releases:**
 - "List all releases" → `list_releases`

--- a/src/backendng/src/main/kotlin/com/secman/controller/AwsAccountSharingController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AwsAccountSharingController.kt
@@ -1,0 +1,109 @@
+package com.secman.controller
+
+import com.secman.dto.CreateAwsAccountSharingRequest
+import com.secman.service.AwsAccountSharingService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.*
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import org.slf4j.LoggerFactory
+
+/**
+ * REST controller for AWS Account Sharing management.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * All endpoints require ADMIN role.
+ * Provides CRUD operations for sharing rules that allow
+ * one user's AWS account visibility to be shared with another user.
+ */
+@Controller("/api/aws-account-sharing")
+@Secured("ADMIN")
+class AwsAccountSharingController(
+    private val awsAccountSharingService: AwsAccountSharingService
+) {
+    private val logger = LoggerFactory.getLogger(AwsAccountSharingController::class.java)
+
+    /**
+     * GET /api/aws-account-sharing - List all sharing rules with pagination.
+     */
+    @Get
+    fun listSharingRules(
+        @QueryValue("page") page: Int?,
+        @QueryValue("size") size: Int?
+    ): HttpResponse<Map<String, Any>> {
+        logger.debug("Listing AWS account sharing rules: page=$page, size=$size")
+
+        return try {
+            val result = awsAccountSharingService.listSharingRules(page ?: 0, size ?: 20)
+            HttpResponse.ok(result)
+        } catch (e: Exception) {
+            logger.error("Failed to list AWS account sharing rules", e)
+            HttpResponse.serverError(mapOf(
+                "error" to "Internal Server Error",
+                "message" to "Failed to list sharing rules"
+            ))
+        }
+    }
+
+    /**
+     * POST /api/aws-account-sharing - Create a new sharing rule.
+     */
+    @Post
+    fun createSharingRule(
+        @Body request: CreateAwsAccountSharingRequest,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        logger.info("Creating AWS account sharing rule: source=${request.sourceUserId}, target=${request.targetUserId}")
+
+        return try {
+            val adminUserId = getUserIdFromAuthentication(authentication)
+            val result = awsAccountSharingService.createSharingRule(request, adminUserId)
+            HttpResponse.status<Any>(HttpStatus.CREATED).body(result)
+        } catch (e: IllegalArgumentException) {
+            logger.warn("AWS account sharing creation failed: ${e.message}")
+            HttpResponse.badRequest(mapOf(
+                "error" to "Validation Error",
+                "message" to (e.message ?: "Invalid request")
+            ))
+        } catch (e: IllegalStateException) {
+            logger.warn("AWS account sharing creation failed: ${e.message}")
+            HttpResponse.badRequest(mapOf(
+                "error" to "Conflict",
+                "message" to (e.message ?: "Sharing rule already exists")
+            ))
+        } catch (e: NoSuchElementException) {
+            HttpResponse.notFound(mapOf(
+                "error" to "Not Found",
+                "message" to (e.message ?: "User not found")
+            ))
+        }
+    }
+
+    /**
+     * DELETE /api/aws-account-sharing/{id} - Delete a sharing rule.
+     */
+    @Delete("/{id}")
+    fun deleteSharingRule(@PathVariable id: Long): HttpResponse<Void> {
+        logger.info("Deleting AWS account sharing rule: id=$id")
+
+        return try {
+            awsAccountSharingService.deleteSharingRule(id)
+            HttpResponse.noContent()
+        } catch (e: NoSuchElementException) {
+            logger.warn("AWS account sharing rule not found: $id")
+            HttpResponse.notFound()
+        }
+    }
+
+    private fun getUserIdFromAuthentication(authentication: Authentication): Long {
+        val userId = authentication.attributes["userId"]
+        return when (userId) {
+            is Long -> userId
+            is Int -> userId.toLong()
+            is String -> userId.toLong()
+            else -> throw IllegalStateException("Unable to determine user ID from authentication")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/AwsAccountSharing.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/AwsAccountSharing.kt
@@ -1,0 +1,89 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * AwsAccountSharing entity - stores directional, non-transitive sharing rules
+ * for AWS account visibility between users.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * Semantics:
+ * - sourceUser shares their AWS account visibility with targetUser
+ * - targetUser can then see all assets whose cloudAccountId matches
+ *   any of sourceUser's AWS account mappings (via user_mapping)
+ * - Sharing is directional: A->B does NOT imply B->A
+ * - Sharing is NOT transitive: if A->B and B->C, C does NOT see A's accounts via B
+ *
+ * Business Rules:
+ * - sourceUser and targetUser must be different users
+ * - Unique constraint on (source_user_id, target_user_id) prevents duplicates
+ * - Only ADMIN users can create/manage sharing rules
+ * - ON DELETE CASCADE ensures cleanup when users are deleted
+ * - createdBy tracks which admin created the rule for audit purposes
+ */
+@Entity
+@Table(
+    name = "aws_account_sharing",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_aws_sharing_source_target",
+            columnNames = ["source_user_id", "target_user_id"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_aws_sharing_source", columnList = "source_user_id"),
+        Index(name = "idx_aws_sharing_target", columnList = "target_user_id"),
+        Index(name = "idx_aws_sharing_created_by", columnList = "created_by_id")
+    ]
+)
+@Serdeable
+data class AwsAccountSharing(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "source_user_id", nullable = false)
+    var sourceUser: User,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "target_user_id", nullable = false)
+    var targetUser: User,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by_id", nullable = false)
+    var createdBy: User,
+
+    @Column(name = "created_at", updatable = false)
+    var createdAt: Instant? = null,
+
+    @Column(name = "updated_at")
+    var updatedAt: Instant? = null
+) {
+    @PrePersist
+    fun onCreate() {
+        val now = Instant.now()
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AwsAccountSharing) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+
+    override fun toString(): String {
+        return "AwsAccountSharing(id=$id, sourceUserId=${sourceUser.id}, targetUserId=${targetUser.id})"
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/dto/AwsAccountSharingDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/AwsAccountSharingDto.kt
@@ -1,0 +1,54 @@
+package com.secman.dto
+
+import com.secman.domain.AwsAccountSharing
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Response DTO for AWS Account Sharing rules.
+ *
+ * Feature: AWS Account Sharing
+ */
+@Serdeable
+data class AwsAccountSharingResponse(
+    val id: Long,
+    val sourceUserId: Long,
+    val sourceUserEmail: String,
+    val sourceUserUsername: String,
+    val targetUserId: Long,
+    val targetUserEmail: String,
+    val targetUserUsername: String,
+    val createdById: Long,
+    val createdByUsername: String,
+    val sharedAwsAccountCount: Int,
+    val createdAt: String,
+    val updatedAt: String
+)
+
+/**
+ * Request DTO for creating an AWS Account Sharing rule.
+ */
+@Serdeable
+data class CreateAwsAccountSharingRequest(
+    val sourceUserId: Long,
+    val targetUserId: Long
+)
+
+/**
+ * Extension function to convert AwsAccountSharing entity to response DTO.
+ */
+fun AwsAccountSharing.toResponse(sharedAwsAccountCount: Int = 0): AwsAccountSharingResponse {
+    return AwsAccountSharingResponse(
+        id = this.id!!,
+        sourceUserId = this.sourceUser.id!!,
+        sourceUserEmail = this.sourceUser.email,
+        sourceUserUsername = this.sourceUser.username,
+        targetUserId = this.targetUser.id!!,
+        targetUserEmail = this.targetUser.email,
+        targetUserUsername = this.targetUser.username,
+        createdById = this.createdBy.id!!,
+        createdByUsername = this.createdBy.username,
+        sharedAwsAccountCount = sharedAwsAccountCount,
+        createdAt = this.createdAt?.toString() ?: "",
+        updatedAt = this.updatedAt?.toString() ?: ""
+    )
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -72,7 +72,11 @@ class McpToolRegistry(
     // Feature: MCP Send Admin Summary Tool
     @Inject private val sendAdminSummaryTool: SendAdminSummaryTool,
     // Feature: MCP Compare Releases Tool
-    @Inject private val compareReleasesTool: CompareReleasesTool
+    @Inject private val compareReleasesTool: CompareReleasesTool,
+    // Feature: AWS Account Sharing
+    @Inject private val listAwsAccountSharingTool: ListAwsAccountSharingTool,
+    @Inject private val createAwsAccountSharingTool: CreateAwsAccountSharingTool,
+    @Inject private val deleteAwsAccountSharingTool: DeleteAwsAccountSharingTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -141,7 +145,11 @@ class McpToolRegistry(
             // Feature: MCP Send Admin Summary Tool
             sendAdminSummaryTool,
             // Feature: MCP Compare Releases Tool
-            compareReleasesTool
+            compareReleasesTool,
+            // Feature: AWS Account Sharing
+            listAwsAccountSharingTool,
+            createAwsAccountSharingTool,
+            deleteAwsAccountSharingTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -369,6 +377,11 @@ class McpToolRegistry(
             // Feature: MCP Send Admin Summary Tool (ADMIN only via User Delegation)
             "send_admin_summary" -> {
                 permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
+            }
+
+            // Feature: AWS Account Sharing (ADMIN only via User Delegation)
+            "list_aws_account_sharing", "create_aws_account_sharing", "delete_aws_account_sharing" -> {
+                permissions.contains(McpPermission.USER_ACTIVITY) // ADMIN role checked in tool execute()
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateAwsAccountSharingTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateAwsAccountSharingTool.kt
@@ -1,0 +1,108 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.CreateAwsAccountSharingRequest
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.AwsAccountSharingService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * MCP tool for creating an AWS account sharing rule.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - sourceUserId (required): ID of the user whose AWS accounts will be shared
+ * - targetUserId (required): ID of the user who will receive visibility
+ *
+ * Returns:
+ * - Created sharing rule details
+ */
+@Singleton
+class CreateAwsAccountSharingTool(
+    @Inject private val awsAccountSharingService: AwsAccountSharingService
+) : McpTool {
+
+    private val log = LoggerFactory.getLogger(CreateAwsAccountSharingTool::class.java)
+
+    override val name = "create_aws_account_sharing"
+    override val description = "Create an AWS account sharing rule to share one user's AWS account visibility with another user (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "sourceUserId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the user whose AWS accounts will be shared (the sharer)"
+            ),
+            "targetUserId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the user who will receive AWS account visibility (the recipient)"
+            )
+        ),
+        "required" to listOf("sourceUserId", "targetUserId")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to create AWS account sharing rules"
+            )
+        }
+
+        val sourceUserId = (arguments["sourceUserId"] as? Number)?.toLong()
+        val targetUserId = (arguments["targetUserId"] as? Number)?.toLong()
+
+        if (sourceUserId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "sourceUserId is required and must be a valid number")
+        }
+        if (targetUserId == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "targetUserId is required and must be a valid number")
+        }
+
+        try {
+            val adminUserId = context.delegatedUserId
+                ?: return McpToolResult.error("DELEGATION_REQUIRED", "Delegated user ID is required")
+
+            val request = CreateAwsAccountSharingRequest(
+                sourceUserId = sourceUserId,
+                targetUserId = targetUserId
+            )
+
+            val result = awsAccountSharingService.createSharingRule(request, adminUserId)
+
+            log.info(
+                "AUDIT: MCP create_aws_account_sharing: source={}, target={}, actor={}",
+                result.sourceUserEmail, result.targetUserEmail, context.delegatedUserEmail
+            )
+
+            return McpToolResult.success(mapOf(
+                "sharingRule" to result,
+                "message" to "AWS account sharing rule created: ${result.sourceUserEmail} -> ${result.targetUserEmail} (${result.sharedAwsAccountCount} accounts)"
+            ))
+
+        } catch (e: IllegalArgumentException) {
+            return McpToolResult.error("VALIDATION_ERROR", e.message ?: "Invalid request")
+        } catch (e: IllegalStateException) {
+            return McpToolResult.error("CONFLICT", e.message ?: "Sharing rule already exists")
+        } catch (e: NoSuchElementException) {
+            return McpToolResult.error("NOT_FOUND", e.message ?: "User not found")
+        } catch (e: Exception) {
+            log.error("Failed to create AWS account sharing rule", e)
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to create sharing rule: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAwsAccountSharingTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAwsAccountSharingTool.kt
@@ -1,0 +1,85 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.AwsAccountSharingService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * MCP tool for deleting an AWS account sharing rule.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - id (required): ID of the sharing rule to delete
+ *
+ * Returns:
+ * - Success confirmation
+ */
+@Singleton
+class DeleteAwsAccountSharingTool(
+    @Inject private val awsAccountSharingService: AwsAccountSharingService
+) : McpTool {
+
+    private val log = LoggerFactory.getLogger(DeleteAwsAccountSharingTool::class.java)
+
+    override val name = "delete_aws_account_sharing"
+    override val description = "Delete an AWS account sharing rule (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.DELETE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "id" to mapOf(
+                "type" to "number",
+                "description" to "The ID of the sharing rule to delete"
+            )
+        ),
+        "required" to listOf("id")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to delete AWS account sharing rules"
+            )
+        }
+
+        val id = (arguments["id"] as? Number)?.toLong()
+
+        if (id == null) {
+            return McpToolResult.error("VALIDATION_ERROR", "id is required and must be a valid number")
+        }
+
+        try {
+            awsAccountSharingService.deleteSharingRule(id)
+
+            log.info(
+                "AUDIT: MCP delete_aws_account_sharing: id={}, actor={}",
+                id, context.delegatedUserEmail
+            )
+
+            return McpToolResult.success(mapOf(
+                "message" to "AWS account sharing rule $id deleted successfully"
+            ))
+
+        } catch (e: NoSuchElementException) {
+            return McpToolResult.error("NOT_FOUND", e.message ?: "Sharing rule not found")
+        } catch (e: Exception) {
+            log.error("Failed to delete AWS account sharing rule", e)
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to delete sharing rule: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListAwsAccountSharingTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListAwsAccountSharingTool.kt
@@ -1,0 +1,88 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.AwsAccountSharingService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * MCP tool for listing AWS account sharing rules with pagination.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * ADMIN role is required via User Delegation.
+ *
+ * Input parameters:
+ * - page (optional): Page number (0-indexed). Defaults to 0.
+ * - size (optional): Page size. Defaults to 20, max 100.
+ *
+ * Returns:
+ * - sharingRules: List of sharing rule DTOs
+ * - page, size, totalElements, totalPages
+ */
+@Singleton
+class ListAwsAccountSharingTool(
+    @Inject private val awsAccountSharingService: AwsAccountSharingService
+) : McpTool {
+
+    private val log = LoggerFactory.getLogger(ListAwsAccountSharingTool::class.java)
+
+    override val name = "list_aws_account_sharing"
+    override val description = "List AWS account sharing rules (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "page" to mapOf(
+                "type" to "number",
+                "description" to "Page number (0-indexed)",
+                "default" to 0,
+                "minimum" to 0
+            ),
+            "size" to mapOf(
+                "type" to "number",
+                "description" to "Page size",
+                "default" to 20,
+                "minimum" to 1,
+                "maximum" to 100
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to list AWS account sharing rules"
+            )
+        }
+
+        val page = (arguments["page"] as? Number)?.toInt() ?: 0
+        val size = ((arguments["size"] as? Number)?.toInt() ?: 20).coerceIn(1, 100)
+
+        try {
+            val result = awsAccountSharingService.listSharingRules(page, size)
+
+            log.debug(
+                "MCP list_aws_account_sharing: page={}, size={}, total={}, actor={}",
+                page, size, result["totalElements"], context.delegatedUserEmail
+            )
+
+            return McpToolResult.success(result)
+
+        } catch (e: Exception) {
+            log.error("Failed to list AWS account sharing rules", e)
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to list sharing rules: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
@@ -64,6 +64,13 @@ interface AssetRepository : JpaRepository<Asset, Long> {
                     SELECT LOWER(um.domain) FROM user_mapping um
                     WHERE um.email = :userEmail AND um.domain IS NOT NULL
                 )
+                OR a.cloud_account_id IN (
+                    SELECT DISTINCT um2.aws_account_id
+                    FROM aws_account_sharing acs
+                    JOIN users u_source ON u_source.id = acs.source_user_id
+                    JOIN user_mapping um2 ON um2.email = u_source.email AND um2.aws_account_id IS NOT NULL
+                    WHERE acs.target_user_id = :userId
+                )
             ORDER BY a.name ASC
         """,
         nativeQuery = true

--- a/src/backendng/src/main/kotlin/com/secman/repository/AwsAccountSharingRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AwsAccountSharingRepository.kt
@@ -1,0 +1,62 @@
+package com.secman.repository
+
+import com.secman.domain.AwsAccountSharing
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import io.micronaut.data.model.Page
+import io.micronaut.data.model.Pageable
+import java.util.Optional
+
+/**
+ * Repository for AwsAccountSharing entity.
+ *
+ * Feature: AWS Account Sharing
+ */
+@Repository
+interface AwsAccountSharingRepository : JpaRepository<AwsAccountSharing, Long> {
+
+    fun findByTargetUserId(targetUserId: Long): List<AwsAccountSharing>
+
+    fun findBySourceUserId(sourceUserId: Long): List<AwsAccountSharing>
+
+    fun existsBySourceUserIdAndTargetUserId(sourceUserId: Long, targetUserId: Long): Boolean
+
+    fun findBySourceUserIdAndTargetUserId(sourceUserId: Long, targetUserId: Long): Optional<AwsAccountSharing>
+
+    fun deleteBySourceUserIdAndTargetUserId(sourceUserId: Long, targetUserId: Long)
+
+    override fun findAll(pageable: Pageable): Page<AwsAccountSharing>
+
+    /**
+     * Find all sharing rules with eager-loaded user associations for admin listing.
+     */
+    @Query("""
+        SELECT s FROM AwsAccountSharing s
+        LEFT JOIN FETCH s.sourceUser
+        LEFT JOIN FETCH s.targetUser
+        LEFT JOIN FETCH s.createdBy
+        ORDER BY s.createdAt DESC
+    """)
+    fun findAllWithUsers(): List<AwsAccountSharing>
+
+    /**
+     * Find all AWS account IDs accessible to a target user via sharing rules.
+     * Joins aws_account_sharing -> users -> user_mapping to resolve shared accounts.
+     *
+     * This is the critical query for access control integration.
+     * Non-transitive by design: only joins user_mapping (direct mappings),
+     * not recursively computed visibility.
+     */
+    @Query(
+        value = """
+            SELECT DISTINCT um.aws_account_id
+            FROM aws_account_sharing acs
+            JOIN users u_source ON u_source.id = acs.source_user_id
+            JOIN user_mapping um ON um.email = u_source.email AND um.aws_account_id IS NOT NULL
+            WHERE acs.target_user_id = :targetUserId
+        """,
+        nativeQuery = true
+    )
+    fun findSharedAwsAccountIdsByTargetUserId(targetUserId: Long): List<String>
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/AssetFilterService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AssetFilterService.kt
@@ -40,7 +40,8 @@ open class AssetFilterService(
     private val scanRepository: ScanRepository,
     private val userRepository: UserRepository,
     private val userMappingRepository: UserMappingRepository,
-    private val memoryConfig: MemoryOptimizationConfig
+    private val memoryConfig: MemoryOptimizationConfig,
+    private val awsAccountSharingService: AwsAccountSharingService
 ) {
 
     /**
@@ -136,8 +137,20 @@ open class AssetFilterService(
             emptyList()
         }
 
+        // Get assets accessible via AWS account sharing (shared accounts from other users)
+        val sharedAwsAccountAssets = if (userEmail != null) {
+            val sharedIds = awsAccountSharingService.getSharedAwsAccountIdsByEmail(userEmail)
+            if (sharedIds.isNotEmpty()) {
+                assetRepository.findByCloudAccountIdIn(sharedIds)
+            } else {
+                emptyList()
+            }
+        } else {
+            emptyList()
+        }
+
         // Combine and deduplicate by asset ID, then sort by name
-        return (workgroupAssets + awsAccountAssets + domainAssets)
+        return (workgroupAssets + awsAccountAssets + domainAssets + sharedAwsAccountAssets)
             .distinctBy { it.id }
             .sortedBy { it.name }
     }

--- a/src/backendng/src/main/kotlin/com/secman/service/AwsAccountSharingService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AwsAccountSharingService.kt
@@ -1,0 +1,133 @@
+package com.secman.service
+
+import com.secman.domain.AwsAccountSharing
+import com.secman.dto.AwsAccountSharingResponse
+import com.secman.dto.CreateAwsAccountSharingRequest
+import com.secman.dto.toResponse
+import com.secman.repository.AwsAccountSharingRepository
+import com.secman.repository.UserMappingRepository
+import com.secman.repository.UserRepository
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+
+/**
+ * Service for managing AWS Account Sharing rules.
+ *
+ * Feature: AWS Account Sharing
+ *
+ * Provides business logic for creating, listing, and deleting sharing rules,
+ * as well as resolving shared AWS account IDs for access control.
+ */
+@Singleton
+open class AwsAccountSharingService(
+    private val awsAccountSharingRepository: AwsAccountSharingRepository,
+    private val userRepository: UserRepository,
+    private val userMappingRepository: UserMappingRepository
+) {
+    private val log = LoggerFactory.getLogger(AwsAccountSharingService::class.java)
+
+    /**
+     * List all sharing rules with source/target user details and shared account counts.
+     * Manually paginates the eager-fetched results to avoid N+1 and LAZY issues.
+     */
+    fun listSharingRules(page: Int, size: Int): Map<String, Any> {
+        val allRules = awsAccountSharingRepository.findAllWithUsers()
+        val totalElements = allRules.size.toLong()
+        val totalPages = if (totalElements == 0L) 0 else ((totalElements + size - 1) / size).toInt()
+
+        val pagedRules = allRules
+            .drop(page * size)
+            .take(size)
+            .map { sharing ->
+                val count = userMappingRepository.findDistinctAwsAccountIdByEmail(sharing.sourceUser.email).size
+                sharing.toResponse(sharedAwsAccountCount = count)
+            }
+
+        return mapOf(
+            "content" to pagedRules,
+            "totalElements" to totalElements,
+            "totalPages" to totalPages,
+            "page" to page,
+            "size" to size
+        )
+    }
+
+    /**
+     * Create a new sharing rule.
+     *
+     * Validates:
+     * - source != target (no self-sharing)
+     * - Both users exist
+     * - No duplicate rule
+     * - Source user has at least one AWS account mapping
+     */
+    @Transactional
+    open fun createSharingRule(request: CreateAwsAccountSharingRequest, adminUserId: Long): AwsAccountSharingResponse {
+        if (request.sourceUserId == request.targetUserId) {
+            throw IllegalArgumentException("Source and target user cannot be the same")
+        }
+
+        val sourceUser = userRepository.findById(request.sourceUserId)
+            .orElseThrow { NoSuchElementException("Source user not found: ${request.sourceUserId}") }
+        val targetUser = userRepository.findById(request.targetUserId)
+            .orElseThrow { NoSuchElementException("Target user not found: ${request.targetUserId}") }
+        val adminUser = userRepository.findById(adminUserId)
+            .orElseThrow { IllegalStateException("Admin user not found: $adminUserId") }
+
+        if (awsAccountSharingRepository.existsBySourceUserIdAndTargetUserId(
+                request.sourceUserId, request.targetUserId)) {
+            throw IllegalStateException("Sharing rule already exists from ${sourceUser.email} to ${targetUser.email}")
+        }
+
+        val sourceAwsAccounts = userMappingRepository.findDistinctAwsAccountIdByEmail(sourceUser.email)
+        if (sourceAwsAccounts.isEmpty()) {
+            throw IllegalArgumentException("Source user ${sourceUser.email} has no AWS account mappings to share")
+        }
+
+        val sharing = AwsAccountSharing(
+            sourceUser = sourceUser,
+            targetUser = targetUser,
+            createdBy = adminUser
+        )
+
+        val saved = awsAccountSharingRepository.save(sharing)
+        log.info("AUDIT: AWS account sharing created: source={}, target={}, admin={}, sharedAccounts={}",
+            sourceUser.email, targetUser.email, adminUser.email, sourceAwsAccounts.size)
+
+        return saved.toResponse(sharedAwsAccountCount = sourceAwsAccounts.size)
+    }
+
+    /**
+     * Delete a sharing rule by ID.
+     */
+    @Transactional
+    open fun deleteSharingRule(sharingId: Long): Boolean {
+        val sharing = awsAccountSharingRepository.findById(sharingId)
+            .orElseThrow { NoSuchElementException("Sharing rule not found: $sharingId") }
+
+        awsAccountSharingRepository.delete(sharing)
+        log.info("AUDIT: AWS account sharing deleted: id={}, source={}, target={}",
+            sharingId, sharing.sourceUser.email, sharing.targetUser.email)
+        return true
+    }
+
+    /**
+     * Get all shared AWS account IDs for a target user.
+     * Used by access control services to determine asset visibility.
+     *
+     * Returns distinct AWS account IDs from all source users sharing with this target user.
+     */
+    fun getSharedAwsAccountIds(targetUserId: Long): List<String> {
+        return awsAccountSharingRepository.findSharedAwsAccountIdsByTargetUserId(targetUserId)
+    }
+
+    /**
+     * Get shared AWS account IDs by resolving the target user's email to their ID.
+     * Convenience method for services that have the email but not the user ID.
+     */
+    fun getSharedAwsAccountIdsByEmail(targetUserEmail: String): List<String> {
+        val user = userRepository.findByEmailIgnoreCase(targetUserEmail).orElse(null) ?: return emptyList()
+        return getSharedAwsAccountIds(user.id!!)
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/mcp/McpAccessControlService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/mcp/McpAccessControlService.kt
@@ -8,6 +8,7 @@ import com.secman.dto.mcp.McpExecutionContext
 import com.secman.repository.AssetRepository
 import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
+import com.secman.service.AwsAccountSharingService
 import io.micronaut.cache.annotation.Cacheable
 import jakarta.inject.Singleton
 import org.slf4j.LoggerFactory
@@ -34,7 +35,8 @@ import org.slf4j.LoggerFactory
 open class McpAccessControlService(
     private val assetRepository: AssetRepository,
     private val userMappingRepository: UserMappingRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val awsAccountSharingService: AwsAccountSharingService
 ) {
     private val logger = LoggerFactory.getLogger(McpAccessControlService::class.java)
 
@@ -171,11 +173,19 @@ open class McpAccessControlService(
             emptyList()
         }
 
-        val allAccessibleIds = (workgroupAssets + awsAssets + domainAssets).toSet()
+        // Criteria 6: AWS account sharing (shared accounts from other users)
+        val sharedAwsAccountIds = awsAccountSharingService.getSharedAwsAccountIds(userId)
+        val sharedAssets = if (sharedAwsAccountIds.isNotEmpty()) {
+            assetRepository.findByCloudAccountIdIn(sharedAwsAccountIds).mapNotNull { it.id }
+        } else {
+            emptyList()
+        }
+
+        val allAccessibleIds = (workgroupAssets + awsAssets + domainAssets + sharedAssets).toSet()
 
         logger.info(
-            "Computed accessible assets: userId={}, email={}, workgroup={}, aws={}, domain={}, total={}",
-            userId, userEmail, workgroupAssets.size, awsAssets.size, domainAssets.size, allAccessibleIds.size
+            "Computed accessible assets: userId={}, email={}, workgroup={}, aws={}, domain={}, shared={}, total={}",
+            userId, userEmail, workgroupAssets.size, awsAssets.size, domainAssets.size, sharedAssets.size, allAccessibleIds.size
         )
 
         return allAccessibleIds

--- a/src/frontend/src/components/AdminPage.tsx
+++ b/src/frontend/src/components/AdminPage.tsx
@@ -228,6 +228,21 @@ const AdminPage = () => {
                     <div className="card">
                         <div className="card-body">
                             <h5 className="card-title">
+                                <i className="bi bi-share-fill me-2"></i>
+                                AWS Account Sharing
+                            </h5>
+                            <p className="card-text">Share AWS account visibility between users for cross-team asset access.</p>
+                            <a href="/admin/aws-account-sharing" className="btn btn-primary">
+                                Manage Sharing
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="col-md-4 mb-3">
+                    <div className="card">
+                        <div className="card-body">
+                            <h5 className="card-title">
                                 <i className="bi bi-bell-fill me-2"></i>
                                 Notification Settings
                             </h5>

--- a/src/frontend/src/components/AwsAccountSharingManager.tsx
+++ b/src/frontend/src/components/AwsAccountSharingManager.tsx
@@ -1,0 +1,343 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { authenticatedGet } from '../utils/auth';
+import {
+    listSharingRules,
+    createSharingRule,
+    deleteSharingRule,
+    type AwsAccountSharing,
+} from '../services/awsAccountSharingService';
+
+interface User {
+    id: number;
+    username: string;
+    email: string;
+    roles: string[];
+}
+
+const AwsAccountSharingManager: React.FC = () => {
+    const [sharingRules, setSharingRules] = useState<AwsAccountSharing[]>([]);
+    const [users, setUsers] = useState<User[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+    // Pagination
+    const [page, setPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(0);
+    const [totalElements, setTotalElements] = useState(0);
+    const pageSize = 20;
+
+    // Create form
+    const [showCreateForm, setShowCreateForm] = useState(false);
+    const [sourceUserId, setSourceUserId] = useState<number | ''>('');
+    const [targetUserId, setTargetUserId] = useState<number | ''>('');
+    const [isCreating, setIsCreating] = useState(false);
+
+    // Delete confirmation
+    const [deletingId, setDeletingId] = useState<number | null>(null);
+
+    const showSuccess = (msg: string) => {
+        setSuccessMessage(msg);
+        setTimeout(() => setSuccessMessage(null), 5000);
+    };
+
+    const showError = (msg: string) => {
+        setError(msg);
+        setTimeout(() => setError(null), 8000);
+    };
+
+    const fetchSharingRules = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            const result = await listSharingRules(page, pageSize);
+            setSharingRules(result.content);
+            setTotalPages(result.totalPages);
+            setTotalElements(result.totalElements);
+        } catch (err: any) {
+            showError(err.message || 'Failed to load sharing rules');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [page]);
+
+    const fetchUsers = useCallback(async () => {
+        try {
+            const response = await authenticatedGet('/api/users');
+            if (response.ok) {
+                const data = await response.json();
+                setUsers(data);
+            }
+        } catch {
+            // Non-critical - user dropdowns will be empty
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchSharingRules();
+        fetchUsers();
+    }, [fetchSharingRules, fetchUsers]);
+
+    const handleCreate = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (sourceUserId === '' || targetUserId === '') {
+            showError('Please select both source and target users');
+            return;
+        }
+        if (sourceUserId === targetUserId) {
+            showError('Source and target user cannot be the same');
+            return;
+        }
+
+        setIsCreating(true);
+        try {
+            const result = await createSharingRule({
+                sourceUserId: sourceUserId as number,
+                targetUserId: targetUserId as number,
+            });
+            showSuccess(
+                `Sharing rule created: ${result.sourceUserEmail} -> ${result.targetUserEmail} (${result.sharedAwsAccountCount} accounts)`
+            );
+            setShowCreateForm(false);
+            setSourceUserId('');
+            setTargetUserId('');
+            fetchSharingRules();
+        } catch (err: any) {
+            showError(err.message || 'Failed to create sharing rule');
+        } finally {
+            setIsCreating(false);
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        try {
+            await deleteSharingRule(id);
+            showSuccess('Sharing rule deleted successfully');
+            setDeletingId(null);
+            fetchSharingRules();
+        } catch (err: any) {
+            showError(err.message || 'Failed to delete sharing rule');
+        }
+    };
+
+    const formatDate = (dateStr: string) => {
+        try {
+            return new Date(dateStr).toLocaleString();
+        } catch {
+            return dateStr;
+        }
+    };
+
+    return (
+        <div>
+            <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2>
+                    <i className="bi bi-share-fill me-2"></i>
+                    AWS Account Sharing
+                </h2>
+                <button
+                    className="btn btn-primary"
+                    onClick={() => setShowCreateForm(!showCreateForm)}
+                >
+                    <i className={`bi ${showCreateForm ? 'bi-x-lg' : 'bi-plus-lg'} me-1`}></i>
+                    {showCreateForm ? 'Cancel' : 'Create Sharing Rule'}
+                </button>
+            </div>
+
+            <p className="text-muted mb-3">
+                Share AWS account visibility between users. When User A's accounts are shared with User B,
+                User B can see all assets belonging to User A's AWS accounts. Sharing is directional and non-transitive.
+            </p>
+
+            {/* Alerts */}
+            {successMessage && (
+                <div className="alert alert-success alert-dismissible fade show" role="alert">
+                    {successMessage}
+                    <button type="button" className="btn-close" onClick={() => setSuccessMessage(null)}></button>
+                </div>
+            )}
+            {error && (
+                <div className="alert alert-danger alert-dismissible fade show" role="alert">
+                    {error}
+                    <button type="button" className="btn-close" onClick={() => setError(null)}></button>
+                </div>
+            )}
+
+            {/* Create Form */}
+            {showCreateForm && (
+                <div className="card mb-4">
+                    <div className="card-body">
+                        <h5 className="card-title">Create Sharing Rule</h5>
+                        <form onSubmit={handleCreate}>
+                            <div className="row g-3">
+                                <div className="col-md-5">
+                                    <label htmlFor="sourceUser" className="form-label">
+                                        Source User (shares their AWS accounts)
+                                    </label>
+                                    <select
+                                        id="sourceUser"
+                                        className="form-select"
+                                        value={sourceUserId}
+                                        onChange={(e) => setSourceUserId(e.target.value ? Number(e.target.value) : '')}
+                                        required
+                                    >
+                                        <option value="">-- Select source user --</option>
+                                        {users.map((user) => (
+                                            <option key={user.id} value={user.id}>
+                                                {user.username} ({user.email})
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="col-md-1 d-flex align-items-end justify-content-center pb-2">
+                                    <i className="bi bi-arrow-right fs-4"></i>
+                                </div>
+                                <div className="col-md-5">
+                                    <label htmlFor="targetUser" className="form-label">
+                                        Target User (receives visibility)
+                                    </label>
+                                    <select
+                                        id="targetUser"
+                                        className="form-select"
+                                        value={targetUserId}
+                                        onChange={(e) => setTargetUserId(e.target.value ? Number(e.target.value) : '')}
+                                        required
+                                    >
+                                        <option value="">-- Select target user --</option>
+                                        {users.map((user) => (
+                                            <option key={user.id} value={user.id}>
+                                                {user.username} ({user.email})
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="col-md-1 d-flex align-items-end">
+                                    <button
+                                        type="submit"
+                                        className="btn btn-success"
+                                        disabled={isCreating}
+                                    >
+                                        {isCreating ? (
+                                            <span className="spinner-border spinner-border-sm me-1"></span>
+                                        ) : (
+                                            <i className="bi bi-check-lg me-1"></i>
+                                        )}
+                                        Create
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {/* Table */}
+            {isLoading ? (
+                <div className="text-center py-4">
+                    <div className="spinner-border" role="status">
+                        <span className="visually-hidden">Loading...</span>
+                    </div>
+                </div>
+            ) : sharingRules.length === 0 ? (
+                <div className="alert alert-info">
+                    No AWS account sharing rules configured. Click "Create Sharing Rule" to add one.
+                </div>
+            ) : (
+                <>
+                    <div className="table-responsive">
+                        <table className="table table-striped table-hover">
+                            <thead className="table-dark">
+                                <tr>
+                                    <th>Source User</th>
+                                    <th>Target User</th>
+                                    <th>Shared Accounts</th>
+                                    <th>Created By</th>
+                                    <th>Created At</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {sharingRules.map((rule) => (
+                                    <tr key={rule.id}>
+                                        <td>
+                                            <strong>{rule.sourceUserUsername}</strong>
+                                            <br />
+                                            <small className="text-muted">{rule.sourceUserEmail}</small>
+                                        </td>
+                                        <td>
+                                            <strong>{rule.targetUserUsername}</strong>
+                                            <br />
+                                            <small className="text-muted">{rule.targetUserEmail}</small>
+                                        </td>
+                                        <td>
+                                            <span className="badge bg-info">{rule.sharedAwsAccountCount}</span>
+                                        </td>
+                                        <td>{rule.createdByUsername}</td>
+                                        <td>{formatDate(rule.createdAt)}</td>
+                                        <td>
+                                            {deletingId === rule.id ? (
+                                                <div className="btn-group btn-group-sm">
+                                                    <button
+                                                        className="btn btn-danger"
+                                                        onClick={() => handleDelete(rule.id)}
+                                                    >
+                                                        Confirm
+                                                    </button>
+                                                    <button
+                                                        className="btn btn-secondary"
+                                                        onClick={() => setDeletingId(null)}
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            ) : (
+                                                <button
+                                                    className="btn btn-outline-danger btn-sm"
+                                                    onClick={() => setDeletingId(rule.id)}
+                                                    title="Delete sharing rule"
+                                                >
+                                                    <i className="bi bi-trash"></i>
+                                                </button>
+                                            )}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Pagination */}
+                    {totalPages > 1 && (
+                        <nav aria-label="Sharing rules pagination">
+                            <div className="d-flex justify-content-between align-items-center">
+                                <span className="text-muted">
+                                    Showing {page * pageSize + 1}-{Math.min((page + 1) * pageSize, totalElements)} of {totalElements} rules
+                                </span>
+                                <ul className="pagination mb-0">
+                                    <li className={`page-item ${page === 0 ? 'disabled' : ''}`}>
+                                        <button className="page-link" onClick={() => setPage(p => Math.max(0, p - 1))}>
+                                            Previous
+                                        </button>
+                                    </li>
+                                    {Array.from({ length: totalPages }, (_, i) => (
+                                        <li key={i} className={`page-item ${page === i ? 'active' : ''}`}>
+                                            <button className="page-link" onClick={() => setPage(i)}>
+                                                {i + 1}
+                                            </button>
+                                        </li>
+                                    ))}
+                                    <li className={`page-item ${page >= totalPages - 1 ? 'disabled' : ''}`}>
+                                        <button className="page-link" onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}>
+                                            Next
+                                        </button>
+                                    </li>
+                                </ul>
+                            </div>
+                        </nav>
+                    )}
+                </>
+            )}
+        </div>
+    );
+};
+
+export default AwsAccountSharingManager;

--- a/src/frontend/src/pages/admin/aws-account-sharing.astro
+++ b/src/frontend/src/pages/admin/aws-account-sharing.astro
@@ -1,0 +1,22 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import AwsAccountSharingManager from '../../components/AwsAccountSharingManager';
+---
+
+<Layout title="AWS Account Sharing - Admin">
+    <div class="container-fluid">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="/">Home</a></li>
+                <li class="breadcrumb-item"><a href="/admin">Admin</a></li>
+                <li class="breadcrumb-item active" aria-current="page">AWS Account Sharing</li>
+            </ol>
+        </nav>
+
+        <AwsAccountSharingManager client:load />
+
+        <div class="mt-4">
+          <a href="/admin" class="btn btn-secondary">Back to Admin</a>
+        </div>
+    </div>
+</Layout>

--- a/src/frontend/src/services/awsAccountSharingService.ts
+++ b/src/frontend/src/services/awsAccountSharingService.ts
@@ -1,0 +1,92 @@
+import { authenticatedGet, authenticatedPost, authenticatedDelete } from '../utils/auth';
+
+/**
+ * Service for AWS Account Sharing API operations.
+ *
+ * Feature: AWS Account Sharing
+ */
+
+export interface AwsAccountSharing {
+    id: number;
+    sourceUserId: number;
+    sourceUserEmail: string;
+    sourceUserUsername: string;
+    targetUserId: number;
+    targetUserEmail: string;
+    targetUserUsername: string;
+    createdById: number;
+    createdByUsername: string;
+    sharedAwsAccountCount: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CreateAwsAccountSharingRequest {
+    sourceUserId: number;
+    targetUserId: number;
+}
+
+export interface AwsAccountSharingListResponse {
+    content: AwsAccountSharing[];
+    totalElements: number;
+    totalPages: number;
+    page: number;
+    size: number;
+}
+
+/**
+ * List AWS account sharing rules with pagination.
+ */
+export async function listSharingRules(
+    page: number = 0,
+    size: number = 20
+): Promise<AwsAccountSharingListResponse> {
+    const params = new URLSearchParams({
+        page: page.toString(),
+        size: size.toString()
+    });
+
+    const response = await authenticatedGet(`/api/aws-account-sharing?${params.toString()}`);
+
+    if (!response.ok) {
+        if (response.status === 401) throw new Error('Authentication required');
+        if (response.status === 403) throw new Error('Insufficient permissions (ADMIN role required)');
+        throw new Error(`Failed to list sharing rules: ${response.status}`);
+    }
+
+    return await response.json();
+}
+
+/**
+ * Create a new AWS account sharing rule.
+ */
+export async function createSharingRule(
+    request: CreateAwsAccountSharingRequest
+): Promise<AwsAccountSharing> {
+    const response = await authenticatedPost('/api/aws-account-sharing', request);
+
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: 'Failed to create sharing rule' }));
+        if (response.status === 400) throw new Error(errorData.message || 'Invalid request');
+        if (response.status === 401) throw new Error('Authentication required');
+        if (response.status === 403) throw new Error('Insufficient permissions (ADMIN role required)');
+        if (response.status === 404) throw new Error(errorData.message || 'User not found');
+        throw new Error(errorData.message || `Failed to create sharing rule: ${response.status}`);
+    }
+
+    return await response.json();
+}
+
+/**
+ * Delete an AWS account sharing rule.
+ */
+export async function deleteSharingRule(id: number): Promise<void> {
+    const response = await authenticatedDelete(`/api/aws-account-sharing/${id}`);
+
+    if (!response.ok) {
+        if (response.status === 401) throw new Error('Authentication required');
+        if (response.status === 403) throw new Error('Insufficient permissions (ADMIN role required)');
+        if (response.status === 404) throw new Error('Sharing rule not found');
+        throw new Error(`Failed to delete sharing rule: ${response.status}`);
+    }
+}


### PR DESCRIPTION
## Summary
Implements a new AWS Account Sharing feature that allows administrators to create directional, non-transitive sharing rules between users. When User A's AWS accounts are shared with User B, User B gains visibility of all assets belonging to User A's AWS accounts.

## Key Changes

### Backend Implementation
- **Domain Model**: Added `AwsAccountSharing` entity with directional relationships (sourceUser → targetUser), unique constraint on source/target pairs, and audit tracking via `createdBy`
- **Service Layer**: Implemented `AwsAccountSharingService` with:
  - Validation logic (prevents self-sharing, duplicate rules, sharing from users without AWS account mappings)
  - Pagination support for listing rules
  - Integration with `UserMappingRepository` to resolve shared AWS account IDs
- **Repository**: Added `AwsAccountSharingRepository` with specialized queries:
  - `findAllWithUsers()` for eager-loaded admin listing
  - `findSharedAwsAccountIdsByTargetUserId()` native query for access control integration
- **REST API**: Created `AwsAccountSharingController` with ADMIN-only endpoints for CRUD operations
- **MCP Tools**: Added three MCP tools for AI integration:
  - `ListAwsAccountSharingTool` - list sharing rules with pagination
  - `CreateAwsAccountSharingTool` - create new sharing rules
  - `DeleteAwsAccountSharingTool` - delete sharing rules
- **Access Control Integration**: Modified `AssetFilterService` and `McpAccessControlService` to incorporate shared AWS account visibility when filtering assets

### Frontend Implementation
- **Component**: Created `AwsAccountSharingManager` React component with:
  - Paginated table display of sharing rules
  - Create form with source/target user selection
  - Delete confirmation dialog
  - Success/error notifications
  - User dropdown population from `/api/users`
- **Service**: Added `awsAccountSharingService.ts` with typed API client functions
- **Page**: Created admin page at `/admin/aws-account-sharing`
- **Navigation**: Updated AdminPage component with link to AWS Account Sharing management

### Documentation & Configuration
- Updated `MCP.md` to document the three new MCP tools under `USER_ACTIVITY` capability
- Updated `CLAUDE.md` with AWS Account Sharing entity documentation
- Updated `McpToolRegistry` to register the three new tools

## Implementation Details

**Directional & Non-Transitive Design**: The sharing relationship is explicitly directional (A→B ≠ B→A) and non-transitive (A→B and B→C does not grant C access to A's accounts). This is enforced at the query level in `findSharedAwsAccountIdsByTargetUserId()` which only joins direct user mappings, not recursive visibility.

**Access Control Integration**: The `AssetFilterService` now queries `AwsAccountSharingService.getSharedAwsAccountIds()` to include shared accounts in asset visibility calculations, ensuring users see assets from both their own and shared AWS accounts.

**Audit Trail**: All sharing rule operations are logged with source/target user emails and the admin who created/deleted the rule for compliance tracking.

**Validation**: Comprehensive validation prevents invalid states (self-sharing, duplicates, sharing from users without AWS accounts) with clear error messages.

https://claude.ai/code/session_01A4T7x6pk9UWfkoDWALVxGb