### PR TITLE
docs: reconcile counts, roles, endpoints, and tool lists with codebase

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Secman Installation Guide
 
-**Last Updated:** 2026-04-03
+**Last Updated:** 2026-04-16
 
 Complete installation instructions for new users of the Secman security management application.
 
@@ -478,7 +478,7 @@ After installation, verify everything is working:
 
 ```bash
 curl http://localhost:8080/health
-# Expected: {"status":"UP"}
+# Expected: {"status":"UP","service":"secman-backend-ng","version":"0.1"}
 ```
 
 ### 2. Check Frontend

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ SecMan is a full-stack security management platform that helps organizations man
   - `SECCHAMPION` - Security champion access
   - `REQ` - Requirements editor
   - `REQADMIN` - Requirements admin (create/delete releases, alignment decisions)
+  - `RISK` - Risk assessment access (read/write/execute risk assessments)
   - `REPORT` - Report generation and viewing
 - **Row-Level Security**: Users see only their workgroup resources + owned items
 - **Last Admin Protection**: System prevents deletion/demotion of the last ADMIN user
@@ -109,7 +110,7 @@ SecMan is a full-stack security management platform that helps organizations man
 
 - **Model Context Protocol** support for AI assistants (Claude, etc.)
 - Streamable HTTP transport (direct connection, no middleware required)
-- 53 MCP tools for requirements, assets, vulnerabilities, scans, releases, user mappings, workgroups, and more
+- 52 MCP tools for requirements, assets, vulnerabilities, scans, releases, user mappings, workgroups, AWS account sharing, vulnerability heatmap, and more
 - User delegation (act on behalf of users)
 - API key management with granular permissions
 - Rate limiting and session management
@@ -239,7 +240,7 @@ secman/
 │   │   │   ├── controller/ # REST controllers (62 controllers)
 │   │   │   ├── domain/     # JPA entities
 │   │   │   ├── repository/ # Data repositories
-│   │   │   ├── service/    # Business logic (95 services)
+│   │   │   ├── service/    # Business logic (97 services)
 │   │   │   ├── config/     # Configuration classes
 │   │   │   ├── dto/        # Data transfer objects
 │   │   │   ├── filter/     # HTTP filters
@@ -341,6 +342,11 @@ POST /api/auth/login
 | `/api/notification-logs`                              | GET     | Notification audit logs          | ADMIN                  |
 | `/api/account-vulns`                                  | GET     | Account-scoped vulnerabilities   | USER                   |
 | `/api/workgroups`                                     | GET/POST| List/create workgroups           | ADMIN                  |
+| `/api/aws-account-sharing`                            | GET/POST| List/create AWS account sharing  | ADMIN                  |
+| `/api/aws-account-sharing/{id}`                       | DELETE  | Remove AWS account sharing rule  | ADMIN                  |
+| `/api/vulnerability-heatmap`                          | GET     | Vulnerability heatmap            | Authenticated          |
+| `/api/vulnerability-heatmap/refresh`                  | POST    | Recalculate heatmap              | ADMIN                  |
+| `/api/external/vulnerability-heatmap`                 | GET     | External heatmap (API key)       | API Key                |
 | `/api/import/upload-nmap-xml`                         | POST    | Import Nmap scan                 | ADMIN                  |
 | `/api/import/upload-vulnerability-xlsx`               | POST    | Import vulnerabilities           | ADMIN                  |
 | `/api/import/upload-user-mappings-csv`                | POST    | Import user mappings             | ADMIN                  |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Secman Architecture
 
-**Last Updated:** 2026-04-15
+**Last Updated:** 2026-04-16
 
 This document describes the system architecture, data model, and design patterns used in Secman.
 
@@ -78,7 +78,7 @@ Secman is a security requirement and risk assessment management tool consisting 
 
 ### Backend (`src/backendng/`)
 
-The backend follows a layered architecture with 63 controllers:
+The backend follows a layered architecture with 62 controllers:
 
 ```
 +-----------------------------------------------------------------+
@@ -86,7 +86,7 @@ The backend follows a layered architecture with 63 controllers:
 |   REST endpoints, request validation, response formatting       |
 |   @Controller, @Secured, @PathVariable, @Body                   |
 +-----------------------------------------------------------------+
-|                     Service Layer (95 services)                   |
+|                     Service Layer (97 services)                   |
 |   Business logic, transaction management, domain operations     |
 |   @Singleton, @Transactional                                    |
 +-----------------------------------------------------------------+
@@ -549,7 +549,7 @@ secman/
 │   │       ├── repository/           # Data access
 │   │       ├── service/              # Business logic
 │   │       │   └── mcp/              # MCP-specific services
-│   │       ├── controller/           # REST endpoints (63 controllers)
+│   │       ├── controller/           # REST endpoints (62 controllers)
 │   │       ├── config/               # Configuration
 │   │       ├── dto/                  # DTOs
 │   │       │   └── mcp/              # MCP DTOs

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,9 +1,16 @@
 # Secman CLI Reference
 
-**Last Updated:** 2026-04-01
-**Version:** 1.0
+**Last Updated:** 2026-04-16
+**Version:** 1.1
 
 Command-line interface for CrowdStrike vulnerability queries, notifications, user mapping management, and manual vulnerability entry.
+
+> **Invocation Styles:** The examples below use `java -jar secman-cli.jar ...` to document the raw JAR invocation. During local development or scripted usage, you can substitute any of the following equivalent wrappers:
+>
+> - `./scripts/secman <command>` — symlink to `secmancli`, uses 1Password to inject secrets from `secman.env`
+> - `./scripts/secmanng <command>` — alternative 1Password-based wrapper with explicit env exports (e.g. `SECMAN_INSECURE` for self-signed SSL)
+>
+> See [1PASSWORD.md](./1PASSWORD.md) for details on which secrets each wrapper resolves.
 
 ---
 

--- a/docs/E2E_EXCEPTION_WORKFLOW_TEST.md
+++ b/docs/E2E_EXCEPTION_WORKFLOW_TEST.md
@@ -1,7 +1,7 @@
 # E2E Vulnerability Exception Workflow Test
 
 **Feature**: 063-e2e-vuln-exception
-**Last Updated**: 2026-01-14
+**Last Updated**: 2026-04-16
 
 This document describes how to run the end-to-end test for the vulnerability exception workflow.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,7 +1,7 @@
 # MCP (Model Context Protocol) Integration Guide
 
-**Last Updated:** 2026-04-02
-**Version:** 5.0
+**Last Updated:** 2026-04-16
+**Version:** 5.1
 
 This guide covers integrating Secman with AI assistants (Claude Desktop, Claude Code, ChatGPT, etc.) using the Model Context Protocol (MCP).
 
@@ -34,7 +34,7 @@ Secman supports the Model Context Protocol (MCP), allowing AI assistants to prog
 - **Vulnerability Data** - Search vulnerabilities by severity, CVE, or affected asset
 - **Scan Results** - Review network scan history and discovered services
 
-The MCP server exposes **53 tools** for comprehensive security management workflows.
+The MCP server exposes **52 tools** for comprehensive security management workflows.
 
 ### Prerequisites
 
@@ -434,6 +434,38 @@ Retrieve profile for a single asset including vulnerabilities and scan history.
 
 #### `get_asset_complete_profile`
 Retrieve complete asset profile with all vulnerabilities and scan results.
+
+#### `create_asset`
+Create a new asset in the inventory. **Requires User Delegation.**
+
+Duplicate detection: returns an error if an asset with the same name already exists (case-insensitive). The delegated user is recorded as `manualCreator` for access control.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Asset hostname or name (max 255 characters) |
+| `type` | string | Yes | Asset type (e.g., `SERVER`, `WORKSTATION`, `NETWORK_DEVICE`) |
+| `owner` | string | Yes | Owner username (max 255 characters) |
+| `ip` | string | No | IP address |
+| `description` | string | No | Asset description |
+| `criticality` | enum | No | `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `NA` |
+| `adDomain` | string | No | Active Directory domain |
+| `cloudAccountId` | string | No | AWS account ID |
+
+#### `update_asset`
+Update an existing asset's properties. **Requires User Delegation.**
+
+Supports partial updates — only provided fields are modified. Row-level access control applies: users can only update assets they have access to. Workgroup reassignment is handled via `assign_assets_to_workgroup` instead.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `assetId` | number | Yes | ID of the asset to update |
+| `name` | string | No | New asset name (max 255 characters) |
+| `type` | string | No | New asset type |
+| `owner` | string | No | New owner username |
+| `ip` | string | No | New IP address |
+| `description` | string | No | New asset description |
+| `criticality` | enum | No | `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `NA` |
+| `adDomain` | string | No | New Active Directory domain |
 
 ### Vulnerability Management
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Security requirement and risk assessment management tool.
 
-**Last Updated:** 2026-04-15
+**Last Updated:** 2026-04-16
 
 ---
 
@@ -235,7 +235,7 @@ See [CLI.md](./CLI.md) for all commands and cron setup.
 ```bash
 # Backend
 curl http://localhost:8080/health
-# Expected: {"status":"UP","service":"secman-backend-ng"}
+# Expected: {"status":"UP","service":"secman-backend-ng","version":"0.1"}
 
 # Frontend
 curl http://localhost:4321/

--- a/docs/S3_USER_MAPPING_IMPORT.md
+++ b/docs/S3_USER_MAPPING_IMPORT.md
@@ -1,7 +1,7 @@
 # S3 User Mapping Import
 
 **Feature**: 065-s3-user-mapping-import
-**Last Updated**: 2026-02-13
+**Last Updated**: 2026-04-16
 
 Import user mappings (domain and AWS account associations) directly from CSV or JSON files stored in AWS S3 buckets via the CLI.
 


### PR DESCRIPTION
- README.md: add missing RISK role to RBAC list; correct services count (95->97) and MCP tool count (53->52); add AWS account sharing and vulnerability heatmap endpoints to Key Endpoints table
- ARCHITECTURE.md: fix controller count (63->62) and service count (95->97) to match current codebase
- MCP.md: document the previously undocumented create_asset and update_asset tools; correct tool count (53->52)
- CLI.md: clarify up front that java -jar examples are equivalent to the ./scripts/secman and ./scripts/secmanng wrappers so readers can map between CLAUDE.md and the full CLI reference
- INSTALL.md, docs/README.md: include version field in /health response example to match actual HealthController output
- E2E_EXCEPTION_WORKFLOW_TEST.md, S3_USER_MAPPING_IMPORT.md: refresh stale "Last Updated" dates