### PR TITLE
Route skill start/stop through ./scriptpp/

### DIFF
--- a/.claude/skills/admin-asset-e2e/SKILL.md
+++ b/.claude/skills/admin-asset-e2e/SKILL.md
@@ -113,8 +113,11 @@ Fix in priority order: **backend errors first**, then frontend.
 
 #### Restart Rules
 
-- `backend` → kill process, re-run start command, wait for health check
-- `frontend` → Astro/Vite hot-reloads. Wait 3 seconds, then proceed.
+- `backend` → run `./scriptpp/stopbackenddev.sh`, then `./scriptpp/startbackenddev.sh`,
+  wait for health check. Never `kill` inline.
+- `frontend` → Astro/Vite hot-reloads. Wait 3 seconds, then proceed. If a full
+  restart is required, use `./scriptpp/stopfrontenddev.sh` then
+  `./scriptpp/startfrontenddev.sh`.
 - `test` → no service restart needed.
 
 #### Guard Rails
@@ -125,7 +128,8 @@ Fix in priority order: **backend errors first**, then frontend.
 
 ### Phase 4 — Teardown & Report
 
-- Kill backend and frontend processes.
+- Stop backend and frontend via `./scriptpp/stopbackenddev.sh` and
+  `./scriptpp/stopfrontenddev.sh` (never raw `kill`).
 - Print a summary table:
 
 ```

--- a/.claude/skills/e2eexception/SKILL.md
+++ b/.claude/skills/e2eexception/SKILL.md
@@ -127,17 +127,17 @@ On **any** failure:
 
 #### Step 3a: Stop Both Services
 
-```bash
-# Kill backend
-kill $BACKEND_PID 2>/dev/null
-lsof -ti :8080 | xargs kill -9 2>/dev/null
+Always stop via the canonical scripts in `./scriptpp/` — never call `kill`
+or `lsof | xargs kill` inline:
 
-# Kill frontend
-kill $FRONTEND_PID 2>/dev/null
-lsof -ti :4321 | xargs kill -9 2>/dev/null
+```bash
+./scriptpp/stopbackenddev.sh
+./scriptpp/stopfrontenddev.sh
 ```
 
-Wait 3 seconds for processes to fully terminate.
+Both scripts target the dev ports (8080 and 4321), graceful-kill first, then
+force-kill if anything is still listening. They are no-ops when nothing is
+running. Wait 3 seconds for processes to fully terminate.
 
 #### Step 3b: Diagnose and Fix
 
@@ -200,7 +200,8 @@ Go back to Phase 2 and re-run the test script. Increment the iteration counter.
 
 ### Phase 4 — Teardown & Report
 
-- Kill backend and frontend processes.
+- Stop backend and frontend via `./scriptpp/stopbackenddev.sh` and
+  `./scriptpp/stopfrontenddev.sh` (never raw `kill`).
 - Print a summary table:
 
 ```

--- a/.claude/skills/e2ejs/SKILL.md
+++ b/.claude/skills/e2ejs/SKILL.md
@@ -199,12 +199,12 @@ For each failure, fix in priority order: **backend errors first**, then frontend
 
 After applying fixes (whether backend or frontend):
 
-1. **Kill the backend process** — find and kill the entire process tree:
+1. **Stop the backend** via the canonical script (handles graceful + force kill,
+   port 8080):
    ```bash
-   kill $BACKEND_PID
-   # Also kill any orphaned gradle/java processes on port 8080
-   lsof -ti :8080 | xargs kill -9 2>/dev/null
+   ./scriptpp/stopbackenddev.sh
    ```
+   Never call `kill` or `lsof | xargs kill` inline — always go through the script.
 2. **Restart backend**:
    ```bash
    nohup ./scriptpp/startbackenddev.sh > .e2e-logs/backend.log 2>&1 &
@@ -230,7 +230,8 @@ error count decreased.
 
 ### Phase 4 — Teardown & Report
 
-- Kill backend and frontend processes.
+- Stop backend and frontend via `./scriptpp/stopbackenddev.sh` and
+  `./scriptpp/stopfrontenddev.sh` (never raw `kill`).
 - Leave any user-managed local reverse proxy alone.
 - Print a summary table:
 

--- a/scriptpp/stopbackenddev.sh
+++ b/scriptpp/stopbackenddev.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Stop dev-mode backend (gradle :backendng:run) by killing whatever is bound to port 8080.
+# Companion to ./scriptpp/startbackenddev.sh — never targets the systemd service.
+
+set -u
+PORT=8080
+PIDS=$(lsof -ti :"$PORT" 2>/dev/null || true)
+
+if [ -z "$PIDS" ]; then
+  echo "No backend dev process listening on port $PORT."
+  exit 0
+fi
+
+echo "Stopping backend dev process(es) on port $PORT: $PIDS"
+kill $PIDS 2>/dev/null || true
+
+for _ in 1 2 3 4 5; do
+  sleep 1
+  REMAINING=$(lsof -ti :"$PORT" 2>/dev/null || true)
+  [ -z "$REMAINING" ] && break
+done
+
+REMAINING=$(lsof -ti :"$PORT" 2>/dev/null || true)
+if [ -n "$REMAINING" ]; then
+  echo "Force-killing remaining process(es) on port $PORT: $REMAINING"
+  kill -9 $REMAINING 2>/dev/null || true
+fi

--- a/scriptpp/stopfrontend.sh
+++ b/scriptpp/stopfrontend.sh
@@ -1,1 +1,1 @@
-sudo systemctl stop secman-backend.service
+sudo systemctl stop secman-frontend.service

--- a/scriptpp/stopfrontenddev.sh
+++ b/scriptpp/stopfrontenddev.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Stop dev-mode frontend (npm run dev / Vite / Astro) by killing whatever is bound to port 4321.
+# Companion to ./scriptpp/startfrontenddev.sh — never targets the systemd service.
+
+set -u
+PORT=4321
+PIDS=$(lsof -ti :"$PORT" 2>/dev/null || true)
+
+if [ -z "$PIDS" ]; then
+  echo "No frontend dev process listening on port $PORT."
+  exit 0
+fi
+
+echo "Stopping frontend dev process(es) on port $PORT: $PIDS"
+kill $PIDS 2>/dev/null || true
+
+for _ in 1 2 3 4 5; do
+  sleep 1
+  REMAINING=$(lsof -ti :"$PORT" 2>/dev/null || true)
+  [ -z "$REMAINING" ] && break
+done
+
+REMAINING=$(lsof -ti :"$PORT" 2>/dev/null || true)
+if [ -n "$REMAINING" ]; then
+  echo "Force-killing remaining process(es) on port $PORT: $REMAINING"
+  kill -9 $REMAINING 2>/dev/null || true
+fi


### PR DESCRIPTION
Add stopbackenddev.sh / stopfrontenddev.sh to mirror the existing dev-mode
start scripts and fix the stopfrontend.sh typo that targeted the backend
service. Update e2eexception, admin-asset-e2e and e2ejs skills to invoke
these canonical scripts instead of inline kill/lsof commands so every
start/stop of backend and frontend goes through ./scriptpp/.