### PR TITLE
feat(clinotify): add Telegram alert script for stale CrowdStrike chec…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Users access assets if **ANY** is true:
 **Auth**: POST /api/auth/login, GET /oauth/{authorize,callback}
 
 **CrowdStrike**: POST /api/crowdstrike/servers/import (ADMIN/VULN), GET /api/crowdstrike/servers/import/latest (ADMIN/VULN), POST /api/crowdstrike/vulnerabilities/save (ADMIN/VULN), GET /api/crowdstrike/vulnerabilities (ADMIN/VULN), GET /api/crowdstrike/last-checkin (PUBLIC, returns ISO-8601 timestamp of the last import as `text/plain`, or `"never"` if no import has happened)
+- Monitoring script: `src/clinotify/check_crowdstrike_checkin.py` polls the public checkin endpoint and sends a Telegram alert when the last import is older than `--max-age-minutes` (or `never`). Stdlib-only Python; see `src/clinotify/README.md`.
 
 **User Mappings**: GET /api/user-mappings/{current,applied-history} (ADMIN), POST/PUT/DELETE /api/user-mappings[/{id}] (ADMIN)
 

--- a/docs/CROWDSTRIKE_IMPORT.md
+++ b/docs/CROWDSTRIKE_IMPORT.md
@@ -561,6 +561,19 @@ $ curl -s https://secman.example.com/api/crowdstrike/last-checkin
 never
 ```
 
+### Ready-made monitoring script
+
+A stdlib-only Python script that polls this endpoint and raises a Telegram
+alert when the checkin is older than a configurable threshold (or `never`)
+lives at [`src/clinotify/check_crowdstrike_checkin.py`](../src/clinotify/README.md).
+Typical cron usage:
+
+```bash
+*/10 * * * * TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... \
+  /opt/secman/src/clinotify/check_crowdstrike_checkin.py \
+  --url https://secman.example.com --max-age-minutes 120
+```
+
 ---
 
 ## See Also

--- a/src/clinotify/README.md
+++ b/src/clinotify/README.md
@@ -1,0 +1,120 @@
+# clinotify
+
+Lightweight, stdlib-only Python scripts that monitor secman from the outside
+and raise alerts on notification channels (currently Telegram).
+
+These are intentionally separate from the main Kotlin `src/cli/` tool — they
+need **no build step**, **no JVM**, and **no credentials** against secman,
+because they only consume the public CrowdStrike-checkin endpoint.
+
+## Scripts
+
+### `check_crowdstrike_checkin.py`
+
+Polls `GET /api/crowdstrike/last-checkin` (a public, unauthenticated
+endpoint) and sends a Telegram message when the last CrowdStrike import is
+older than a configurable threshold — or when the endpoint returns the
+literal string `never`.
+
+#### Requirements
+
+* Python 3.9+ (uses `datetime.fromisoformat`)
+* Stdlib only — no `pip install` needed
+* Network access to both the secman host and `api.telegram.org`
+* A Telegram bot token and the target chat id
+
+#### Telegram setup
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) and copy the token
+   it returns (looks like `123456789:ABC-DEF...`).
+2. Start a chat with your bot (or add it to a group) and send any message.
+3. Get the chat id:
+   ```
+   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" \
+       | python3 -c 'import json,sys; print(json.load(sys.stdin))'
+   ```
+   Look for `"chat":{"id": ...}`. For group chats the id is negative.
+
+#### Usage
+
+```
+check_crowdstrike_checkin.py --url URL --max-age-minutes N
+                             [--telegram-bot-token TOKEN]
+                             [--telegram-chat-id CHAT_ID]
+                             [--insecure] [--timeout SECS] [--verbose]
+```
+
+| Flag                    | Description                                                   |
+|-------------------------|---------------------------------------------------------------|
+| `--url`                 | Base URL of the secman instance (e.g. `https://secman.example.com`). |
+| `--max-age-minutes N`   | Alert if the last checkin is older than N minutes or is `never`. |
+| `--telegram-bot-token`  | Bot token. Defaults to `$TELEGRAM_BOT_TOKEN`.                 |
+| `--telegram-chat-id`    | Chat id. Defaults to `$TELEGRAM_CHAT_ID`.                     |
+| `--insecure`            | Disable TLS verification on the secman call (self-signed certs). |
+| `--timeout`             | HTTP timeout in seconds (default: `15`).                      |
+| `--verbose` / `-v`      | Print diagnostic info to stdout.                              |
+
+#### Exit codes
+
+| Code | Meaning                                                |
+|------|--------------------------------------------------------|
+| `0`  | OK — last checkin is within the threshold              |
+| `1`  | Transport / parse error (no alert sent)                |
+| `2`  | Invalid arguments                                      |
+| `3`  | Alert fired (checkin stale or `never`)                 |
+
+#### Examples
+
+One-shot run, credentials via env:
+```bash
+export TELEGRAM_BOT_TOKEN=123456789:ABC-...
+export TELEGRAM_CHAT_ID=-1001234567890
+
+./check_crowdstrike_checkin.py \
+    --url https://secman.example.com \
+    --max-age-minutes 120 \
+    --verbose
+```
+
+Cron, alert if no import in the last 2 hours:
+```cron
+*/10 * * * * TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... \
+  /opt/secman/src/clinotify/check_crowdstrike_checkin.py \
+  --url https://secman.example.com --max-age-minutes 120 \
+  >> /var/log/secman-checkin.log 2>&1
+```
+
+systemd timer (`/etc/systemd/system/secman-checkin.service`):
+```ini
+[Service]
+Type=oneshot
+Environment=TELEGRAM_BOT_TOKEN=...
+Environment=TELEGRAM_CHAT_ID=...
+ExecStart=/opt/secman/src/clinotify/check_crowdstrike_checkin.py \
+    --url https://secman.example.com --max-age-minutes 120
+```
+
+#### Sample alerts
+
+Stale:
+```
+secman alert: CrowdStrike checkin is stale. Last checkin
+2026-04-21T02:13:04.112 (318 min ago, threshold 120 min).
+Source: https://secman.example.com
+```
+
+Never imported:
+```
+secman alert: CrowdStrike has NEVER checked in
+(source: https://secman.example.com).
+```
+
+#### Caveats
+
+* The backend returns a Java `LocalDateTime` — naive, no timezone. The script
+  compares it against the local wallclock on whatever host runs the script,
+  so run it in the **same timezone as the secman backend**, or accept the
+  skew. If this matters, extend the backend to emit a UTC `Instant` instead.
+* The script is idempotent but **not stateful**: every invocation that finds
+  a stale checkin will send a Telegram message. Throttle with cron cadence,
+  or add a state file if you need deduplication.

--- a/src/clinotify/check_crowdstrike_checkin.py
+++ b/src/clinotify/check_crowdstrike_checkin.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Check secman's CrowdStrike last-checkin freshness and alert via Telegram
+if the last import is older than a configurable threshold (or "never").
+
+Queries the public endpoint
+    GET {secman-url}/api/crowdstrike/last-checkin
+which returns either an ISO-8601 timestamp (text/plain) or the literal
+string "never". If the checkin is older than --max-age-minutes, or the
+endpoint returns "never", a message is posted to the configured
+Telegram chat via the Bot API.
+
+Exit codes:
+    0  OK, last checkin is within the threshold
+    1  Transport / parse error (nothing sent)
+    2  Invalid arguments
+    3  Alert triggered (checkin stale or "never")
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+
+
+def fetch_last_checkin(base_url: str, insecure: bool, timeout: int) -> str:
+    endpoint = base_url.rstrip("/") + "/api/crowdstrike/last-checkin"
+    ctx = ssl._create_unverified_context() if insecure else None
+    req = urllib.request.Request(endpoint, headers={"Accept": "text/plain"})
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return resp.read().decode("utf-8").strip()
+
+
+def send_telegram(token: str, chat_id: str, text: str, timeout: int) -> None:
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = json.dumps({"chat_id": chat_id, "text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Telegram API returned HTTP {resp.status}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="Base URL of the secman instance (e.g. https://secman.example.com)",
+    )
+    parser.add_argument(
+        "--max-age-minutes",
+        type=int,
+        required=True,
+        help="Alert if the last checkin is older than this many minutes, "
+             "or if the endpoint returns 'never'",
+    )
+    parser.add_argument(
+        "--telegram-bot-token",
+        default=os.environ.get("TELEGRAM_BOT_TOKEN"),
+        help="Telegram bot token (default: $TELEGRAM_BOT_TOKEN)",
+    )
+    parser.add_argument(
+        "--telegram-chat-id",
+        default=os.environ.get("TELEGRAM_CHAT_ID"),
+        help="Telegram chat id (default: $TELEGRAM_CHAT_ID)",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS verification when calling the secman endpoint",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=15,
+        help="HTTP timeout in seconds (default: 15)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print diagnostic info to stdout",
+    )
+    args = parser.parse_args()
+
+    if not args.telegram_bot_token:
+        print("error: --telegram-bot-token or $TELEGRAM_BOT_TOKEN is required",
+              file=sys.stderr)
+        return 2
+    if not args.telegram_chat_id:
+        print("error: --telegram-chat-id or $TELEGRAM_CHAT_ID is required",
+              file=sys.stderr)
+        return 2
+    if args.max_age_minutes < 0:
+        print("error: --max-age-minutes must be >= 0", file=sys.stderr)
+        return 2
+
+    try:
+        raw = fetch_last_checkin(args.url, args.insecure, args.timeout)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"error: failed to query {args.url}: {e}", file=sys.stderr)
+        return 1
+
+    if args.verbose:
+        print(f"endpoint response: {raw!r}")
+
+    # "never" -> always alert
+    if raw == "never":
+        msg = (f"secman alert: CrowdStrike has NEVER checked in "
+               f"(source: {args.url}).")
+        try:
+            send_telegram(args.telegram_bot_token, args.telegram_chat_id,
+                          msg, args.timeout)
+        except (urllib.error.URLError, TimeoutError, OSError,
+                RuntimeError) as e:
+            print(f"error: telegram send failed: {e}", file=sys.stderr)
+            return 1
+        print(msg)
+        return 3
+
+    # Server returns Java LocalDateTime.toString() -> naive ISO-8601.
+    # Compare naively against local clock; run this script on a host in
+    # the same timezone as the backend.
+    try:
+        last = datetime.fromisoformat(raw)
+    except ValueError as e:
+        print(f"error: could not parse timestamp {raw!r}: {e}",
+              file=sys.stderr)
+        return 1
+
+    now = datetime.now()
+    age_minutes = (now - last).total_seconds() / 60.0
+
+    if args.verbose:
+        print(f"last checkin: {last.isoformat()}")
+        print(f"age: {age_minutes:.1f} min "
+              f"(threshold: {args.max_age_minutes} min)")
+
+    if age_minutes > args.max_age_minutes:
+        msg = (f"secman alert: CrowdStrike checkin is stale. "
+               f"Last checkin {last.isoformat()} "
+               f"({age_minutes:.0f} min ago, "
+               f"threshold {args.max_age_minutes} min). "
+               f"Source: {args.url}")
+        try:
+            send_telegram(args.telegram_bot_token, args.telegram_chat_id,
+                          msg, args.timeout)
+        except (urllib.error.URLError, TimeoutError, OSError,
+                RuntimeError) as e:
+            print(f"error: telegram send failed: {e}", file=sys.stderr)
+            return 1
+        print(msg)
+        return 3
+
+    if args.verbose:
+        print("OK: checkin is fresh")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
…kins

Add src/clinotify/check_crowdstrike_checkin.py: a stdlib-only Python script that polls GET /api/crowdstrike/last-checkin and posts a Telegram message when the last CrowdStrike import is older than --max-age-minutes (or the endpoint returns "never").

Python was chosen because the script has no build step, needs no JVM, and can rely exclusively on the standard library (urllib, argparse, datetime), which keeps deployment as simple as copying one file.

Includes src/clinotify/README.md with usage, setup, cron/systemd examples, and caveats. CLAUDE.md and docs/CROWDSTRIKE_IMPORT.md now cross-reference the script.

https://claude.ai/code/session_01UckFFLMHSj1RsZFrKDmPCR