### PR TITLE
feat(heatmap): add vulnerability heatmap UI with pre-calculated data

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityHeatmapController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityHeatmapController.kt
@@ -1,0 +1,97 @@
+package com.secman.controller
+
+import com.secman.domain.AssetHeatmapEntry
+import com.secman.dto.AssetHeatmapEntryDto
+import com.secman.dto.AssetHeatmapResponseDto
+import com.secman.dto.AssetHeatmapSummaryDto
+import com.secman.repository.AssetHeatmapRepository
+import com.secman.service.AssetHeatmapService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.rules.SecurityRule
+import org.slf4j.LoggerFactory
+
+/**
+ * REST API controller for the vulnerability heatmap.
+ *
+ * Returns pre-calculated heatmap data filtered by the user's access control.
+ * ADMIN/SECCHAMPION see all assets; other users see only accessible assets.
+ */
+@Controller("/api/vulnerability-heatmap")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+class VulnerabilityHeatmapController(
+    private val assetHeatmapRepository: AssetHeatmapRepository,
+    private val assetHeatmapService: AssetHeatmapService
+) {
+    private val logger = LoggerFactory.getLogger(VulnerabilityHeatmapController::class.java)
+
+    @Get
+    @Produces(MediaType.APPLICATION_JSON)
+    fun getHeatmap(authentication: Authentication): HttpResponse<AssetHeatmapResponseDto> {
+        return try {
+            val entries = if (hasRole(authentication, "ADMIN") || hasRole(authentication, "SECCHAMPION")) {
+                assetHeatmapRepository.findAll()
+            } else {
+                val userId = getUserId(authentication)
+                val userEmail = getUserEmail(authentication) ?: return HttpResponse.ok(emptyResponse())
+                val username = authentication.name
+                assetHeatmapRepository.findAccessibleEntries(userId, userEmail, username)
+            }
+
+            val dtos = entries.map { it.toDto() }
+            val summary = AssetHeatmapSummaryDto(
+                totalAssets = dtos.size,
+                redCount = dtos.count { it.heatLevel == AssetHeatmapEntry.HEAT_RED },
+                yellowCount = dtos.count { it.heatLevel == AssetHeatmapEntry.HEAT_YELLOW },
+                greenCount = dtos.count { it.heatLevel == AssetHeatmapEntry.HEAT_GREEN }
+            )
+
+            val response = AssetHeatmapResponseDto(
+                entries = dtos,
+                summary = summary,
+                lastCalculatedAt = assetHeatmapService.getLastCalculatedAt()?.toString()
+            )
+
+            HttpResponse.ok(response)
+        } catch (e: Exception) {
+            logger.error("Error fetching vulnerability heatmap", e)
+            HttpResponse.serverError()
+        }
+    }
+
+    private fun AssetHeatmapEntry.toDto() = AssetHeatmapEntryDto(
+        assetId = assetId,
+        assetName = assetName,
+        assetType = assetType,
+        criticalCount = criticalCount,
+        highCount = highCount,
+        mediumCount = mediumCount,
+        lowCount = lowCount,
+        totalCount = totalCount,
+        heatLevel = heatLevel
+    )
+
+    private fun emptyResponse() = AssetHeatmapResponseDto(
+        entries = emptyList(),
+        summary = AssetHeatmapSummaryDto(0, 0, 0, 0),
+        lastCalculatedAt = null
+    )
+
+    private fun getUserId(authentication: Authentication): Long {
+        return authentication.attributes["userId"]?.toString()?.toLongOrNull()
+            ?: throw IllegalStateException("User ID not found in authentication")
+    }
+
+    private fun getUserEmail(authentication: Authentication): String? {
+        return authentication.attributes["email"]?.toString()
+    }
+
+    private fun hasRole(authentication: Authentication, role: String): Boolean {
+        return authentication.roles.contains(role)
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/AssetHeatmapEntry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/AssetHeatmapEntry.kt
@@ -1,0 +1,92 @@
+package com.secman.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+/**
+ * Pre-calculated heatmap data for each asset.
+ *
+ * Stores severity counts per asset so the heatmap UI can render instantly
+ * without running expensive aggregate queries at request time.
+ * Refreshed during CrowdStrike import (materialized view refresh lifecycle).
+ *
+ * Heat level rules:
+ * - RED: asset has any CRITICAL vulnerability, or more than 100 HIGH vulnerabilities
+ * - YELLOW: asset has HIGH vulnerabilities (1-100)
+ * - GREEN: no CRITICAL or HIGH vulnerabilities
+ */
+@Entity
+@Table(
+    name = "asset_heatmap_entry",
+    indexes = [
+        Index(name = "idx_heatmap_asset_id", columnList = "asset_id", unique = true),
+        Index(name = "idx_heatmap_heat_level", columnList = "heat_level"),
+        Index(name = "idx_heatmap_asset_name", columnList = "asset_name")
+    ]
+)
+data class AssetHeatmapEntry(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "asset_id", nullable = false, unique = true)
+    var assetId: Long,
+
+    @Column(name = "asset_name", nullable = false, length = 255)
+    var assetName: String,
+
+    @Column(name = "asset_type", nullable = false, length = 50)
+    var assetType: String,
+
+    @Column(name = "critical_count", nullable = false)
+    var criticalCount: Int = 0,
+
+    @Column(name = "high_count", nullable = false)
+    var highCount: Int = 0,
+
+    @Column(name = "medium_count", nullable = false)
+    var mediumCount: Int = 0,
+
+    @Column(name = "low_count", nullable = false)
+    var lowCount: Int = 0,
+
+    @Column(name = "total_count", nullable = false)
+    var totalCount: Int = 0,
+
+    @Column(name = "heat_level", nullable = false, length = 10)
+    var heatLevel: String = "GREEN",
+
+    @Column(name = "cloud_account_id", length = 255)
+    var cloudAccountId: String? = null,
+
+    @Column(name = "ad_domain", length = 255)
+    var adDomain: String? = null,
+
+    @Column(name = "owner", length = 255)
+    var owner: String? = null,
+
+    @Column(name = "workgroup_ids", length = 500)
+    var workgroupIds: String? = null,
+
+    @Column(name = "manual_creator_id")
+    var manualCreatorId: Long? = null,
+
+    @Column(name = "scan_uploader_id")
+    var scanUploaderId: Long? = null,
+
+    @Column(name = "last_calculated_at", nullable = false)
+    var lastCalculatedAt: LocalDateTime = LocalDateTime.now()
+) {
+    companion object {
+        const val HEAT_RED = "RED"
+        const val HEAT_YELLOW = "YELLOW"
+        const val HEAT_GREEN = "GREEN"
+
+        fun calculateHeatLevel(criticalCount: Int, highCount: Int): String = when {
+            criticalCount > 0 -> HEAT_RED
+            highCount > 100 -> HEAT_RED
+            highCount > 0 -> HEAT_YELLOW
+            else -> HEAT_GREEN
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/dto/AssetHeatmapDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/AssetHeatmapDto.kt
@@ -1,0 +1,31 @@
+package com.secman.dto
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+data class AssetHeatmapEntryDto(
+    val assetId: Long,
+    val assetName: String,
+    val assetType: String,
+    val criticalCount: Int,
+    val highCount: Int,
+    val mediumCount: Int,
+    val lowCount: Int,
+    val totalCount: Int,
+    val heatLevel: String
+)
+
+@Serdeable
+data class AssetHeatmapResponseDto(
+    val entries: List<AssetHeatmapEntryDto>,
+    val summary: AssetHeatmapSummaryDto,
+    val lastCalculatedAt: String?
+)
+
+@Serdeable
+data class AssetHeatmapSummaryDto(
+    val totalAssets: Int,
+    val redCount: Int,
+    val yellowCount: Int,
+    val greenCount: Int
+)

--- a/src/backendng/src/main/kotlin/com/secman/repository/AssetHeatmapRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AssetHeatmapRepository.kt
@@ -1,0 +1,59 @@
+package com.secman.repository
+
+import com.secman.domain.AssetHeatmapEntry
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import java.util.Optional
+
+/**
+ * Repository for AssetHeatmapEntry pre-calculated heatmap data.
+ *
+ * Provides queries for heatmap retrieval with access control filtering.
+ */
+@Repository
+interface AssetHeatmapRepository : JpaRepository<AssetHeatmapEntry, Long> {
+
+    /**
+     * Find heatmap entries for assets accessible to a non-admin user.
+     * Mirrors the unified access control query from AssetRepository.
+     */
+    @Query(
+        value = """
+            SELECT h.* FROM asset_heatmap_entry h
+            WHERE
+                h.asset_id IN (
+                    SELECT aw.asset_id FROM asset_workgroups aw
+                    JOIN user_workgroups uw ON aw.workgroup_id = uw.workgroup_id
+                    WHERE uw.user_id = :userId
+                )
+                OR h.manual_creator_id = :userId
+                OR h.scan_uploader_id = :userId
+                OR h.cloud_account_id IN (
+                    SELECT um.aws_account_id FROM user_mapping um
+                    WHERE um.email = :userEmail AND um.aws_account_id IS NOT NULL
+                )
+                OR LOWER(h.ad_domain) IN (
+                    SELECT LOWER(um.domain) FROM user_mapping um
+                    WHERE um.email = :userEmail AND um.domain IS NOT NULL
+                )
+                OR h.cloud_account_id IN (
+                    SELECT DISTINCT um2.aws_account_id
+                    FROM aws_account_sharing acs
+                    JOIN users u_source ON u_source.id = acs.source_user_id
+                    JOIN user_mapping um2 ON um2.email = u_source.email AND um2.aws_account_id IS NOT NULL
+                    WHERE acs.target_user_id = :userId
+                )
+                OR h.owner = :username
+            ORDER BY h.asset_name ASC
+        """,
+        nativeQuery = true
+    )
+    fun findAccessibleEntries(userId: Long, userEmail: String, username: String): List<AssetHeatmapEntry>
+
+    @Query("SELECT MAX(h.lastCalculatedAt) FROM AssetHeatmapEntry h")
+    fun findLatestCalculatedAt(): LocalDateTime?
+
+    override fun deleteAll()
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/AssetHeatmapService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AssetHeatmapService.kt
@@ -1,0 +1,135 @@
+package com.secman.service
+
+import com.secman.domain.AssetHeatmapEntry
+import com.secman.repository.AssetHeatmapRepository
+import jakarta.inject.Singleton
+import jakarta.persistence.EntityManager
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+/**
+ * Service for computing and querying pre-calculated asset heatmap data.
+ *
+ * The heatmap is refreshed during the materialized view refresh lifecycle,
+ * triggered after each CrowdStrike import. The data captures per-asset
+ * vulnerability severity counts so the UI can render a heatmap instantly.
+ */
+@Singleton
+open class AssetHeatmapService(
+    private val assetHeatmapRepository: AssetHeatmapRepository,
+    private val entityManager: EntityManager
+) {
+    private val log = LoggerFactory.getLogger(AssetHeatmapService::class.java)
+
+    companion object {
+        private const val BATCH_SIZE = 1000
+    }
+
+    /**
+     * Recalculate the entire heatmap table.
+     * Called during materialized view refresh after CrowdStrike import.
+     *
+     * Uses a single aggregate SQL query to compute severity counts per asset,
+     * then writes the results in batches.
+     */
+    open fun recalculateHeatmap() {
+        val startTime = System.currentTimeMillis()
+        log.info("Starting heatmap recalculation")
+
+        // Step 1: Clear old data
+        clearHeatmap()
+
+        // Step 2: Aggregate vulnerability counts per asset using native SQL
+        @Suppress("UNCHECKED_CAST")
+        val rows = entityManager.createNativeQuery("""
+            SELECT
+                a.id AS asset_id,
+                a.name AS asset_name,
+                a.type AS asset_type,
+                COALESCE(SUM(CASE WHEN v.cvss_severity = 'CRITICAL' THEN 1 ELSE 0 END), 0) AS critical_count,
+                COALESCE(SUM(CASE WHEN v.cvss_severity = 'HIGH' THEN 1 ELSE 0 END), 0) AS high_count,
+                COALESCE(SUM(CASE WHEN v.cvss_severity = 'MEDIUM' THEN 1 ELSE 0 END), 0) AS medium_count,
+                COALESCE(SUM(CASE WHEN v.cvss_severity = 'LOW' THEN 1 ELSE 0 END), 0) AS low_count,
+                COUNT(v.id) AS total_count,
+                a.cloud_account_id,
+                a.ad_domain,
+                a.owner,
+                a.manual_creator_id,
+                a.scan_uploader_id
+            FROM asset a
+            LEFT JOIN vulnerability v ON v.asset_id = a.id
+            GROUP BY a.id, a.name, a.type, a.cloud_account_id, a.ad_domain, a.owner, a.manual_creator_id, a.scan_uploader_id
+        """).resultList as List<Array<Any?>>
+
+        log.info("Aggregated vulnerability counts for {} assets", rows.size)
+
+        // Step 3: Build heatmap entries and also denormalize workgroup IDs
+        val workgroupMap = loadWorkgroupMap()
+        val now = LocalDateTime.now()
+
+        val entries = rows.map { row ->
+            val assetId = (row[0] as Number).toLong()
+            val criticalCount = (row[3] as Number).toInt()
+            val highCount = (row[4] as Number).toInt()
+
+            AssetHeatmapEntry(
+                assetId = assetId,
+                assetName = row[1] as String,
+                assetType = row[2] as String,
+                criticalCount = criticalCount,
+                highCount = highCount,
+                mediumCount = (row[5] as Number).toInt(),
+                lowCount = (row[6] as Number).toInt(),
+                totalCount = (row[7] as Number).toInt(),
+                heatLevel = AssetHeatmapEntry.calculateHeatLevel(criticalCount, highCount),
+                cloudAccountId = row[8] as? String,
+                adDomain = row[9] as? String,
+                owner = row[10] as? String,
+                manualCreatorId = (row[11] as? Number)?.toLong(),
+                scanUploaderId = (row[12] as? Number)?.toLong(),
+                workgroupIds = workgroupMap[assetId],
+                lastCalculatedAt = now
+            )
+        }
+
+        // Step 4: Save in batches
+        entries.chunked(BATCH_SIZE).forEachIndexed { batchIndex, batch ->
+            saveHeatmapBatch(batch)
+            log.debug("Saved heatmap batch {}: {} entries", batchIndex + 1, batch.size)
+        }
+
+        val durationMs = System.currentTimeMillis() - startTime
+        log.info("Heatmap recalculation completed: {} entries in {}ms", entries.size, durationMs)
+    }
+
+    @Transactional
+    open fun clearHeatmap() {
+        assetHeatmapRepository.deleteAll()
+    }
+
+    @Transactional
+    open fun saveHeatmapBatch(entries: List<AssetHeatmapEntry>) {
+        assetHeatmapRepository.saveAll(entries)
+    }
+
+    /**
+     * Load workgroup IDs per asset as a denormalized comma-separated string.
+     */
+    private fun loadWorkgroupMap(): Map<Long, String?> {
+        @Suppress("UNCHECKED_CAST")
+        val rows = entityManager.createNativeQuery("""
+            SELECT asset_id, GROUP_CONCAT(workgroup_id ORDER BY workgroup_id) AS wg_ids
+            FROM asset_workgroups
+            GROUP BY asset_id
+        """).resultList as List<Array<Any?>>
+
+        return rows.associate { row ->
+            (row[0] as Number).toLong() to (row[1] as? String)
+        }
+    }
+
+    fun getLastCalculatedAt(): LocalDateTime? {
+        return assetHeatmapRepository.findLatestCalculatedAt()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/MaterializedViewRefreshService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/MaterializedViewRefreshService.kt
@@ -40,7 +40,8 @@ open class MaterializedViewRefreshService(
     private val vulnerabilityConfigService: VulnerabilityConfigService,
     private val eventPublisher: ApplicationEventPublisher<RefreshProgressEvent>,
     private val vulnerabilityExceptionService: VulnerabilityExceptionService,  // For checking active exceptions
-    private val vulnerabilityStatisticsCacheService: VulnerabilityStatisticsCacheService
+    private val vulnerabilityStatisticsCacheService: VulnerabilityStatisticsCacheService,
+    private val assetHeatmapService: AssetHeatmapService
 ) {
     private val log = LoggerFactory.getLogger(MaterializedViewRefreshService::class.java)
 
@@ -205,6 +206,14 @@ open class MaterializedViewRefreshService(
             vulnerabilityStatisticsCacheService.refreshCache()
         } catch (e: Exception) {
             log.error("Statistics cache refresh failed (non-fatal): {}", e.message, e)
+        }
+
+        // Step 7: Refresh asset heatmap (piggyback on refresh lifecycle)
+        try {
+            log.info("Refreshing asset heatmap after materialized view refresh")
+            assetHeatmapService.recalculateHeatmap()
+        } catch (e: Exception) {
+            log.error("Asset heatmap refresh failed (non-fatal): {}", e.message, e)
         }
 
         // Publish completion event

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -299,6 +299,11 @@ const Sidebar = () => {
                                     </a>
                                 </li>
                                 <li>
+                                    <a href="/vulnerability-heatmap" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
+                                        <i className="bi bi-grid-3x3-gap-fill me-2"></i> Heatmap
+                                    </a>
+                                </li>
+                                <li>
                                     <a href="/products" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
                                         <i className="bi bi-box-seam me-2"></i> Products
                                     </a>

--- a/src/frontend/src/components/VulnerabilityHeatmap.tsx
+++ b/src/frontend/src/components/VulnerabilityHeatmap.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useState } from 'react';
+import type { AssetHeatmapResponseDto, AssetHeatmapEntryDto } from '../services/api/vulnerabilityHeatmapApi';
+import { getVulnerabilityHeatmap } from '../services/api/vulnerabilityHeatmapApi';
+
+type SortField = 'name' | 'heatLevel' | 'totalCount';
+type SortDir = 'asc' | 'desc';
+
+const HEAT_COLORS: Record<string, string> = {
+  RED: '#dc3545',
+  YELLOW: '#ffc107',
+  GREEN: '#198754',
+};
+
+const HEAT_BG_LIGHT: Record<string, string> = {
+  RED: '#f8d7da',
+  YELLOW: '#fff3cd',
+  GREEN: '#d1e7dd',
+};
+
+const HEAT_ORDER: Record<string, number> = { RED: 0, YELLOW: 1, GREEN: 2 };
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return 'Never';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function VulnerabilityHeatmap() {
+  const [data, setData] = useState<AssetHeatmapResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [filterLevel, setFilterLevel] = useState<string>('ALL');
+  const [sortField, setSortField] = useState<SortField>('heatLevel');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [hoveredEntry, setHoveredEntry] = useState<AssetHeatmapEntryDto | null>(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const result = await getVulnerabilityHeatmap();
+        setData(result);
+      } catch (err: any) {
+        setError(err?.response?.data?.message || err?.message || 'Failed to load heatmap data');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="d-flex justify-content-center align-items-center py-5">
+        <div className="spinner-border text-primary" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+        <span className="ms-3">Loading heatmap data...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="alert alert-danger" role="alert">
+        <i className="bi bi-exclamation-triangle me-2"></i>
+        {error}
+      </div>
+    );
+  }
+
+  if (!data || data.entries.length === 0) {
+    return (
+      <div className="alert alert-info" role="alert">
+        <i className="bi bi-info-circle me-2"></i>
+        No heatmap data available. Data is generated after a CrowdStrike import.
+      </div>
+    );
+  }
+
+  // Filter entries
+  let filtered = data.entries;
+  if (search) {
+    const q = search.toLowerCase();
+    filtered = filtered.filter(e => e.assetName.toLowerCase().includes(q));
+  }
+  if (filterLevel !== 'ALL') {
+    filtered = filtered.filter(e => e.heatLevel === filterLevel);
+  }
+
+  // Sort entries
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0;
+    switch (sortField) {
+      case 'name':
+        cmp = a.assetName.localeCompare(b.assetName);
+        break;
+      case 'heatLevel':
+        cmp = (HEAT_ORDER[a.heatLevel] ?? 3) - (HEAT_ORDER[b.heatLevel] ?? 3);
+        if (cmp === 0) cmp = b.totalCount - a.totalCount;
+        break;
+      case 'totalCount':
+        cmp = b.totalCount - a.totalCount;
+        break;
+    }
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
+
+  const handleMouseEnter = (entry: AssetHeatmapEntryDto, e: React.MouseEvent) => {
+    setHoveredEntry(entry);
+    setTooltipPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    setTooltipPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredEntry(null);
+  };
+
+  const { summary } = data;
+
+  return (
+    <div>
+      <h4 className="mb-3">
+        <i className="bi bi-grid-3x3-gap-fill me-2"></i>
+        Vulnerability Heatmap
+      </h4>
+
+      {/* Summary cards */}
+      <div className="row mb-4">
+        <div className="col-6 col-md-3 mb-2">
+          <div className="card text-center border-0 shadow-sm">
+            <div className="card-body py-2">
+              <div className="fs-3 fw-bold">{summary.totalAssets}</div>
+              <div className="text-muted small">Total Systems</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-6 col-md-3 mb-2">
+          <div className="card text-center border-0 shadow-sm" style={{ borderLeft: '4px solid #dc3545' }}>
+            <div className="card-body py-2">
+              <div className="fs-3 fw-bold" style={{ color: '#dc3545' }}>{summary.redCount}</div>
+              <div className="text-muted small">Critical</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-6 col-md-3 mb-2">
+          <div className="card text-center border-0 shadow-sm" style={{ borderLeft: '4px solid #ffc107' }}>
+            <div className="card-body py-2">
+              <div className="fs-3 fw-bold" style={{ color: '#b58a00' }}>{summary.yellowCount}</div>
+              <div className="text-muted small">High</div>
+            </div>
+          </div>
+        </div>
+        <div className="col-6 col-md-3 mb-2">
+          <div className="card text-center border-0 shadow-sm" style={{ borderLeft: '4px solid #198754' }}>
+            <div className="card-body py-2">
+              <div className="fs-3 fw-bold" style={{ color: '#198754' }}>{summary.greenCount}</div>
+              <div className="text-muted small">Healthy</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="card mb-4">
+        <div className="card-body py-2">
+          <div className="row align-items-center g-2">
+            <div className="col-md-4">
+              <div className="input-group input-group-sm">
+                <span className="input-group-text"><i className="bi bi-search"></i></span>
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Search systems..."
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                />
+              </div>
+            </div>
+            <div className="col-md-3">
+              <select
+                className="form-select form-select-sm"
+                value={filterLevel}
+                onChange={e => setFilterLevel(e.target.value)}
+              >
+                <option value="ALL">All levels</option>
+                <option value="RED">Red (Critical)</option>
+                <option value="YELLOW">Yellow (High)</option>
+                <option value="GREEN">Green (Healthy)</option>
+              </select>
+            </div>
+            <div className="col-md-3">
+              <select
+                className="form-select form-select-sm"
+                value={`${sortField}-${sortDir}`}
+                onChange={e => {
+                  const [f, d] = e.target.value.split('-');
+                  setSortField(f as SortField);
+                  setSortDir(d as SortDir);
+                }}
+              >
+                <option value="heatLevel-asc">Sort: Severity (worst first)</option>
+                <option value="heatLevel-desc">Sort: Severity (best first)</option>
+                <option value="name-asc">Sort: Name (A-Z)</option>
+                <option value="name-desc">Sort: Name (Z-A)</option>
+                <option value="totalCount-asc">Sort: Vuln count (low-high)</option>
+                <option value="totalCount-desc">Sort: Vuln count (high-low)</option>
+              </select>
+            </div>
+            <div className="col-md-2 text-end text-muted small">
+              {sorted.length} of {data.entries.length} systems
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Heatmap grid */}
+      <div className="card">
+        <div className="card-header d-flex justify-content-between align-items-center">
+          <span>
+            <i className="bi bi-grid-3x3-gap-fill me-2"></i>
+            System Heatmap
+          </span>
+          <span className="text-muted small">
+            Last calculated: {formatDateTime(data.lastCalculatedAt)}
+          </span>
+        </div>
+        <div className="card-body">
+          {sorted.length === 0 ? (
+            <div className="text-center text-muted py-4">
+              No systems match your filters.
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+              {sorted.map(entry => (
+                <div
+                  key={entry.assetId}
+                  onMouseEnter={e => handleMouseEnter(entry, e)}
+                  onMouseMove={handleMouseMove}
+                  onMouseLeave={handleMouseLeave}
+                  style={{
+                    width: '28px',
+                    height: '28px',
+                    backgroundColor: HEAT_COLORS[entry.heatLevel] || '#6c757d',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    transition: 'transform 0.1s, box-shadow 0.1s',
+                    border: hoveredEntry?.assetId === entry.assetId ? '2px solid #000' : '1px solid rgba(0,0,0,0.15)',
+                    transform: hoveredEntry?.assetId === entry.assetId ? 'scale(1.3)' : 'scale(1)',
+                    boxShadow: hoveredEntry?.assetId === entry.assetId ? '0 2px 8px rgba(0,0,0,0.3)' : 'none',
+                    zIndex: hoveredEntry?.assetId === entry.assetId ? 10 : 1,
+                    position: 'relative',
+                  }}
+                  title={entry.assetName}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="card-footer text-muted small d-flex align-items-center gap-3">
+          <span className="d-flex align-items-center gap-1">
+            <span style={{ display: 'inline-block', width: 14, height: 14, backgroundColor: HEAT_COLORS.RED, borderRadius: 3 }}></span>
+            Critical / &gt;100 High
+          </span>
+          <span className="d-flex align-items-center gap-1">
+            <span style={{ display: 'inline-block', width: 14, height: 14, backgroundColor: HEAT_COLORS.YELLOW, borderRadius: 3 }}></span>
+            High (1-100)
+          </span>
+          <span className="d-flex align-items-center gap-1">
+            <span style={{ display: 'inline-block', width: 14, height: 14, backgroundColor: HEAT_COLORS.GREEN, borderRadius: 3 }}></span>
+            Healthy
+          </span>
+        </div>
+      </div>
+
+      {/* Tooltip */}
+      {hoveredEntry && (
+        <div
+          style={{
+            position: 'fixed',
+            left: tooltipPos.x + 15,
+            top: tooltipPos.y - 10,
+            backgroundColor: 'white',
+            border: '1px solid #dee2e6',
+            borderRadius: '8px',
+            padding: '12px 16px',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
+            zIndex: 9999,
+            pointerEvents: 'none',
+            minWidth: '220px',
+            maxWidth: '320px',
+          }}
+        >
+          <div className="fw-bold mb-1" style={{ fontSize: '0.9rem' }}>{hoveredEntry.assetName}</div>
+          <div className="mb-2">
+            <span
+              className="badge"
+              style={{
+                backgroundColor: HEAT_BG_LIGHT[hoveredEntry.heatLevel],
+                color: HEAT_COLORS[hoveredEntry.heatLevel],
+                border: `1px solid ${HEAT_COLORS[hoveredEntry.heatLevel]}`,
+              }}
+            >
+              {hoveredEntry.heatLevel}
+            </span>
+            <span className="text-muted ms-2 small">{hoveredEntry.assetType}</span>
+          </div>
+          <table style={{ fontSize: '0.8rem', width: '100%' }}>
+            <tbody>
+              <tr>
+                <td style={{ color: '#dc3545' }}>Critical</td>
+                <td className="text-end fw-bold">{hoveredEntry.criticalCount}</td>
+              </tr>
+              <tr>
+                <td style={{ color: '#fd7e14' }}>High</td>
+                <td className="text-end fw-bold">{hoveredEntry.highCount}</td>
+              </tr>
+              <tr>
+                <td style={{ color: '#ffc107' }}>Medium</td>
+                <td className="text-end fw-bold">{hoveredEntry.mediumCount}</td>
+              </tr>
+              <tr>
+                <td style={{ color: '#0dcaf0' }}>Low</td>
+                <td className="text-end fw-bold">{hoveredEntry.lowCount}</td>
+              </tr>
+              <tr style={{ borderTop: '1px solid #dee2e6' }}>
+                <td className="fw-bold pt-1">Total</td>
+                <td className="text-end fw-bold pt-1">{hoveredEntry.totalCount}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Detail table */}
+      {sorted.length > 0 && sorted.length <= 500 && (
+        <div className="card mt-4">
+          <div className="card-header">
+            <i className="bi bi-table me-2"></i>
+            System Details
+          </div>
+          <div className="card-body p-0">
+            <div className="table-responsive">
+              <table className="table table-sm table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th style={{ cursor: 'pointer' }} onClick={() => handleSort('name')}>
+                      System {sortField === 'name' && (sortDir === 'asc' ? '\u25B2' : '\u25BC')}
+                    </th>
+                    <th>Type</th>
+                    <th style={{ cursor: 'pointer' }} onClick={() => handleSort('heatLevel')}>
+                      Status {sortField === 'heatLevel' && (sortDir === 'asc' ? '\u25B2' : '\u25BC')}
+                    </th>
+                    <th className="text-end">Critical</th>
+                    <th className="text-end">High</th>
+                    <th className="text-end">Medium</th>
+                    <th className="text-end">Low</th>
+                    <th className="text-end" style={{ cursor: 'pointer' }} onClick={() => handleSort('totalCount')}>
+                      Total {sortField === 'totalCount' && (sortDir === 'asc' ? '\u25B2' : '\u25BC')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map(entry => (
+                    <tr key={entry.assetId}>
+                      <td>
+                        <span
+                          style={{
+                            display: 'inline-block',
+                            width: 10,
+                            height: 10,
+                            borderRadius: '50%',
+                            backgroundColor: HEAT_COLORS[entry.heatLevel],
+                            marginRight: 8,
+                          }}
+                        ></span>
+                        {entry.assetName}
+                      </td>
+                      <td className="text-muted">{entry.assetType}</td>
+                      <td>
+                        <span
+                          className="badge"
+                          style={{
+                            backgroundColor: HEAT_BG_LIGHT[entry.heatLevel],
+                            color: HEAT_COLORS[entry.heatLevel],
+                            border: `1px solid ${HEAT_COLORS[entry.heatLevel]}`,
+                          }}
+                        >
+                          {entry.heatLevel}
+                        </span>
+                      </td>
+                      <td className="text-end">{entry.criticalCount > 0 ? <span className="text-danger fw-bold">{entry.criticalCount}</span> : <span className="text-muted">0</span>}</td>
+                      <td className="text-end">{entry.highCount > 0 ? <span style={{ color: '#fd7e14' }} className="fw-bold">{entry.highCount}</span> : <span className="text-muted">0</span>}</td>
+                      <td className="text-end">{entry.mediumCount > 0 ? entry.mediumCount : <span className="text-muted">0</span>}</td>
+                      <td className="text-end">{entry.lowCount > 0 ? entry.lowCount : <span className="text-muted">0</span>}</td>
+                      <td className="text-end fw-bold">{entry.totalCount}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/vulnerability-heatmap.astro
+++ b/src/frontend/src/pages/vulnerability-heatmap.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '../layouts/Layout.astro';
+import VulnerabilityHeatmap from '../components/VulnerabilityHeatmap';
+---
+
+<Layout title="Vulnerability Heatmap">
+  <div class="container-fluid py-4">
+    <VulnerabilityHeatmap client:load />
+  </div>
+</Layout>

--- a/src/frontend/src/services/api/vulnerabilityHeatmapApi.ts
+++ b/src/frontend/src/services/api/vulnerabilityHeatmapApi.ts
@@ -1,0 +1,46 @@
+/**
+ * API client for vulnerability heatmap endpoints.
+ *
+ * Fetches pre-calculated heatmap data for the logged-in user's accessible assets.
+ */
+
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.PUBLIC_API_URL || '';
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export interface AssetHeatmapEntryDto {
+  assetId: number;
+  assetName: string;
+  assetType: string;
+  criticalCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  totalCount: number;
+  heatLevel: 'RED' | 'YELLOW' | 'GREEN';
+}
+
+export interface AssetHeatmapSummaryDto {
+  totalAssets: number;
+  redCount: number;
+  yellowCount: number;
+  greenCount: number;
+}
+
+export interface AssetHeatmapResponseDto {
+  entries: AssetHeatmapEntryDto[];
+  summary: AssetHeatmapSummaryDto;
+  lastCalculatedAt: string | null;
+}
+
+export async function getVulnerabilityHeatmap(): Promise<AssetHeatmapResponseDto> {
+  const response = await apiClient.get<AssetHeatmapResponseDto>('/api/vulnerability-heatmap');
+  return response.data;
+}


### PR DESCRIPTION
Add a new Vulnerability Heatmap page under Vulnerability Management that
visualizes per-system vulnerability severity as a color-coded grid.

Backend:
- AssetHeatmapEntry entity stores pre-calculated severity counts per asset
- AssetHeatmapService recalculates the heatmap during CrowdStrike import
  (piggybacks on MaterializedViewRefreshService lifecycle)
- VulnerabilityHeatmapController serves heatmap data with unified access control
- Heat levels: RED (critical or >100 high), YELLOW (1-100 high), GREEN (healthy)

Frontend:
- Interactive heatmap grid with hover tooltips showing severity breakdown
- Summary cards showing total/red/yellow/green counts
- Search, filter by level, and sort controls
- Detail table for smaller datasets
- Added to Sidebar under Vulnerability Management

https://claude.ai/code/session_01Fm1DgCRjFfLe7eBCqXhav2