### PR TITLE
security: fix critical issues found in full security review

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/Application.kt
+++ b/src/backendng/src/main/kotlin/com/secman/Application.kt
@@ -1,8 +1,22 @@
 package com.secman
 
 import io.micronaut.runtime.Micronaut
+import org.apache.poi.openxml4j.util.ZipSecureFile
+import org.apache.poi.util.IOUtils
 
 fun main(args: Array<String>) {
+    // Security hardening for Apache POI before any workbook is parsed.
+    // Defends against zip-bomb / decompression-bomb attacks via crafted XLSX uploads
+    // (Apache POI CVE-2014-3574 and similar). Without these limits a 5 MB file can
+    // expand to many gigabytes during XSSFWorkbook parsing and exhaust JVM memory.
+    //
+    // - setMinInflateRatio: rejects archives whose compression ratio is below the
+    //   threshold (compressed/uncompressed). 0.001 means we accept up to 1:1000.
+    // - setByteArrayMaxOverride: hard cap on the largest byte[] POI is allowed to
+    //   allocate while parsing a single record (100 MB).
+    ZipSecureFile.setMinInflateRatio(0.001)
+    IOUtils.setByteArrayMaxOverride(100 * 1024 * 1024)
+
     Micronaut.build()
         .args(*args)
         .packages("com.secman")

--- a/src/backendng/src/main/kotlin/com/secman/controller/ImportController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ImportController.kt
@@ -595,7 +595,14 @@ open class ImportController(
             // Validate file extension
             val filename = csvFile.filename.orEmpty()
             if (!filename.lowercase().endsWith(".csv")) {
-                val errorMsg = "Invalid file type: expected .csv file, received ${filename.substringAfterLast('.')}"
+                // Security: sanitize the extension before reflecting it back. The original
+                // filename is attacker-controlled and could contain HTML/script payloads,
+                // header-injection bytes, or noisy unicode. We strip everything that is not
+                // a plain alphanumeric so the response stays a stable, harmless ASCII token.
+                val rawExt = filename.substringAfterLast('.', "")
+                val safeExt = rawExt.take(16).replace(Regex("[^A-Za-z0-9]"), "")
+                val displayExt = if (safeExt.isNotEmpty()) ".$safeExt" else "(none)"
+                val errorMsg = "Invalid file type: expected .csv file, received $displayExt"
                 log.warn("CSV upload rejected: {}", errorMsg)
                 return HttpResponse.badRequest(ErrorResponse(errorMsg))
             }

--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
@@ -327,7 +327,7 @@ open class WorkgroupController(
      * Returns: 200 OK with list of child workgroups, 404 if parent not found
      */
     @Get("/{id}/children")
-    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Secured("ADMIN")
     @Transactional
     open fun getChildren(@PathVariable id: Long): HttpResponse<List<WorkgroupResponse>> {
         return try {
@@ -347,7 +347,7 @@ open class WorkgroupController(
      * Returns: 200 OK with list of root-level workgroups
      */
     @Get("/root")
-    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Secured("ADMIN")
     @Transactional
     open fun getRootWorkgroups(): HttpResponse<List<WorkgroupResponse>> {
         val roots = workgroupService.getRootWorkgroups()
@@ -363,7 +363,7 @@ open class WorkgroupController(
      * Returns: 200 OK with list of ancestors (root first), 404 if not found
      */
     @Get("/{id}/ancestors")
-    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Secured("ADMIN")
     @Transactional
     open fun getAncestors(@PathVariable id: Long): HttpResponse<List<BreadcrumbItem>> {
         return try {
@@ -383,7 +383,7 @@ open class WorkgroupController(
      * Returns: 200 OK with list of all descendants
      */
     @Get("/{id}/descendants")
-    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Secured("ADMIN")
     @Transactional
     open fun getDescendants(@PathVariable id: Long): HttpResponse<List<WorkgroupResponse>> {
         val descendants = workgroupService.getDescendants(id)

--- a/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
@@ -182,6 +182,7 @@ open class OAuthService(
         EMAIL_REQUIRED("Your account does not have an email address configured."),
         TENANT_MISMATCH("Your account is not from the expected organization."),
         PROVIDER_NOT_FOUND("Identity provider not found. Please contact support."),
+        MFA_REQUIRED("Your account requires multi-factor authentication. Please log in with username and password to complete MFA."),
         UNEXPECTED_ERROR("An unexpected error occurred during login. Please try again.")
     }
 
@@ -531,6 +532,17 @@ open class OAuthService(
                 val user = userResult.user
                 logger.info("[{}] User resolved: id={}, username={}, isNew={}, roles={}",
                     correlationId, user.id, user.username, userResult.isNewUser, user.roles)
+
+                // SECURITY: enforce MFA — OAuth must not bypass an account's MFA setting.
+                // Local login (AuthController.login) refuses to issue a JWT when user.mfaEnabled
+                // is true; the OAuth flow must do the same, otherwise an attacker who controls
+                // the OAuth identity can sidestep the second factor entirely.
+                if (user.mfaEnabled) {
+                    logger.warn("[{}] OAuth login blocked: user '{}' has MFA enabled and must use local login to complete second factor",
+                        correlationId, user.username)
+                    deleteOAuthStateQuietly(state)
+                    return CallbackResult.Error(OAuthErrorCode.MFA_REQUIRED.userMessage)
+                }
 
                 // Send notification if user was newly created via OAuth (Feature 027)
                 if (userResult.isNewUser) {

--- a/src/backendng/src/main/kotlin/com/secman/util/EncryptedStringConverter.kt
+++ b/src/backendng/src/main/kotlin/com/secman/util/EncryptedStringConverter.kt
@@ -87,18 +87,46 @@ class EncryptedStringConverter : AttributeConverter<String?, String?> {
     /**
      * Convert the database column value to an entity attribute.
      * Decrypts the encrypted string for use in the application.
-     * Falls back to returning raw data if decryption fails (e.g., legacy plaintext values
-     * stored before encryption was enabled). The value will be re-encrypted on next save.
+     *
+     * Legacy fallback: Spring's Encryptors.text() emits lowercase hex strings whose
+     * length is a multiple of 2 (and >= 32 chars to cover salt + IV + at least one
+     * AES block). If the stored value clearly does NOT match that shape we treat it
+     * as legacy plaintext (pre-encryption schema) and return it as-is so it can be
+     * re-encrypted on next save.
+     *
+     * SECURITY: We must NOT silently swallow decryption errors on values that DO
+     * look like ciphertext — that would let an attacker with DB write access bypass
+     * encryption by storing plaintext-looking blobs. In that case we fail loudly so
+     * the operator notices a key mismatch instead of silently leaking the raw value.
      */
     override fun convertToEntityAttribute(dbData: String?): String? {
-        return dbData?.let { encrypted ->
+        return dbData?.let { stored ->
+            if (!looksLikeCiphertext(stored)) {
+                // Pre-encryption legacy plaintext — return as-is so the entity can
+                // round-trip and the next save will encrypt it.
+                return@let stored
+            }
             try {
-                textEncryptor.decrypt(encrypted)
+                textEncryptor.decrypt(stored)
             } catch (e: Exception) {
-                log.warn("Failed to decrypt value — returning as plaintext (legacy data or key mismatch). " +
-                    "Value will be re-encrypted on next save.")
-                encrypted
+                // Looks like ciphertext but decryption failed — almost certainly a
+                // key/salt mismatch. Failing loud is safer than returning the raw
+                // ciphertext and pretending nothing happened.
+                log.error("Failed to decrypt value that appears to be ciphertext. " +
+                    "Check SECMAN_ENCRYPTION_PASSWORD / SECMAN_ENCRYPTION_SALT — they must match " +
+                    "the values used when the data was originally encrypted.")
+                throw RuntimeException("Failed to decrypt sensitive data", e)
             }
         }
+    }
+
+    private fun looksLikeCiphertext(value: String): Boolean {
+        // Spring's Encryptors.text() produces lowercase hex output. The minimum useful
+        // size is salt(16) + iv(16) + 1 AES block(16) = 48 bytes -> 96 hex chars, but
+        // we use 32 as a generous lower bound to err on the side of treating short
+        // values as plaintext rather than failing on them.
+        if (value.length < 32) return false
+        if (value.length % 2 != 0) return false
+        return value.all { it in '0'..'9' || it in 'a'..'f' }
     }
 }

--- a/src/frontend/src/layouts/BaseLayout.astro
+++ b/src/frontend/src/layouts/BaseLayout.astro
@@ -5,8 +5,10 @@ interface Props {
 }
 const { title } = Astro.props;
 
-// Generate a CSRF token for frontend use
-const csrfToken = "placeholder-token"; // This would actually come from the server in a real implementation
+// CSRF protection is provided by the HttpOnly secman_auth cookie's SameSite=Lax
+// attribute (see AuthCookieService on the backend) — there is no separate CSRF
+// token to embed here. Any earlier "placeholder-token" was security theater and
+// has been removed.
 ---
 <!doctype html>
 <html lang="en">
@@ -16,7 +18,6 @@ const csrfToken = "placeholder-token"; // This would actually come from the serv
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="csrf-token" content={csrfToken} />
 		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' cdn.jsdelivr.net; form-action 'self'; base-uri 'self'; object-src 'none';" />
 		<title>{title}</title>
         <!-- Bootstrap CSS -->


### PR DESCRIPTION
- POI zip-bomb hardening: set ZipSecureFile.setMinInflateRatio(0.001) and IOUtils.setByteArrayMaxOverride(100MB) at startup so every XSSFWorkbook parser (vulnerability/asset/user-mapping/alignment imports) is protected against decompression-bomb DoS.
- OAuth MFA bypass: AuthController refuses login when user.mfaEnabled, but OAuthService.handleCallback was issuing JWTs unconditionally. Add MFA_REQUIRED error code and short-circuit OAuth callback for MFA-enabled users.
- EncryptedStringConverter: replace silent "fallback to plaintext on decryption failure" with a ciphertext-shape check. Legacy plaintext rows still pass through, but values that look like ciphertext and fail to decrypt now throw loudly instead of leaking the raw blob.
- Workgroup tree-traversal endpoints (root/children/ancestors/descendants) were IS_AUTHENTICATED, leaking org structure to any logged-in user. Restrict to ADMIN to match the rest of the workgroup API.
- ImportController CSV upload: sanitize the rejected filename's extension before reflecting it in the error response.
- BaseLayout.astro: remove placeholder-token CSRF meta tag that was security theater (real CSRF defense is the SameSite=Lax HttpOnly auth cookie).

https://claude.ai/code/session_01DjBra5kp7LiRhABhgxMcjG