### PR TITLE
fix(security): harden frontend storage, CSP, and API error responses

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeController.kt
@@ -181,15 +181,15 @@ open class CrowdStrikeController(
             val retryAfter = e.retryAfterSeconds ?: 60
             HttpResponse.status<Map<String, String>>(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", retryAfter.toString())
-                .body(mapOf("error" to e.message))
+                .body(mapOf("error" to "Rate limit exceeded. Please retry later."))
         } catch (e: CrowdStrikeError.ConfigurationError) {
             log.error("Configuration error: {}", e.message)
             HttpResponse.status<Map<String, String>>(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(mapOf("error" to e.message))
+                .body(mapOf("error" to "CrowdStrike API is not configured properly"))
         } catch (e: CrowdStrikeError) {
             log.error("CrowdStrike error: {}", e.message)
             HttpResponse.status<Map<String, String>>(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(mapOf("error" to e.message))
+                .body(mapOf("error" to "An error occurred communicating with CrowdStrike"))
         } catch (e: Exception) {
             log.error("Unexpected error", e)
             HttpResponse.serverError(mapOf("error" to "An unexpected error occurred"))

--- a/src/backendng/src/main/kotlin/com/secman/controller/DomainVulnsController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/DomainVulnsController.kt
@@ -89,7 +89,7 @@ class DomainVulnsController(
             log.warn("User {} has no domain mappings: {}", email, e.message)
             HttpResponse.status<Any>(io.micronaut.http.HttpStatus.NOT_FOUND)
                 .body(mapOf(
-                    "message" to (e.message ?: "No domain mappings found for user"),
+                    "message" to "No domain mappings found for user",
                     "error" to "NO_DOMAIN_MAPPINGS"
                 ))
         } catch (e: IllegalStateException) {
@@ -97,7 +97,7 @@ class DomainVulnsController(
             log.error("Service error for user {}: {}", email, e.message)
             HttpResponse.status<Any>(io.micronaut.http.HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(mapOf(
-                    "message" to (e.message ?: "Service configuration error"),
+                    "message" to "Service configuration error",
                     "error" to "SERVICE_ERROR"
                 ))
         } catch (e: Exception) {
@@ -170,7 +170,7 @@ class DomainVulnsController(
             log.error("CrowdStrike configuration error for user {}: {}", email, e.message)
             HttpResponse.status<Any>(io.micronaut.http.HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(mapOf(
-                    "message" to (e.message ?: "CrowdStrike API not configured"),
+                    "message" to "CrowdStrike API is not configured",
                     "error" to "CONFIG_ERROR"
                 ))
         } catch (e: Exception) {

--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityHeatmapController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityHeatmapController.kt
@@ -83,7 +83,7 @@ class VulnerabilityHeatmapController(
         } catch (e: Exception) {
             logger.error("Manual heatmap refresh failed", e)
             HttpResponse.serverError<Map<String, Any>>().body(mapOf(
-                "message" to "Heatmap refresh failed: ${e.message}"
+                "message" to "Heatmap refresh failed. Please try again or contact an administrator."
             ))
         }
     }

--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityStatisticsController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityStatisticsController.kt
@@ -288,7 +288,7 @@ class VulnerabilityStatisticsController(
             val result = vulnerabilityStatisticsService.getTemporalTrends(authentication, days)
             HttpResponse.ok(result)
         } catch (e: IllegalArgumentException) {
-            HttpResponse.status<String>(HttpStatus.BAD_REQUEST).body(e.message)
+            HttpResponse.status<String>(HttpStatus.BAD_REQUEST).body("Invalid request parameters")
         } catch (e: Exception) {
             logger.error("Error fetching temporal trends", e)
             HttpResponse.serverError<String>()

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -30,7 +30,7 @@ const Header = () => {
             if (response.ok) {
                 // Clear client-side authentication data
                 // Note: The HttpOnly secman_auth cookie is cleared by the server response
-                localStorage.removeItem('user');
+                sessionStorage.removeItem('user');
                 // Clean up legacy token storage from previous versions
                 localStorage.removeItem('authToken');
                 document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';

--- a/src/frontend/src/components/Login.tsx
+++ b/src/frontend/src/components/Login.tsx
@@ -60,7 +60,7 @@ const Login = () => {
         // Clear any stale authentication data before starting fresh OAuth flow
         // This prevents issues with cached OAuth states in corporate AAD environments
         localStorage.removeItem('authToken'); // Legacy cleanup
-        localStorage.removeItem('user');
+        sessionStorage.removeItem('user');
         sessionStorage.clear(); // Clear any cached OAuth-related data
 
         // Delete legacy auth cookies to ensure fresh OAuth flow
@@ -172,7 +172,7 @@ const Login = () => {
                             awsAccountCount: 0,
                             domainCount: 0,
                         };
-                        localStorage.setItem('user', JSON.stringify(userData));
+                        sessionStorage.setItem('user', JSON.stringify(userData));
                         (window as any).currentUser = userData;
                         window.dispatchEvent(new CustomEvent('userLoaded'));
                         setTimeout(() => { window.location.href = '/'; }, 100);
@@ -194,7 +194,7 @@ const Login = () => {
                     awsAccountCount: data.awsAccountCount || 0,
                     domainCount: data.domainCount || 0
                 };
-                localStorage.setItem('user', JSON.stringify(userData));
+                sessionStorage.setItem('user', JSON.stringify(userData));
                 // Note: Token is NOT stored in localStorage for security (XSS protection)
                 // Authentication is handled via HttpOnly cookie set by backend
 

--- a/src/frontend/src/layouts/BaseLayout.astro
+++ b/src/frontend/src/layouts/BaseLayout.astro
@@ -5,8 +5,9 @@ interface Props {
 }
 const { title } = Astro.props;
 
-// Generate a CSRF token for frontend use
-const csrfToken = "placeholder-token"; // This would actually come from the server in a real implementation
+// CSRF protection is handled via SameSite=Lax on the HttpOnly auth cookie.
+// No explicit CSRF token is needed since the backend enforces cookie-based auth
+// with SameSite policy, which prevents cross-site request forgery.
 ---
 <!doctype html>
 <html lang="en">
@@ -16,8 +17,8 @@ const csrfToken = "placeholder-token"; // This would actually come from the serv
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="csrf-token" content={csrfToken} />
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' cdn.jsdelivr.net; form-action 'self'; base-uri 'self'; object-src 'none';" />
+		<!-- CSRF protection via SameSite=Lax cookie policy; no token meta tag needed -->
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' cdn.jsdelivr.net; form-action 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none';" />
 		<title>{title}</title>
         <!-- Bootstrap CSS -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">

--- a/src/frontend/src/layouts/Layout.astro
+++ b/src/frontend/src/layouts/Layout.astro
@@ -42,7 +42,7 @@ const requiresRedirect = !user && !isPublicPage;
 		<meta name="viewport" content="width=device-width, initial-scale=1" /> 
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' cdn.jsdelivr.net; form-action 'self'; base-uri 'self'; object-src 'none';" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' cdn.jsdelivr.net; form-action 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none';" />
 		<title>{title}</title>
         <!-- Bootstrap CSS -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
@@ -112,7 +112,7 @@ const requiresRedirect = !user && !isPublicPage;
                     // Check for user data in localStorage (indicates a logged-in session)
                     // The actual JWT token is stored in an HttpOnly cookie (secman_auth)
                     // for XSS protection and is sent automatically with credentials: 'include'
-                    const userStr = localStorage.getItem('user');
+                    const userStr = sessionStorage.getItem('user');
                     if (!userStr) {
                         // No user data, redirect to login
                         console.log('No user data found, redirecting to /login');
@@ -132,7 +132,7 @@ const requiresRedirect = !user && !isPublicPage;
                         if (response.status === 401) {
                              console.log('Not authenticated, clearing user data and redirecting to /login');
                              // Clear user data (token is in HttpOnly cookie, cleared by server)
-                             localStorage.removeItem('user');
+                             sessionStorage.removeItem('user');
                              window.location.href = '/login';
                         } else {
                             // Handle other errors if needed

--- a/src/frontend/src/pages/login/success.astro
+++ b/src/frontend/src/pages/login/success.astro
@@ -75,7 +75,7 @@
             })
             .then(function(userData) {
                 // Store user metadata for UI display and role checks
-                localStorage.setItem('user', JSON.stringify(userData));
+                sessionStorage.setItem('user', JSON.stringify(userData));
 
                 // Set global user state for Header component
                 window.currentUser = userData;

--- a/src/frontend/src/utils/auth-init.ts
+++ b/src/frontend/src/utils/auth-init.ts
@@ -21,11 +21,11 @@ declare global {
  * Should be called on app startup.
  *
  * Note: The JWT token is stored in an HttpOnly cookie (secman_auth)
- * for XSS protection. Only user data is stored in localStorage.
+ * for XSS protection. Only user data is stored in sessionStorage.
  */
 export function initializeAuth(): void {
     try {
-        const userStr = localStorage.getItem('user');
+        const userStr = sessionStorage.getItem('user');
 
         if (userStr) {
             const user = JSON.parse(userStr);
@@ -39,7 +39,7 @@ export function initializeAuth(): void {
     } catch (error) {
         console.error('Failed to initialize auth:', error);
         // Clear invalid data
-        localStorage.removeItem('user');
+        sessionStorage.removeItem('user');
         window.currentUser = null;
         window.dispatchEvent(new CustomEvent('userLoaded'));
     }
@@ -51,7 +51,7 @@ export function initializeAuth(): void {
  */
 export async function validateToken(): Promise<boolean> {
     // Check if we have user data (indicates a logged-in session)
-    const userStr = localStorage.getItem('user');
+    const userStr = sessionStorage.getItem('user');
     if (!userStr) return false;
 
     try {
@@ -66,13 +66,13 @@ export async function validateToken(): Promise<boolean> {
         if (response.ok) {
             const userData = await response.json();
             // Update stored user data
-            localStorage.setItem('user', JSON.stringify(userData));
+            sessionStorage.setItem('user', JSON.stringify(userData));
             window.currentUser = userData;
             window.dispatchEvent(new CustomEvent('userLoaded'));
             return true;
         } else {
             // Session is invalid - clear user data
-            localStorage.removeItem('user');
+            sessionStorage.removeItem('user');
             window.currentUser = null;
             window.dispatchEvent(new CustomEvent('userLoaded'));
             return false;

--- a/src/frontend/src/utils/auth.ts
+++ b/src/frontend/src/utils/auth.ts
@@ -16,7 +16,7 @@ export interface User {
  */
 export function getUser(): User | null {
     if (typeof window === 'undefined') return null;
-    const userStr = localStorage.getItem('user');
+    const userStr = sessionStorage.getItem('user');
     if (!userStr) return null;
 
     try {
@@ -74,10 +74,11 @@ export function hasVulnAccess(): boolean {
  */
 export function clearAuth(): void {
     if (typeof window === 'undefined') return;
-    // Clear user data
-    localStorage.removeItem('user');
+    // Clear user data (stored in sessionStorage for XSS protection)
+    sessionStorage.removeItem('user');
     // Clean up any legacy token storage from previous versions
     localStorage.removeItem('authToken');
+    localStorage.removeItem('user'); // Clean up legacy localStorage usage
     document.cookie = 'authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 }
 


### PR DESCRIPTION
- Move user data from localStorage to sessionStorage to reduce XSS attack surface (data cleared on tab close, not persistent)
- Add frame-ancestors 'none' to CSP meta tags in both layouts to prevent clickjacking via iframes
- Replace raw exception messages (e.message) with generic error strings in CrowdStrike, DomainVulns, VulnerabilityHeatmap, and VulnerabilityStatistics controllers to prevent information disclosure
- Remove misleading placeholder CSRF token from BaseLayout (CSRF protection is already handled by SameSite=Lax cookie policy)

https://claude.ai/code/session_01F84Hf6GotS7qh9X2oGTVX5