### PR TITLE
feat(mcp): expose remaining vulnerability exception endpoints as MCP …

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -46,6 +46,12 @@ class McpToolRegistry(
     @Inject private val approveExceptionRequestTool: ApproveExceptionRequestTool,
     @Inject private val rejectExceptionRequestTool: RejectExceptionRequestTool,
     @Inject private val cancelExceptionRequestTool: CancelExceptionRequestTool,
+    @Inject private val getExceptionRequestTool: GetExceptionRequestTool,
+    @Inject private val getMyExceptionRequestSummaryTool: GetMyExceptionRequestSummaryTool,
+    @Inject private val getExceptionRequestStatisticsTool: GetExceptionRequestStatisticsTool,
+    @Inject private val deleteExceptionRequestTool: DeleteExceptionRequestTool,
+    @Inject private val reconcileExceptionRequestsTool: ReconcileExceptionRequestsTool,
+    @Inject private val listVulnerabilityExceptionsTool: ListVulnerabilityExceptionsTool,
     // Feature 063: MCP Tools for E2E Vulnerability Exception Workflow
     @Inject private val deleteAllAssetsTool: DeleteAllAssetsTool,
     @Inject private val addVulnerabilityTool: AddVulnerabilityTool,
@@ -129,6 +135,12 @@ class McpToolRegistry(
             approveExceptionRequestTool,
             rejectExceptionRequestTool,
             cancelExceptionRequestTool,
+            getExceptionRequestTool,
+            getMyExceptionRequestSummaryTool,
+            getExceptionRequestStatisticsTool,
+            deleteExceptionRequestTool,
+            reconcileExceptionRequestsTool,
+            listVulnerabilityExceptionsTool,
             // Feature 063: MCP Tools for E2E Vulnerability Exception Workflow
             deleteAllAssetsTool,
             addVulnerabilityTool,
@@ -349,6 +361,24 @@ class McpToolRegistry(
             }
             "cancel_exception_request" -> {
                 permissions.contains(McpPermission.VULNERABILITIES_READ) // Ownership check in tool
+            }
+            "get_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Ownership/role check in tool
+            }
+            "get_my_exception_request_summary" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Any authenticated user (own data)
+            }
+            "get_exception_request_statistics" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // ADMIN/SECCHAMPION role checked in tool
+            }
+            "delete_exception_request" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // Ownership check in tool
+            }
+            "reconcile_exception_requests" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // ADMIN role checked in tool
+            }
+            "list_vulnerability_exceptions" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // ADMIN/SECCHAMPION/VULN role checked in tool
             }
 
             // Feature 063: MCP Tools for E2E Vulnerability Exception Workflow

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteExceptionRequestTool.kt
@@ -1,0 +1,79 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool to permanently delete an exception request owned by the delegated user.
+ *
+ * Mirrors DELETE /api/vulnerability-exception-requests/{id}/delete.
+ *
+ * Behaviour:
+ * - For APPROVED requests, the associated VulnerabilityException is removed first
+ *   (so the CVE is no longer excepted), then the request row itself is deleted.
+ * - For other statuses, only the request row is deleted.
+ * - Pending count is republished if the deleted request was PENDING.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Only the original requester can delete the request (enforced by service)
+ */
+@Singleton
+class DeleteExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "delete_exception_request"
+    override val description = "Permanently delete one of your own exception requests; for APPROVED requests this also removes the underlying exception (requires User Delegation)"
+    override val operation = McpOperation.DELETE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("requestId"),
+        "properties" to mapOf(
+            "requestId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the exception request to delete"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            val requestId = (arguments["requestId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "requestId is required")
+
+            exceptionRequestService.deleteRequest(
+                requestId = requestId,
+                requesterUserId = context.delegatedUserId!!,
+                clientIp = null
+            )
+
+            return McpToolResult.success(
+                mapOf(
+                    "requestId" to requestId,
+                    "message" to "Exception request deleted successfully"
+                )
+            )
+        } catch (e: IllegalArgumentException) {
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error("NOT_FOUND", message)
+                message.contains("original requester") -> McpToolResult.error("FORBIDDEN", message)
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to delete request: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetExceptionRequestStatisticsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetExceptionRequestStatisticsTool.kt
@@ -1,0 +1,95 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.ExceptionRequestStatisticsService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool returning analytics for vulnerability exception requests.
+ *
+ * Mirrors GET /api/vulnerability-exception-requests/statistics.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN or SECCHAMPION role required
+ */
+@Singleton
+class GetExceptionRequestStatisticsTool(
+    @Inject private val statisticsService: ExceptionRequestStatisticsService
+) : McpTool {
+
+    override val name = "get_exception_request_statistics"
+    override val description = "Get exception-request analytics: approval rate, median approval time, status counts, top requesters/CVEs (ADMIN/SECCHAMPION, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "dateRange" to mapOf(
+                "type" to "string",
+                "enum" to listOf("7days", "30days", "90days", "alltime"),
+                "description" to "Date range to aggregate over (default: 30days)"
+            ),
+            "topLimit" to mapOf(
+                "type" to "number",
+                "description" to "Maximum number of top requesters/CVEs to return (default: 10, max: 50)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        val hasApprovalRole = context.isAdmin ||
+            context.delegatedUserRoles?.contains("SECCHAMPION") == true
+        if (!hasApprovalRole) {
+            return McpToolResult.error(
+                "APPROVAL_ROLE_REQUIRED",
+                "ADMIN or SECCHAMPION role required to view exception statistics"
+            )
+        }
+
+        try {
+            val dateRange = (arguments["dateRange"] as? String) ?: "30days"
+            if (dateRange !in listOf("7days", "30days", "90days", "alltime")) {
+                return McpToolResult.error(
+                    "VALIDATION_ERROR",
+                    "Invalid dateRange. Must be one of: 7days, 30days, 90days, alltime"
+                )
+            }
+            val topLimit = ((arguments["topLimit"] as? Number)?.toInt() ?: 10).coerceIn(1, 50)
+
+            val approvalRate = statisticsService.getApprovalRate(dateRange)
+            val avgApprovalTime = statisticsService.getAverageApprovalTime(dateRange)
+            val byStatus = statisticsService.getRequestsByStatus(dateRange)
+            val topRequesters = statisticsService.getTopRequesters(topLimit, dateRange)
+            val topCves = statisticsService.getTopCVEs(topLimit, dateRange)
+            val totalRequests = byStatus.values.sum()
+
+            return McpToolResult.success(
+                mapOf(
+                    "dateRange" to dateRange,
+                    "totalRequests" to totalRequests,
+                    "approvalRatePercent" to approvalRate,
+                    "averageApprovalTimeHours" to avgApprovalTime,
+                    "requestsByStatus" to byStatus.mapKeys { it.key.name },
+                    "topRequesters" to topRequesters.map { (username, count) ->
+                        mapOf("username" to username, "count" to count)
+                    },
+                    "topCVEs" to topCves.map { (cveId, count) ->
+                        mapOf("cveId" to cveId, "count" to count)
+                    }
+                )
+            )
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to fetch statistics: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetExceptionRequestTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetExceptionRequestTool.kt
@@ -1,0 +1,104 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.UserRepository
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for fetching a single vulnerability exception request by its ID.
+ *
+ * Mirrors GET /api/vulnerability-exception-requests/{id}.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Requesters can view their own requests
+ * - ADMIN or SECCHAMPION can view any request
+ */
+@Singleton
+class GetExceptionRequestTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService,
+    @Inject private val userRepository: UserRepository
+) : McpTool {
+
+    override val name = "get_exception_request"
+    override val description = "Get a vulnerability exception request by ID (requires User Delegation; requester or ADMIN/SECCHAMPION)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "required" to listOf("requestId"),
+        "properties" to mapOf(
+            "requestId" to mapOf(
+                "type" to "number",
+                "description" to "ID of the exception request to fetch"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            val requestId = (arguments["requestId"] as? Number)?.toLong()
+                ?: return McpToolResult.error("VALIDATION_ERROR", "requestId is required")
+
+            val request = exceptionRequestService.getRequestById(requestId)
+
+            // Access control: owner or ADMIN/SECCHAMPION
+            val isAdminOrSecChampion = context.isAdmin ||
+                context.delegatedUserRoles?.contains("SECCHAMPION") == true
+            val username = userRepository.findById(context.delegatedUserId!!).orElse(null)?.username
+            val isOwner = username != null && request.requestedByUsername == username
+            if (!isOwner && !isAdminOrSecChampion) {
+                return McpToolResult.error(
+                    "FORBIDDEN",
+                    "You can only view your own exception requests"
+                )
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "request" to mapOf(
+                        "id" to request.id,
+                        "vulnerabilityId" to request.vulnerabilityId,
+                        "vulnerabilityCve" to request.vulnerabilityCve,
+                        "assetName" to request.assetName,
+                        "assetIp" to request.assetIp,
+                        "requestedByUsername" to request.requestedByUsername,
+                        "subject" to request.subject.name,
+                        "scope" to request.scope.name,
+                        "subjectValue" to request.subjectValue,
+                        "scopeValue" to request.scopeValue,
+                        "assetId" to request.assetId,
+                        "reason" to request.reason,
+                        "expirationDate" to request.expirationDate.toString(),
+                        "status" to request.status.name,
+                        "autoApproved" to request.autoApproved,
+                        "reviewedByUsername" to request.reviewedByUsername,
+                        "reviewDate" to request.reviewDate?.toString(),
+                        "reviewComment" to request.reviewComment,
+                        "createdAt" to request.createdAt.toString(),
+                        "updatedAt" to request.updatedAt.toString()
+                    )
+                )
+            )
+
+        } catch (e: IllegalArgumentException) {
+            val message = e.message ?: "Validation failed"
+            return when {
+                message.contains("not found") -> McpToolResult.error("NOT_FOUND", message)
+                else -> McpToolResult.error("VALIDATION_ERROR", message)
+            }
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to fetch request: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestSummaryTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetMyExceptionRequestSummaryTool.kt
@@ -1,0 +1,56 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool returning the delegated user's exception-request counts by status.
+ *
+ * Mirrors GET /api/vulnerability-exception-requests/my/summary.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - Any authenticated user gets a summary scoped to their own requests
+ */
+@Singleton
+class GetMyExceptionRequestSummaryTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "get_my_exception_request_summary"
+    override val description = "Get summary counts of your own exception requests by status (requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        try {
+            val summary = exceptionRequestService.getUserRequestSummary(context.delegatedUserId!!)
+            return McpToolResult.success(
+                mapOf(
+                    "totalRequests" to summary.totalRequests,
+                    "approvedCount" to summary.approvedCount,
+                    "pendingCount" to summary.pendingCount,
+                    "rejectedCount" to summary.rejectedCount,
+                    "expiredCount" to summary.expiredCount,
+                    "cancelledCount" to summary.cancelledCount
+                )
+            )
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to fetch summary: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListVulnerabilityExceptionsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ListVulnerabilityExceptionsTool.kt
@@ -1,0 +1,133 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.domain.VulnerabilityException
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool listing approved VulnerabilityException rows (the actual exceptions in
+ * effect, not the request workflow).
+ *
+ * Mirrors the read-only view used by the admin UI to inspect what is currently
+ * suppressed. Supports optional filtering by activity, subject, and scope.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN, SECCHAMPION, or VULN role required
+ */
+@Singleton
+class ListVulnerabilityExceptionsTool(
+    @Inject private val vulnerabilityExceptionService: VulnerabilityExceptionService
+) : McpTool {
+
+    override val name = "list_vulnerability_exceptions"
+    override val description = "List vulnerability exceptions currently in effect, with optional filters (ADMIN/SECCHAMPION/VULN, requires User Delegation)"
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "activeOnly" to mapOf(
+                "type" to "boolean",
+                "description" to "If true, only return non-expired exceptions (default: false)"
+            ),
+            "subject" to mapOf(
+                "type" to "string",
+                "enum" to listOf("ALL_VULNS", "PRODUCT", "CVE"),
+                "description" to "Filter by subject (what is excepted)"
+            ),
+            "scope" to mapOf(
+                "type" to "string",
+                "enum" to listOf("GLOBAL", "IP", "ASSET", "AWS_ACCOUNT"),
+                "description" to "Filter by scope (where the exception applies)"
+            ),
+            "includeAffectedCount" to mapOf(
+                "type" to "boolean",
+                "description" to "If true, include the count of vulnerabilities each exception currently matches (default: true)"
+            )
+        )
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        val roles = context.delegatedUserRoles ?: emptySet()
+        val hasReadRole = context.isAdmin ||
+            roles.contains("SECCHAMPION") ||
+            roles.contains("VULN")
+        if (!hasReadRole) {
+            return McpToolResult.error(
+                "READ_ROLE_REQUIRED",
+                "ADMIN, SECCHAMPION, or VULN role required to list vulnerability exceptions"
+            )
+        }
+
+        try {
+            val activeOnly = arguments["activeOnly"] as? Boolean ?: false
+            val includeAffectedCount = arguments["includeAffectedCount"] as? Boolean ?: true
+
+            val subject = (arguments["subject"] as? String)?.let {
+                try { VulnerabilityException.Subject.valueOf(it) }
+                catch (_: IllegalArgumentException) {
+                    return McpToolResult.error(
+                        "VALIDATION_ERROR",
+                        "Invalid subject. Must be one of: ALL_VULNS, PRODUCT, CVE"
+                    )
+                }
+            }
+            val scope = (arguments["scope"] as? String)?.let {
+                try { VulnerabilityException.Scope.valueOf(it) }
+                catch (_: IllegalArgumentException) {
+                    return McpToolResult.error(
+                        "VALIDATION_ERROR",
+                        "Invalid scope. Must be one of: GLOBAL, IP, ASSET, AWS_ACCOUNT"
+                    )
+                }
+            }
+
+            val exceptions = vulnerabilityExceptionService.getAllExceptions(
+                activeOnly = activeOnly,
+                subject = subject,
+                scope = scope,
+                includeAffectedCount = includeAffectedCount
+            )
+
+            val items = exceptions.map { dto ->
+                mapOf(
+                    "id" to dto.id,
+                    "subject" to dto.subject.name,
+                    "scope" to dto.scope.name,
+                    "subjectValue" to dto.subjectValue,
+                    "scopeValue" to dto.scopeValue,
+                    "assetId" to dto.assetId,
+                    "assetName" to dto.assetName,
+                    "expirationDate" to dto.expirationDate?.toString(),
+                    "reason" to dto.reason,
+                    "createdBy" to dto.createdBy,
+                    "createdAt" to dto.createdAt?.toString(),
+                    "updatedAt" to dto.updatedAt?.toString(),
+                    "isActive" to dto.isActive,
+                    "affectedVulnerabilityCount" to dto.affectedVulnerabilityCount
+                )
+            }
+
+            return McpToolResult.success(
+                mapOf(
+                    "exceptions" to items,
+                    "totalCount" to items.size,
+                    "activeOnly" to activeOnly
+                )
+            )
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Failed to list exceptions: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ReconcileExceptionRequestsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ReconcileExceptionRequestsTool.kt
@@ -1,0 +1,60 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityExceptionRequestService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool to rebuild missing VulnerabilityException rows for APPROVED exception
+ * requests. Mirrors POST /api/vulnerability-exception-requests/reconcile.
+ *
+ * Access Control:
+ * - Requires User Delegation
+ * - ADMIN role required (operator maintenance only)
+ */
+@Singleton
+class ReconcileExceptionRequestsTool(
+    @Inject private val exceptionRequestService: VulnerabilityExceptionRequestService
+) : McpTool {
+
+    override val name = "reconcile_exception_requests"
+    override val description = "Rebuild missing VulnerabilityException rows for APPROVED requests (ADMIN-only operator maintenance, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_ROLE_REQUIRED",
+                "ADMIN role required to reconcile exception requests"
+            )
+        }
+
+        try {
+            val report = exceptionRequestService.reconcileApprovedRequests()
+            return McpToolResult.success(
+                mapOf(
+                    "scanned" to report.scanned,
+                    "alreadyConsistent" to report.alreadyConsistent,
+                    "repaired" to report.repaired,
+                    "failed" to report.failed,
+                    "failureReasons" to report.failureReasons.mapKeys { it.key.toString() }
+                )
+            )
+        } catch (e: Exception) {
+            return McpToolResult.error("EXECUTION_ERROR", "Reconcile failed: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
…tools

The REST API for vulnerability exception requests already covered the full lifecycle (create/approve/reject/cancel/list-mine/list-pending), but several view, delete, statistics, and maintenance endpoints had no MCP equivalent. This closes that gap so MCP clients can drive the entire approve/request/view workflow without falling back to the HTTP API.

New tools registered in McpToolRegistry:
- get_exception_request: fetch a single request by ID (owner or ADMIN/SECCHAMPION)
- get_my_exception_request_summary: status counts for the delegated user
- get_exception_request_statistics: approval rate, median time, top requesters/CVEs
- delete_exception_request: permanent deletion (owner-only; tears down the underlying VulnerabilityException for APPROVED rows)
- reconcile_exception_requests: ADMIN-only repair of missing exception rows
- list_vulnerability_exceptions: read-only view of approved exceptions in effect, filterable by activity/subject/scope (ADMIN/SECCHAMPION/VULN)

All tools require User Delegation and reuse existing service-layer access control (ownership, role checks, optimistic locking). No backend behaviour changes — these are thin MCP wrappers over already-tested service methods.

https://claude.ai/code/session_01WCz7ALpBsqn2PSFGo5bk8X