### PR TITLE
feat(crowdstrike): add public last-checkin endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Users access assets if **ANY** is true:
 
 **Auth**: POST /api/auth/login, GET /oauth/{authorize,callback}
 
+**CrowdStrike**: POST /api/crowdstrike/servers/import (ADMIN/VULN), GET /api/crowdstrike/servers/import/latest (ADMIN/VULN), POST /api/crowdstrike/vulnerabilities/save (ADMIN/VULN), GET /api/crowdstrike/vulnerabilities (ADMIN/VULN), GET /api/crowdstrike/last-checkin (PUBLIC, returns ISO-8601 timestamp of the last import as `text/plain`, or `"never"` if no import has happened)
+
 **User Mappings**: GET /api/user-mappings/{current,applied-history} (ADMIN), POST/PUT/DELETE /api/user-mappings[/{id}] (ADMIN)
 
 **AWS Account Sharing**: GET/POST /api/aws-account-sharing (ADMIN), DELETE /api/aws-account-sharing/{id} (ADMIN)

--- a/docs/CROWDSTRIKE_IMPORT.md
+++ b/docs/CROWDSTRIKE_IMPORT.md
@@ -528,6 +528,41 @@ Comprehensive integration tests verify duplicate prevention:
 
 ---
 
+## Public Checkin Freshness Endpoint
+
+For external monitoring / dashboards that need to verify CrowdStrike data is
+still being refreshed, secman exposes a single **unauthenticated** endpoint:
+
+```
+GET /api/crowdstrike/last-checkin
+```
+
+- **Auth**: none (public)
+- **Content-Type**: `text/plain`
+- **Response body**: either the ISO-8601 timestamp of the most recent
+  successful CrowdStrike import (e.g. `2026-04-21T08:42:13.511`), or the
+  literal string `never` if no import has ever been recorded.
+- **No other information** is returned — not the user who triggered it, not
+  the number of vulnerabilities imported, etc.
+
+The timestamp comes from the latest row in `crowdstrike_import_history`
+(`imported_at`), which is written by
+`CrowdStrikeVulnerabilityImportService.recordImportHistory()` at the end of
+every batch import (including CLI-driven imports via
+`./scripts/secman query servers --save`).
+
+**Example**:
+
+```bash
+$ curl -s https://secman.example.com/api/crowdstrike/last-checkin
+2026-04-21T08:42:13.511
+
+$ curl -s https://secman.example.com/api/crowdstrike/last-checkin
+never
+```
+
+---
+
 ## See Also
 
 - [CLI Reference](./CLI.md) - CrowdStrike query commands

--- a/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeController.kt
@@ -15,6 +15,7 @@ import com.secman.util.ValidationUtils
 import io.micronaut.cache.annotation.CacheInvalidate
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.*
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
@@ -343,6 +344,23 @@ open class CrowdStrikeController(
     open fun getLatestImportStatus(): HttpResponse<*> {
         val status: CrowdStrikeImportStatusDto? = importService.getLatestImportStatus()
         return status?.let { HttpResponse.ok(it) } ?: HttpResponse.noContent<CrowdStrikeImportStatusDto>()
+    }
+
+    /**
+     * Public endpoint: returns the timestamp of the most recent CrowdStrike
+     * checkin (i.e. the latest successful CrowdStrike import) as an ISO-8601
+     * string, or the literal string "never" if no import has ever occurred.
+     *
+     * Unauthenticated by design so that external monitoring / dashboards can
+     * poll the freshness of CrowdStrike data without needing API credentials.
+     * Only a single timestamp (or "never") is exposed — no other information.
+     */
+    @Get("/crowdstrike/last-checkin", produces = [MediaType.TEXT_PLAIN])
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    open fun getLastCheckin(): HttpResponse<String> {
+        val status = importService.getLatestImportStatus()
+        val body = status?.importedAt?.toString() ?: "never"
+        return HttpResponse.ok(body)
     }
 
     /**


### PR DESCRIPTION
Expose GET /api/crowdstrike/last-checkin as an unauthenticated endpoint
returning either the ISO-8601 timestamp of the most recent CrowdStrike
import or the literal string "never" as text/plain.

This lets external monitoring / dashboards poll CrowdStrike data
freshness without needing credentials. Only a single timestamp (or
"never") is ever returned - no metadata, user, or counts.

Docs updated in CLAUDE.md and docs/CROWDSTRIKE_IMPORT.md.

https://claude.ai/code/session_01UckFFLMHSj1RsZFrKDmPCR