### PR TITLE
docs: fix outdated counts, stale dates, and inaccurate content across…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ SecMan is a full-stack security management platform that helps organizations man
 
 - **Model Context Protocol** support for AI assistants (Claude, etc.)
 - Streamable HTTP transport (direct connection, no middleware required)
-- 53 MCP tools for requirements, assets, vulnerabilities, scans, releases, user mappings, workgroups, AWS account sharing, vulnerability heatmap, and more
+- 55 MCP tools for requirements, assets, vulnerabilities, scans, releases, user mappings, workgroups, AWS account sharing, vulnerability heatmap, and more
 - User delegation (act on behalf of users)
 - API key management with granular permissions
 - Rate limiting and session management
@@ -237,7 +237,7 @@ secman/
 ├── src/
 │   ├── backendng/          # Kotlin/Micronaut backend
 │   │   ├── src/main/kotlin/com/secman/
-│   │   │   ├── controller/ # REST controllers (63 controllers)
+│   │   │   ├── controller/ # REST controllers (62 controllers)
 │   │   │   ├── domain/     # JPA entities
 │   │   │   ├── repository/ # Data repositories
 │   │   │   ├── service/    # Business logic (97 services)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Secman Architecture
 
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-04-23
 
 This document describes the system architecture, data model, and design patterns used in Secman.
 
@@ -78,7 +78,7 @@ Secman is a security requirement and risk assessment management tool consisting 
 
 ### Backend (`src/backendng/`)
 
-The backend follows a layered architecture with 63 controllers:
+The backend follows a layered architecture with 62 controllers:
 
 ```
 +-----------------------------------------------------------------+
@@ -549,7 +549,7 @@ secman/
 │   │       ├── repository/           # Data access
 │   │       ├── service/              # Business logic
 │   │       │   └── mcp/              # MCP-specific services
-│   │       ├── controller/           # REST endpoints (63 controllers)
+│   │       ├── controller/           # REST endpoints (62 controllers)
 │   │       ├── config/               # Configuration
 │   │       ├── dto/                  # DTOs
 │   │       │   └── mcp/              # MCP DTOs

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # Secman CLI Reference
 
-**Last Updated:** 2026-04-16
+**Last Updated:** 2026-04-23
 **Version:** 1.1
 
 Command-line interface for CrowdStrike vulnerability queries, notifications, user mapping management, and manual vulnerability entry.

--- a/docs/E2E_EXCEPTION_WORKFLOW_TEST.md
+++ b/docs/E2E_EXCEPTION_WORKFLOW_TEST.md
@@ -1,7 +1,7 @@
 # E2E Vulnerability Exception Workflow Test
 
 **Feature**: 063-e2e-vuln-exception
-**Last Updated**: 2026-04-16
+**Last Updated**: 2026-04-23
 
 This document describes how to run the end-to-end test for the vulnerability exception workflow.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,6 +1,6 @@
 # MCP (Model Context Protocol) Integration Guide
 
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-04-23
 **Version:** 5.1
 
 This guide covers integrating Secman with AI assistants (Claude Desktop, Claude Code, ChatGPT, etc.) using the Model Context Protocol (MCP).
@@ -34,7 +34,7 @@ Secman supports the Model Context Protocol (MCP), allowing AI assistants to prog
 - **Vulnerability Data** - Search vulnerabilities by severity, CVE, or affected asset
 - **Scan Results** - Review network scan history and discovered services
 
-The MCP server exposes **53 tools** for comprehensive security management workflows.
+The MCP server exposes **55 tools** for comprehensive security management workflows.
 
 ### Prerequisites
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Security requirement and risk assessment management tool.
 
-**Last Updated:** 2026-04-22
+**Last Updated:** 2026-04-23
 
 ---
 

--- a/docs/S3_USER_MAPPING_IMPORT.md
+++ b/docs/S3_USER_MAPPING_IMPORT.md
@@ -1,7 +1,7 @@
 # S3 User Mapping Import
 
 **Feature**: 065-s3-user-mapping-import
-**Last Updated**: 2026-04-16
+**Last Updated**: 2026-04-23
 
 Import user mappings (domain and AWS account associations) directly from CSV or JSON files stored in AWS S3 buckets via the CLI.
 

--- a/scriptpp/install/db/README.md
+++ b/scriptpp/install/db/README.md
@@ -44,7 +44,7 @@ The scripts create a database setup matching the application defaults:
 
 This configuration is used by:
 - `src/backendng/src/main/resources/application.yml` - Backend database configuration
-- `docker-compose.yml` - Docker Compose database service
+- `docker/` - Docker container setup scripts
 - All database management scripts in this directory
 
 Override via environment variables: `DB_USERNAME`, `DB_PASSWORD`, `DB_CONNECT`
@@ -81,7 +81,7 @@ The auto-generated password is printed to the **backend console output** on firs
 ## Security Notes
 
 - **Database password:** Change `CHANGEME` to a strong password in production. Set via `DB_PASSWORD` environment variable.
-- **Admin password:** The default admin password (`password`) must be changed immediately after first login.
+- **Admin password:** The auto-generated admin password (printed to console on first startup) must be changed immediately after first login.
 - **Privileges:** The `secman` database user is granted only the privileges needed for application operation (no SUPER, GRANT, or global privileges).
 - **Localhost only:** The database user is restricted to localhost connections.
 - See `docs/ENVIRONMENT.md` for the full production security checklist.

--- a/scriptpp/mcp/README.md
+++ b/scriptpp/mcp/README.md
@@ -7,7 +7,7 @@ A standalone Go client that communicates with the Secman MCP server using JSON-R
 ```bash
 export SECMAN_BASE_URL=http://localhost:8080   # default
 export SECMAN_API_KEY=sk-your-api-key          # required
-export SECMAN_USER_EMAIL=admin@example.com     # optional, for user delegation
+export SECMAN_USER_EMAIL=admin@example.com     # mandatory for data-accessing tools
 ```
 
 ## Usage

--- a/scripts/mcp/README.md
+++ b/scripts/mcp/README.md
@@ -7,7 +7,7 @@ A standalone Go client that communicates with the Secman MCP server using JSON-R
 ```bash
 export SECMAN_BASE_URL=http://localhost:8080   # default
 export SECMAN_API_KEY=sk-your-api-key          # required
-export SECMAN_USER_EMAIL=admin@example.com     # optional, for user delegation
+export SECMAN_USER_EMAIL=admin@example.com     # mandatory for data-accessing tools
 ```
 
 ## Usage


### PR DESCRIPTION
… documentation

- Update controller count from 63 to 62 (README, ARCHITECTURE)
- Update MCP tool count from 53 to 55 (README, MCP)
- Update last-updated dates from 2026-04-16 to 2026-04-23 (CLI, E2E, S3)
- Update last-updated dates from 2026-04-22 to 2026-04-23 (ARCHITECTURE, MCP, docs/README)
- Fix scriptpp/install/db/README: replace docker-compose.yml reference with docker/
- Fix scriptpp/install/db/README: correct admin password description from hardcoded to auto-generated
- Fix MCP Go client READMEs: mark SECMAN_USER_EMAIL as mandatory (not optional)

https://claude.ai/code/session_01YEAKe3JzHPBqJfFQ3jgcHM