### PR TITLE
test(e2e): add full vulnerability+exception E2E loop covering MCP and…

### DIFF
--- a/.claude/skills/e2evulnexception/SKILL.md
+++ b/.claude/skills/e2evulnexception/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: e2evulnexception
+description: >
+  Run the full vulnerability + exception E2E test loop covering both MCP and
+  Web UI. Sets up a clean testbed with two users, two assets, and three
+  vulnerability rows; exercises the exception lifecycle (approve, reject,
+  cancel) plus authorization negatives via MCP; then verifies the same state
+  through the Astro/React UI with Playwright. Cleans up before and after.
+  Use this skill when the user says "run vuln exception e2e", "e2evulnexception",
+  "test vulnerability + exception workflow", or similar.
+context: fork
+---
+# E2E Vulnerability + Exception Full Workflow — Iterative Fix Loop
+
+You are an orchestration agent that brings up a full-stack environment, runs
+the **combined MCP + Web UI** vulnerability and exception lifecycle test, and
+**iteratively fixes every failure** until it passes or you've exhausted the
+retry budget.
+
+## Test Overview
+
+The driver script is
+`scriptpp/test/test-e2e-vuln-exception-full.sh`. It owns the testbed:
+
+**Users** (USER + VULN + REQ — no ADMIN/SECCHAMPION so requests stay PENDING):
+- `e2etestuser1` (`e2etestuser1@e2e.test`)
+- `e2etestuser2` (`e2etestuser2@e2e.test`)
+
+**Assets** (owner is a plain string username):
+- `testasset1` — owner `e2etestuser1`, ip `10.99.0.1`
+- `testasset2` — owner `e2etestuser2`, ip `10.99.0.2`
+
+**Vulnerabilities**:
+- `vuln1` — `CVE-E2E-0001` CRITICAL, `daysOpen=40` on `testasset1` (overdue, threshold = 30d)
+- `vuln2` — `CVE-E2E-0002` CRITICAL, `daysOpen=5` on **both** `testasset1` and `testasset2`
+
+**Phases inside the driver**:
+
+| Phase | What it covers |
+|------:|----------------|
+| 0 | Pre-run cleanup (idempotent — direct SQL on `users`, `asset`, `vulnerability`, `vulnerability_exception_request`, `exception_request_audit`, `outdated_asset_materialized_view`) |
+| 1 | MCP setup: `add_user` × 2, `create_asset` × 2, `add_vulnerability` × 3, materialized-view refresh |
+| 2 | MCP visibility/RBAC: `get_vulnerabilities` as user1, user2, admin |
+| 3 | MCP overdue: `get_overdue_assets` as user1, user2, admin |
+| 4 | MCP exception lifecycle — APPROVE path (user1 creates → admin approves → user1 sees APPROVED) |
+| 5 | MCP exception lifecycle — REJECT path (user2 creates → admin rejects with comment) |
+| 6 | MCP exception lifecycle — CANCEL path (user1 creates → user1 cancels) |
+| 7 | MCP authorization negatives: user2 cannot approve, user1 cannot create on user2's asset, missing `X-MCP-User-Email` |
+| 8 | Web UI (Playwright `tests/e2e/vuln-exception-full.spec.ts`): scoped visibility, my-requests states, approval dashboard |
+| (trap) | Post-run cleanup — runs even on failure |
+
+The shell driver calls MCP via `curl`/`jq` and shells out to `npx playwright`
+for Phase 8, passing the captured IDs/credentials through env vars.
+
+## High-Level Loop
+
+```
+1. Start backend   (./scriptpp/startbackenddev.sh)
+2. Start frontend  (./scriptpp/startfrontenddev.sh)
+3. Wait for both ports to be bound (8080 / 4321)
+4. Run the driver:
+     pass-cli run --env-file ./secmanpp.env -- \
+       ./scriptpp/test/test-e2e-vuln-exception-full.sh --verbose
+5. IF all green → done, report success
+6. IF failure →
+   a. STOP both services (./scriptpp/stopbackenddev.sh, ./scriptpp/stopfrontenddev.sh)
+   b. Diagnose backend vs frontend vs test
+   c. Apply the fix
+   d. RESTART both services
+   e. Go to step 4
+7. After 5 iterations without progress → stop and present summary
+```
+
+**CRITICAL RULE**: On any error, **stop both services first**, apply the fix,
+then **restart both** before retrying. Never edit code while services are
+running. (Frontend may hot-reload for trivial fixes, but the safe default is
+full restart for this skill.)
+
+## Detailed Instructions
+
+### Phase 1 — Environment Setup
+
+This skill is **pinned to Proton Pass** — start services via the wrapper
+scripts that source secrets via `pass-cli`. Never hardcode `localhost:8080`
+or `localhost:4321` in tests; the driver and Playwright config already
+respect `BASE_URL` / `FRONTEND_URL` / `SECMAN_BASE_URL`.
+
+| Setting                  | Default                           |
+| ------------------------ | --------------------------------- |
+| Backend start            | `./scriptpp/startbackenddev.sh`   |
+| Backend port             | `8080` (liveness via port binding)|
+| Backend wait timeout     | `120` seconds                     |
+| Frontend start           | `./scriptpp/startfrontenddev.sh`  |
+| Frontend port            | `4321` (liveness via port binding)|
+| Frontend wait timeout    | `60` seconds                      |
+
+**Starting services:**
+
+1. Create `.e2e-logs/` if it doesn't exist.
+2. **Check ports** — `lsof -iTCP:8080 -sTCP:LISTEN -n -P` and
+   `lsof -iTCP:4321 -sTCP:LISTEN -n -P`. If something is listening,
+   stop it via the canonical scripts (never `kill` inline).
+3. Start backend in background:
+   ```bash
+   nohup ./scriptpp/startbackenddev.sh > .e2e-logs/backend.log 2>&1 &
+   ```
+4. Start frontend in background:
+   ```bash
+   nohup ./scriptpp/startfrontenddev.sh > .e2e-logs/frontend.log 2>&1 &
+   ```
+5. **Wait for liveness via port binding** (not HTTP probes against localhost):
+   - Backend: poll `lsof -iTCP:8080 -sTCP:LISTEN -n -P` until non-empty (120s).
+   - Frontend: poll `lsof -iTCP:4321 -sTCP:LISTEN -n -P` until non-empty (60s).
+6. **Install Playwright deps** if missing:
+   ```bash
+   [ -d tests/e2e/node_modules ] || (cd tests/e2e && npm install)
+   ```
+   (Browsers should already be installed via
+   `npx playwright install chrome msedge` per `CLAUDE.md`.)
+
+### Phase 2 — Run Tests
+
+Run the driver with Proton Pass injection:
+
+```bash
+pass-cli run --env-file ./secmanpp.env -- \
+    ./scriptpp/test/test-e2e-vuln-exception-full.sh --verbose 2>&1 \
+    | tee .e2e-logs/e2e-vuln-exception-run-<N>.log
+```
+
+Where `<N>` is the iteration number (starting at 1).
+
+The driver consumes from env (already in `secmanpp.env`):
+- `SECMAN_MCP_KEY`, `SECMAN_ADMIN_EMAIL` — MCP auth + delegation
+- `SECMAN_ADMIN_NAME`, `SECMAN_ADMIN_PASS` — JWT for view refresh + UI login
+
+**Required tools on the system**: `curl`, `jq`, `mariadb`, `pass-cli`,
+`node`/`npx` (Playwright).
+
+### Phase 2.5 — Error Classification
+
+The driver emits structured `[PASS]` / `[FAIL]` / `[WARN]` / `[INFO]` lines.
+Classify the most recent failure:
+
+| Pattern                                                   | Category     | Action                                                           |
+| --------------------------------------------------------- | ------------ | ---------------------------------------------------------------- |
+| `MCP tool '...' failed`                                   | **backend**  | Fix tool handler in `src/backendng/.../mcp/tools/<Tool>.kt`      |
+| `[FAIL] user1 visibility wrong` etc.                      | **backend**  | Asset filter / RBAC service logic                                |
+| `[FAIL] admin overdue list mismatch`                      | **backend**  | Materialized view refresh, `OutdatedAssetService`                |
+| `[FAIL] Expected APPROVED, got ...`                       | **backend**  | `VulnerabilityExceptionRequestService` state machine             |
+| `[FAIL] Expected user2 approve to fail`                   | **backend**  | Role check missing in `ApproveExceptionRequestTool`              |
+| `Failed to create test user`                              | **backend**  | `AddUserTool` / unique constraint / event listener crash         |
+| `Cannot reach backend`                                    | **infra**    | Backend didn't start — read `.e2e-logs/backend.log`              |
+| `Frontend not reachable`                                  | **infra**    | Frontend didn't start — read `.e2e-logs/frontend.log`            |
+| Playwright `expect(body).toContain(CVE_*)` fails          | **frontend** | UI page didn't render — check page route, hydration, API call    |
+| Playwright login redirect timeout                         | **frontend** | Login form / auth handler regression                             |
+| Playwright `expected APPROVED|Approved`                   | **frontend** | `MyExceptionRequests.tsx` doesn't render status text             |
+
+### Phase 3 — Fix Loop (Stop-Fix-Restart)
+
+#### Step 3a: Stop Both Services
+
+```bash
+./scriptpp/stopbackenddev.sh
+./scriptpp/stopfrontenddev.sh
+```
+
+Wait 3 seconds for processes to terminate. Never call `kill` directly.
+
+#### Step 3b: Diagnose and Fix
+
+Fix priority: **backend first**, then frontend.
+
+**Key files for this test:**
+
+| Concern                                  | File                                                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| MCP tool registry                        | `src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt`                                |
+| Add user tool                            | `src/backendng/src/main/kotlin/com/secman/mcp/tools/AddUserTool.kt`                              |
+| Create asset tool                        | `src/backendng/src/main/kotlin/com/secman/mcp/tools/CreateAssetTool.kt`                          |
+| Add vulnerability tool                   | `src/backendng/src/main/kotlin/com/secman/mcp/tools/AddVulnerabilityTool.kt`                     |
+| Get vulnerabilities (RBAC filtering)     | `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetVulnerabilitiesTool.kt`                   |
+| Get overdue assets                       | `src/backendng/src/main/kotlin/com/secman/mcp/tools/GetOverdueAssetsTool.kt`                     |
+| Create / approve / reject / cancel       | `src/backendng/src/main/kotlin/com/secman/mcp/tools/{Create,Approve,Reject,Cancel}ExceptionRequestTool.kt` |
+| Exception request service                | `src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt`       |
+| Vulnerability service (cli-add)          | `src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt`                       |
+| Asset access filter                      | `src/backendng/src/main/kotlin/com/secman/service/AssetFilterService.kt`                         |
+| Materialized view refresh                | `src/backendng/src/main/kotlin/com/secman/service/MaterializedViewRefreshService.kt`             |
+| Vulnerability config (overdue threshold) | `src/backendng/src/main/kotlin/com/secman/domain/VulnerabilityConfig.kt`                         |
+| Exception status enum                    | `src/backendng/src/main/kotlin/com/secman/domain/ExceptionRequestStatus.kt`                      |
+| My exception requests UI                 | `src/frontend/src/components/MyExceptionRequests.tsx`                                            |
+| Approval dashboard UI                    | `src/frontend/src/components/ExceptionApprovalDashboard.tsx`                                     |
+| Account vulnerabilities UI               | `src/frontend/src/pages/account-vulns.astro`                                                     |
+| Outdated assets UI                       | `src/frontend/src/pages/outdated-assets.astro`                                                   |
+| Driver script                            | `scriptpp/test/test-e2e-vuln-exception-full.sh`                                                  |
+| Playwright spec                          | `tests/e2e/vuln-exception-full.spec.ts`                                                          |
+
+**Diagnosis steps:**
+
+1. Read the latest log: `.e2e-logs/e2e-vuln-exception-run-<N>.log`. Find the
+   first `[FAIL]` and the surrounding `[INFO]` / `[DEBUG]` context.
+2. If backend-related, also read `.e2e-logs/backend.log` for stack traces near
+   the timestamp of the failure.
+3. Trace the MCP call: shell sends `tools/call` → `McpController` →
+   `McpToolService` → tool class → service → repository.
+4. For UI failures, the Playwright report is in `tests/e2e/playwright-report/`
+   (auto-opened only if you run with `--reporter=html`). Screenshots and
+   traces go to `tests/e2e/test-results/` (`screenshot: 'only-on-failure'`
+   and `trace: 'retain-on-failure'` per `playwright.config.ts`).
+5. Apply a **minimal** fix. Common categories:
+   - Missing tool registration in `McpToolRegistry`
+   - Null-pointer in service (missing `?.`/`?: default`)
+   - DTO/Serdeable shape mismatch in tool result vs assertion
+   - RBAC: delegation header not honored, role intersection wrong
+   - Materialized view refresh: trigger endpoint returning 5xx → wait fails
+     and overdue assertions break
+   - Frontend: API endpoint URL mismatch, missing `await fetch(...)`,
+     status text removed from rendering
+
+#### Step 3c: Restart Both
+
+```bash
+nohup ./scriptpp/startbackenddev.sh > .e2e-logs/backend.log 2>&1 &
+nohup ./scriptpp/startfrontenddev.sh > .e2e-logs/frontend.log 2>&1 &
+```
+
+Wait for ports `8080` and `4321` to be bound (same timeouts as Phase 1).
+
+#### Step 3d: Re-run
+
+Increment `<N>`, return to Phase 2.
+
+#### Step 3e: Guard Rails
+
+- Track which errors you've already attempted. If the **same error persists
+  after two attempts**, flag it for the user and move on (or stop).
+- After **5 total iterations**, stop and present a summary.
+- If the backend **fails to start** (port never binds), open `.e2e-logs/backend.log`
+  and fix compile/runtime errors before retrying. Don't loop on a broken backend.
+
+### Phase 4 — Teardown & Report
+
+The driver's `trap EXIT` handler already removes test data even on failure.
+After the loop:
+
+```bash
+./scriptpp/stopbackenddev.sh
+./scriptpp/stopfrontenddev.sh
+```
+
+Print a summary table:
+
+```
+| Iter | MCP phase failed | UI phase failed | Fix applied                                       |
+|------|------------------|-----------------|---------------------------------------------------|
+| 1    | Phase 4 (approve)| —               | VulnerabilityExceptionRequestService.kt:approve() |
+| 2    | —                | —               | — (all green)                                     |
+```
+
+If you stop short of green, list each remaining failure with:
+- The `[FAIL]` message
+- The file/line where you believe the root cause is
+- What you tried
+
+## Idempotency Verification
+
+Once green, **re-run the driver immediately** (same command) without doing any
+cleanup yourself. The trap and pre-run cleanup should mean the second pass is
+also green with zero fixes. If the second pass fails, treat it as a regression
+in the cleanup logic and fix `cleanup()` in
+`scriptpp/test/test-e2e-vuln-exception-full.sh`.
+
+## Important Notes
+
+- **Never commit or push** — only edit files locally. The user drives commits.
+- **Secrets via Proton Pass** — both `scriptpp/startbackenddev.sh`,
+  `scriptpp/startfrontenddev.sh`, and the test driver use `pass-cli run`.
+  Never hardcode credentials.
+- **No `localhost` literals in tests** — use `BASE_URL` / `FRONTEND_URL` /
+  `SECMAN_BASE_URL`. Liveness checks use port binding, not HTTP probes.
+- **Logs**: backend → `.e2e-logs/backend.log`; frontend → `.e2e-logs/frontend.log`;
+  driver → `.e2e-logs/e2e-vuln-exception-run-<N>.log`. The directory is gitignored.
+- **MariaDB**: cleanup uses `mariadb -h 127.0.0.1 -u secman -pCHANGEME secman`.
+  MariaDB must be running.
+- **Roles**: `e2etestuser1`/`e2etestuser2` MUST stay non-admin and non-secchampion
+  so exception requests land as PENDING. If they ever get auto-approved, check
+  the `roles` argument in Phase 1 and the auto-approve logic in
+  `VulnerabilityExceptionRequestService`.
+- **Overdue threshold** is `VulnerabilityConfig.reminderOneDays` (default 30).
+  `vuln1` is 40d (overdue) and `vuln2` is 5d (not). If the threshold changes,
+  update both this skill and the driver constants.

--- a/scriptpp/test/test-e2e-vuln-exception-full.sh
+++ b/scriptpp/test/test-e2e-vuln-exception-full.sh
@@ -1,0 +1,607 @@
+#!/usr/bin/env bash
+#
+# E2E Vulnerability + Exception Full Workflow Test (MCP + Web UI)
+#
+# Drives the full vulnerability management and exception lifecycle through both
+# the MCP JSON-RPC interface and the Astro/React web UI.
+#
+# Testbed:
+#   Users:  e2etestuser1, e2etestuser2 (USER+VULN+REQ — no ADMIN/SECCHAMPION)
+#   Assets: testasset1 (owner=e2etestuser1), testasset2 (owner=e2etestuser2)
+#   Vulns:  vuln1 = CVE-E2E-0001  CRITICAL  daysOpen=40  on testasset1 only (overdue)
+#           vuln2 = CVE-E2E-0002  CRITICAL  daysOpen=5   on testasset1 AND testasset2
+#
+# Cleanup runs both before (unconditional) and after (trap EXIT).
+#
+# Required env (resolved via pass-cli):
+#   SECMAN_MCP_KEY
+#   SECMAN_ADMIN_EMAIL
+#   SECMAN_ADMIN_NAME
+#   SECMAN_ADMIN_PASS
+# Optional:
+#   BASE_URL (default http://localhost:8080)
+#   FRONTEND_URL (default http://localhost:4321)
+#   SKIP_UI=true to skip Playwright phase
+#   VERBOSE=true for debug logging
+#
+# Usage:
+#   pass-cli run --env-file ./secmanpp.env -- ./scriptpp/test/test-e2e-vuln-exception-full.sh
+#   ./scriptpp/test/test-e2e-vuln-exception-full.sh --verbose
+#
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+BASE_URL="${BASE_URL:-${SECMAN_BACKEND_URL:-http://localhost:8080}}"
+FRONTEND_URL="${FRONTEND_URL:-http://localhost:4321}"
+SECMAN_MCP_KEY="${SECMAN_MCP_KEY:-}"
+ADMIN_USER_EMAIL="${SECMAN_ADMIN_EMAIL:-}"
+ADMIN_USERNAME="${SECMAN_ADMIN_NAME:-}"
+ADMIN_PASSWORD="${SECMAN_ADMIN_PASS:-}"
+VERBOSE="${VERBOSE:-false}"
+SKIP_UI="${SKIP_UI:-false}"
+
+# Test users — passwords are local-only (these accounts only exist for the test)
+USER1_USERNAME="e2etestuser1"
+USER1_EMAIL="e2etestuser1@e2e.test"
+USER1_PASSWORD="E2eTestPassword!1"
+
+USER2_USERNAME="e2etestuser2"
+USER2_EMAIL="e2etestuser2@e2e.test"
+USER2_PASSWORD="E2eTestPassword!2"
+
+# Test assets
+ASSET1_NAME="testasset1"
+ASSET1_IP="10.99.0.1"
+ASSET2_NAME="testasset2"
+ASSET2_IP="10.99.0.2"
+
+# Test vulnerabilities
+CVE_VULN1="CVE-E2E-0001"
+CVE_VULN2="CVE-E2E-0002"
+
+# Reason text — must be ≥50 chars per CreateExceptionRequestTool
+EXCEPTION_REASON_APPROVE="E2E test scenario: approving an exception while remediation is scheduled in the next maintenance window — automated test"
+EXCEPTION_REASON_REJECT="E2E test scenario: this request is expected to be rejected by the admin to verify the rejection lifecycle path end to end"
+EXCEPTION_REASON_CANCEL="E2E test scenario: the requester will cancel this request to verify the user-driven cancellation lifecycle path"
+
+# DB credentials (matches existing test scripts)
+DB_HOST="127.0.0.1"
+DB_USER="secman"
+DB_PASS="CHANGEME"
+DB_NAME="secman"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+START_TIME=$(date +%s)
+
+# Captured IDs (populated during run)
+USER1_ID=""
+USER2_ID=""
+ASSET1_ID=""
+ASSET2_ID=""
+VULN1_ID=""
+VULN2_A1_ID=""
+VULN2_A2_ID=""
+REQ_APPROVE_ID=""
+REQ_REJECT_ID=""
+REQ_CANCEL_ID=""
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+log()      { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_dbg()  { [[ "$VERBOSE" == "true" ]] && echo -e "${BLUE}[DEBUG]${NC} $1" >&2 || true; }
+ok()       { echo -e "${GREEN}[PASS]${NC} $1"; }
+warn()     { echo -e "${YELLOW}[WARN]${NC} $1"; }
+fail()     {
+    echo -e "${RED}[FAIL]${NC} $1"
+    echo -e "${RED}Test failed after $(( $(date +%s) - START_TIME ))s${NC}"
+    exit 1
+}
+
+usage() {
+    cat <<EOF
+E2E Vulnerability + Exception Full Workflow Test (MCP + Web UI)
+
+Usage:
+    $0 [--verbose|-v] [--skip-ui] [--help|-h]
+
+Environment:
+    BASE_URL              Backend URL (default http://localhost:8080)
+    FRONTEND_URL          Frontend URL (default http://localhost:4321)
+    SECMAN_MCP_KEY        MCP API key (required)
+    SECMAN_ADMIN_EMAIL    Admin email for delegation (required)
+    SECMAN_ADMIN_NAME     Admin username (required for UI phase)
+    SECMAN_ADMIN_PASS     Admin password (required for UI phase)
+    SKIP_UI=true          Skip Playwright UI phase
+    VERBOSE=true          Debug logging
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --help|-h)    usage ;;
+        --verbose|-v) VERBOSE=true; shift ;;
+        --skip-ui)    SKIP_UI=true; shift ;;
+        *) warn "Unknown option: $1"; shift ;;
+    esac
+done
+
+# =============================================================================
+# Pre-flight
+# =============================================================================
+
+for cmd in curl jq mariadb; do
+    command -v "$cmd" >/dev/null || fail "Required command missing: $cmd"
+done
+
+[[ -z "$SECMAN_MCP_KEY"   ]] && fail "SECMAN_MCP_KEY is required (use pass-cli run)"
+[[ -z "$ADMIN_USER_EMAIL" ]] && fail "SECMAN_ADMIN_EMAIL is required (use pass-cli run)"
+
+if ! curl -sf -o /dev/null --connect-timeout 5 "$BASE_URL" 2>/dev/null; then
+    # Some backends don't serve / so also try /api/mcp/capabilities (returns 401 but reachable)
+    if ! curl -s -o /dev/null --connect-timeout 5 "${BASE_URL}/api/mcp/capabilities" 2>/dev/null; then
+        fail "Cannot reach backend at $BASE_URL"
+    fi
+fi
+ok "Backend reachable at $BASE_URL"
+
+# =============================================================================
+# MCP helper
+# =============================================================================
+
+# mcp_call <tool_name> <json_arguments> [delegated_email] [--allow-error]
+# Returns the .result.content payload (object or unwrapped MCP-standard text).
+# By default, fails the test on any JSON-RPC error. With --allow-error, prints
+# the error JSON to stdout instead so the caller can assert on it.
+mcp_call() {
+    local tool="$1"
+    local args="$2"
+    local delegated="${3:-}"
+    local allow_error="${4:-}"
+
+    local headers=(-H "Content-Type: application/json" -H "X-MCP-API-Key: $SECMAN_MCP_KEY")
+    [[ -n "$delegated" ]] && headers+=(-H "X-MCP-User-Email: $delegated")
+
+    local body
+    body=$(jq -nc --arg tool "$tool" --argjson args "$args" \
+        '{jsonrpc:"2.0", id:("t-"+(now|tostring)), method:"tools/call", params:{name:$tool, arguments:$args}}')
+
+    log_dbg "MCP -> $tool delegated=${delegated:-<none>} args=$args"
+    local resp
+    resp=$(curl -sS -X POST "${BASE_URL}/api/mcp/tools/call" "${headers[@]}" -d "$body")
+    log_dbg "MCP <- $resp"
+
+    local err
+    err=$(echo "$resp" | jq -c '.error // empty')
+    if [[ -n "$err" && "$err" != "null" ]]; then
+        if [[ "$allow_error" == "--allow-error" ]]; then
+            echo "$resp" | jq -c '.error'
+            return 0
+        fi
+        local code msg
+        code=$(echo "$err" | jq -r '.code // "UNKNOWN"')
+        msg=$(echo  "$err" | jq -r '.message // "Unknown error"')
+        fail "MCP tool '$tool' failed: [$code] $msg"
+    fi
+
+    # Unwrap content (object) or array[0].text (MCP standard)
+    local content
+    content=$(echo "$resp" | jq -c '.result.content // empty')
+    if [[ -z "$content" || "$content" == "null" ]]; then
+        echo ""
+        return 0
+    fi
+    local kind
+    kind=$(echo "$content" | jq -r 'type')
+    if [[ "$kind" == "object" ]]; then
+        echo "$content"
+    elif [[ "$kind" == "array" ]]; then
+        echo "$content" | jq -r '.[0].text // empty'
+    else
+        echo "$content"
+    fi
+}
+
+# Get JWT for a username/password (used to trigger materialized view refresh)
+get_jwt() {
+    local user="$1"
+    local pass="$2"
+    curl -sS -X POST "${BASE_URL}/api/auth/login" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -nc --arg u "$user" --arg p "$pass" '{username:$u,password:$p}')" \
+        | jq -r '.token // empty'
+}
+
+trigger_view_refresh() {
+    log_dbg "Triggering materialized view refresh as admin..."
+    if [[ -z "$ADMIN_USERNAME" || -z "$ADMIN_PASSWORD" ]]; then
+        warn "SECMAN_ADMIN_NAME/PASS not set — skipping view refresh trigger"
+        return 0
+    fi
+    local token
+    token=$(get_jwt "$ADMIN_USERNAME" "$ADMIN_PASSWORD" || true)
+    if [[ -z "$token" ]]; then
+        warn "Could not get admin JWT; view refresh may be stale"
+        return 0
+    fi
+    curl -sS -X POST "${BASE_URL}/api/materialized-view-refresh/trigger" \
+        -H "Authorization: Bearer $token" >/dev/null 2>&1 || true
+    sleep 5
+}
+
+db_exec() {
+    mariadb -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" -N -e "$1" 2>/dev/null || true
+}
+
+# =============================================================================
+# Cleanup (idempotent — safe to run multiple times)
+# =============================================================================
+
+cleanup() {
+    local phase="${1:-post-run}"
+    log "Cleanup ($phase): removing test users, assets, exception requests..."
+
+    # 1) Delete exception requests + audit rows for our test users (by username)
+    local user_ids_csv
+    user_ids_csv=$(db_exec "SELECT GROUP_CONCAT(id) FROM users WHERE username IN ('${USER1_USERNAME}','${USER2_USERNAME}');")
+    if [[ -n "$user_ids_csv" && "$user_ids_csv" != "NULL" ]]; then
+        db_exec "
+            DELETE FROM exception_request_audit
+              WHERE actor_user_id IN ($user_ids_csv);
+            DELETE FROM vulnerability_exception_request
+              WHERE requested_by_user_id IN ($user_ids_csv)
+                 OR reviewed_by_user_id IN ($user_ids_csv);
+        "
+    fi
+
+    # 2) Delete test assets via direct SQL (cascades vulnerabilities through FKs)
+    local asset_ids_csv
+    asset_ids_csv=$(db_exec "SELECT GROUP_CONCAT(id) FROM asset WHERE name IN ('${ASSET1_NAME}','${ASSET2_NAME}');")
+    if [[ -n "$asset_ids_csv" && "$asset_ids_csv" != "NULL" ]]; then
+        # Also wipe any exception requests still tied to these assets (safety)
+        db_exec "
+            DELETE FROM exception_request_audit
+              WHERE request_id IN (
+                SELECT id FROM vulnerability_exception_request
+                 WHERE vulnerability_id IN (SELECT id FROM vulnerability WHERE asset_id IN ($asset_ids_csv))
+                    OR asset_id IN ($asset_ids_csv)
+              );
+            DELETE FROM vulnerability_exception_request
+              WHERE vulnerability_id IN (SELECT id FROM vulnerability WHERE asset_id IN ($asset_ids_csv))
+                 OR asset_id IN ($asset_ids_csv);
+            DELETE FROM vulnerability WHERE asset_id IN ($asset_ids_csv);
+            DELETE FROM asset WHERE id IN ($asset_ids_csv);
+        "
+    fi
+
+    # 3) Delete test users
+    if [[ -n "$user_ids_csv" && "$user_ids_csv" != "NULL" ]]; then
+        db_exec "DELETE FROM user_roles WHERE user_id IN ($user_ids_csv);"
+        db_exec "DELETE FROM users WHERE id IN ($user_ids_csv);"
+    fi
+
+    # 4) Refresh materialized view so deleted assets disappear
+    db_exec "TRUNCATE TABLE outdated_asset_materialized_view;"
+
+    log_dbg "Cleanup ($phase) done"
+}
+
+# Post-run cleanup runs on any exit, including failure
+trap 'cleanup post-run' EXIT
+
+# =============================================================================
+# Phase 0: Pre-run cleanup
+# =============================================================================
+
+log "=== Phase 0: pre-run cleanup ==="
+cleanup pre-run
+ok "Pre-run cleanup complete"
+
+# =============================================================================
+# Phase 1 (MCP): Setup
+# =============================================================================
+
+log "=== Phase 1: MCP setup ==="
+
+# Create users
+res=$(mcp_call "add_user" "$(jq -nc \
+    --arg u "$USER1_USERNAME" --arg e "$USER1_EMAIL" --arg p "$USER1_PASSWORD" \
+    '{username:$u,email:$e,password:$p,roles:["USER","VULN","REQ"]}')" "$ADMIN_USER_EMAIL")
+USER1_ID=$(echo "$res" | jq -r '.user.id')
+[[ -z "$USER1_ID" || "$USER1_ID" == "null" ]] && fail "Failed to create $USER1_USERNAME: $res"
+ok "Created user $USER1_USERNAME (id=$USER1_ID)"
+
+res=$(mcp_call "add_user" "$(jq -nc \
+    --arg u "$USER2_USERNAME" --arg e "$USER2_EMAIL" --arg p "$USER2_PASSWORD" \
+    '{username:$u,email:$e,password:$p,roles:["USER","VULN","REQ"]}')" "$ADMIN_USER_EMAIL")
+USER2_ID=$(echo "$res" | jq -r '.user.id')
+[[ -z "$USER2_ID" || "$USER2_ID" == "null" ]] && fail "Failed to create $USER2_USERNAME: $res"
+ok "Created user $USER2_USERNAME (id=$USER2_ID)"
+
+# Create assets — owner is a plain string username
+res=$(mcp_call "create_asset" "$(jq -nc \
+    --arg n "$ASSET1_NAME" --arg t "SERVER" --arg o "$USER1_USERNAME" --arg ip "$ASSET1_IP" \
+    '{name:$n,type:$t,owner:$o,ip:$ip,description:"E2E test asset 1"}')" "$ADMIN_USER_EMAIL")
+ASSET1_ID=$(echo "$res" | jq -r '.id')
+[[ -z "$ASSET1_ID" || "$ASSET1_ID" == "null" ]] && fail "Failed to create $ASSET1_NAME: $res"
+ok "Created asset $ASSET1_NAME (id=$ASSET1_ID, owner=$USER1_USERNAME)"
+
+res=$(mcp_call "create_asset" "$(jq -nc \
+    --arg n "$ASSET2_NAME" --arg t "SERVER" --arg o "$USER2_USERNAME" --arg ip "$ASSET2_IP" \
+    '{name:$n,type:$t,owner:$o,ip:$ip,description:"E2E test asset 2"}')" "$ADMIN_USER_EMAIL")
+ASSET2_ID=$(echo "$res" | jq -r '.id')
+[[ -z "$ASSET2_ID" || "$ASSET2_ID" == "null" ]] && fail "Failed to create $ASSET2_NAME: $res"
+ok "Created asset $ASSET2_NAME (id=$ASSET2_ID, owner=$USER2_USERNAME)"
+
+# vuln1 on testasset1 (40 days, overdue)
+res=$(mcp_call "add_vulnerability" "$(jq -nc \
+    --arg h "$ASSET1_NAME" --arg c "$CVE_VULN1" --arg o "$USER1_USERNAME" \
+    '{hostname:$h,cve:$c,criticality:"CRITICAL",daysOpen:40,owner:$o}')" "$ADMIN_USER_EMAIL")
+VULN1_ID=$(echo "$res" | jq -r '.vulnerabilityId')
+[[ -z "$VULN1_ID" || "$VULN1_ID" == "null" ]] && fail "Failed to add vuln1: $res"
+ok "Added vuln1 ($CVE_VULN1, 40d) on $ASSET1_NAME — id=$VULN1_ID"
+
+# vuln2 on testasset1 (5 days)
+res=$(mcp_call "add_vulnerability" "$(jq -nc \
+    --arg h "$ASSET1_NAME" --arg c "$CVE_VULN2" --arg o "$USER1_USERNAME" \
+    '{hostname:$h,cve:$c,criticality:"CRITICAL",daysOpen:5,owner:$o}')" "$ADMIN_USER_EMAIL")
+VULN2_A1_ID=$(echo "$res" | jq -r '.vulnerabilityId')
+[[ -z "$VULN2_A1_ID" || "$VULN2_A1_ID" == "null" ]] && fail "Failed to add vuln2 on $ASSET1_NAME: $res"
+ok "Added vuln2 ($CVE_VULN2, 5d) on $ASSET1_NAME — id=$VULN2_A1_ID"
+
+# vuln2 on testasset2 (5 days)
+res=$(mcp_call "add_vulnerability" "$(jq -nc \
+    --arg h "$ASSET2_NAME" --arg c "$CVE_VULN2" --arg o "$USER2_USERNAME" \
+    '{hostname:$h,cve:$c,criticality:"CRITICAL",daysOpen:5,owner:$o}')" "$ADMIN_USER_EMAIL")
+VULN2_A2_ID=$(echo "$res" | jq -r '.vulnerabilityId')
+[[ -z "$VULN2_A2_ID" || "$VULN2_A2_ID" == "null" ]] && fail "Failed to add vuln2 on $ASSET2_NAME: $res"
+ok "Added vuln2 ($CVE_VULN2, 5d) on $ASSET2_NAME — id=$VULN2_A2_ID"
+
+trigger_view_refresh
+
+# =============================================================================
+# Phase 2 (MCP): Visibility / RBAC
+# =============================================================================
+
+log "=== Phase 2: MCP visibility ==="
+
+# As user1 — should see vuln1 + vuln2-on-asset1, NOT vuln2-on-asset2
+res=$(mcp_call "get_vulnerabilities" '{"pageSize":200,"includeExcepted":true}' "$USER1_EMAIL")
+u1_total=$(echo "$res" | jq -r '.total // 0')
+u1_has_vuln1=$(echo "$res" | jq -r --arg id "$VULN1_ID"    '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+u1_has_v2a1=$(echo "$res" | jq -r --arg id "$VULN2_A1_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+u1_has_v2a2=$(echo "$res" | jq -r --arg id "$VULN2_A2_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+[[ "$u1_has_vuln1" == "1" && "$u1_has_v2a1" == "1" && "$u1_has_v2a2" == "0" ]] \
+    || fail "user1 visibility wrong (total=$u1_total has_vuln1=$u1_has_vuln1 v2a1=$u1_has_v2a1 v2a2=$u1_has_v2a2)"
+ok "user1 sees vuln1 + vuln2-on-asset1, not vuln2-on-asset2"
+
+# As user2 — should see only vuln2-on-asset2
+res=$(mcp_call "get_vulnerabilities" '{"pageSize":200,"includeExcepted":true}' "$USER2_EMAIL")
+u2_has_vuln1=$(echo "$res" | jq -r --arg id "$VULN1_ID"    '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+u2_has_v2a1=$(echo "$res" | jq -r --arg id "$VULN2_A1_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+u2_has_v2a2=$(echo "$res" | jq -r --arg id "$VULN2_A2_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+[[ "$u2_has_vuln1" == "0" && "$u2_has_v2a1" == "0" && "$u2_has_v2a2" == "1" ]] \
+    || fail "user2 visibility wrong (vuln1=$u2_has_vuln1 v2a1=$u2_has_v2a1 v2a2=$u2_has_v2a2)"
+ok "user2 sees only vuln2-on-asset2"
+
+# As admin — should see all three
+res=$(mcp_call "get_vulnerabilities" '{"pageSize":500,"includeExcepted":true}' "$ADMIN_USER_EMAIL")
+a_has_vuln1=$(echo "$res" | jq -r --arg id "$VULN1_ID"    '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+a_has_v2a1=$(echo "$res" | jq -r --arg id "$VULN2_A1_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+a_has_v2a2=$(echo "$res" | jq -r --arg id "$VULN2_A2_ID"  '.vulnerabilities | map(select(.id == ($id|tonumber))) | length')
+[[ "$a_has_vuln1" == "1" && "$a_has_v2a1" == "1" && "$a_has_v2a2" == "1" ]] \
+    || fail "admin should see all 3 vulns (got $a_has_vuln1 / $a_has_v2a1 / $a_has_v2a2)"
+ok "admin sees all 3 vulnerability rows"
+
+# =============================================================================
+# Phase 3 (MCP): Overdue detection
+# =============================================================================
+
+log "=== Phase 3: MCP overdue detection ==="
+
+res=$(mcp_call "get_overdue_assets" '{}' "$ADMIN_USER_EMAIL")
+admin_has_a1_overdue=$(echo "$res" | jq -r --arg id "$ASSET1_ID" \
+    'if .assets then (.assets | map(select((.id // .assetId) == ($id|tonumber))) | length) else 0 end')
+admin_has_a2_overdue=$(echo "$res" | jq -r --arg id "$ASSET2_ID" \
+    'if .assets then (.assets | map(select((.id // .assetId) == ($id|tonumber))) | length) else 0 end')
+[[ "$admin_has_a1_overdue" == "1" && "$admin_has_a2_overdue" == "0" ]] \
+    || fail "admin overdue list mismatch (a1=$admin_has_a1_overdue a2=$admin_has_a2_overdue)"
+ok "admin overdue list includes testasset1, excludes testasset2"
+
+res=$(mcp_call "get_overdue_assets" '{}' "$USER1_EMAIL")
+u1_overdue_count=$(echo "$res" | jq -r 'if .assets then (.assets | length) else 0 end')
+[[ "$u1_overdue_count" -ge 1 ]] || fail "user1 should see >=1 overdue asset, got $u1_overdue_count"
+ok "user1 sees overdue asset (count=$u1_overdue_count)"
+
+res=$(mcp_call "get_overdue_assets" '{}' "$USER2_EMAIL")
+u2_overdue_count=$(echo "$res" | jq -r 'if .assets then (.assets | length) else 0 end')
+[[ "$u2_overdue_count" == "0" ]] || fail "user2 should see 0 overdue assets, got $u2_overdue_count"
+ok "user2 sees 0 overdue assets"
+
+# =============================================================================
+# Phase 4 (MCP): Exception lifecycle — APPROVE
+# =============================================================================
+
+log "=== Phase 4: MCP exception lifecycle (approve) ==="
+
+future_date=$(date -u -d "+90 days" +"%Y-%m-%dT00:00:00" 2>/dev/null \
+              || date -u -v+90d +"%Y-%m-%dT00:00:00")
+
+res=$(mcp_call "create_exception_request" "$(jq -nc \
+    --arg vid "$VULN1_ID" --arg aid "$ASSET1_ID" --arg cve "$CVE_VULN1" \
+    --arg reason "$EXCEPTION_REASON_APPROVE" --arg exp "$future_date" \
+    '{vulnerabilityId:($vid|tonumber), subject:"CVE", scope:"ASSET",
+      subjectValue:$cve, assetId:($aid|tonumber),
+      reason:$reason, expirationDate:$exp}')" "$USER1_EMAIL")
+REQ_APPROVE_ID=$(echo "$res" | jq -r '.request.id')
+status=$(echo "$res" | jq -r '.request.status')
+[[ -z "$REQ_APPROVE_ID" || "$REQ_APPROVE_ID" == "null" ]] && fail "Failed to create approve-request: $res"
+[[ "$status" == "PENDING" ]] || fail "Expected PENDING, got $status (auto-approve leaked through?)"
+ok "user1 created exception request id=$REQ_APPROVE_ID status=PENDING"
+
+# Admin sees it as pending
+res=$(mcp_call "get_pending_exception_requests" '{}' "$ADMIN_USER_EMAIL")
+admin_pending=$(echo "$res" | jq -r --arg id "$REQ_APPROVE_ID" \
+    '(.requests // .) | map(select(.id == ($id|tonumber))) | length')
+[[ "$admin_pending" == "1" ]] || fail "Admin pending list missing request $REQ_APPROVE_ID"
+ok "admin pending list includes request $REQ_APPROVE_ID"
+
+# Approve
+res=$(mcp_call "approve_exception_request" "$(jq -nc --arg id "$REQ_APPROVE_ID" \
+    '{requestId:($id|tonumber)}')" "$ADMIN_USER_EMAIL")
+new_status=$(echo "$res" | jq -r '.request.status')
+[[ "$new_status" == "APPROVED" ]] || fail "Expected APPROVED, got $new_status"
+ok "admin approved request $REQ_APPROVE_ID"
+
+# user1 sees APPROVED
+res=$(mcp_call "get_my_exception_requests" '{}' "$USER1_EMAIL")
+u1_status=$(echo "$res" | jq -r --arg id "$REQ_APPROVE_ID" \
+    '.requests | map(select(.id == ($id|tonumber)))[0].status // empty')
+[[ "$u1_status" == "APPROVED" ]] || fail "user1 should see APPROVED, got '$u1_status'"
+ok "user1 sees request $REQ_APPROVE_ID as APPROVED"
+
+# =============================================================================
+# Phase 5 (MCP): Exception lifecycle — REJECT
+# =============================================================================
+
+log "=== Phase 5: MCP exception lifecycle (reject) ==="
+
+res=$(mcp_call "create_exception_request" "$(jq -nc \
+    --arg vid "$VULN2_A2_ID" --arg aid "$ASSET2_ID" --arg cve "$CVE_VULN2" \
+    --arg reason "$EXCEPTION_REASON_REJECT" --arg exp "$future_date" \
+    '{vulnerabilityId:($vid|tonumber), subject:"CVE", scope:"ASSET",
+      subjectValue:$cve, assetId:($aid|tonumber),
+      reason:$reason, expirationDate:$exp}')" "$USER2_EMAIL")
+REQ_REJECT_ID=$(echo "$res" | jq -r '.request.id')
+status=$(echo "$res" | jq -r '.request.status')
+[[ -z "$REQ_REJECT_ID" || "$REQ_REJECT_ID" == "null" ]] && fail "Failed to create reject-request: $res"
+[[ "$status" == "PENDING" ]] || fail "Expected PENDING, got $status"
+ok "user2 created exception request id=$REQ_REJECT_ID status=PENDING"
+
+res=$(mcp_call "reject_exception_request" "$(jq -nc --arg id "$REQ_REJECT_ID" \
+    '{requestId:($id|tonumber), comment:"E2E reject path: insufficient justification per security policy"}')" \
+    "$ADMIN_USER_EMAIL")
+new_status=$(echo "$res" | jq -r '.request.status')
+[[ "$new_status" == "REJECTED" ]] || fail "Expected REJECTED, got $new_status"
+ok "admin rejected request $REQ_REJECT_ID"
+
+# =============================================================================
+# Phase 6 (MCP): Exception lifecycle — CANCEL
+# =============================================================================
+
+log "=== Phase 6: MCP exception lifecycle (cancel) ==="
+
+res=$(mcp_call "create_exception_request" "$(jq -nc \
+    --arg vid "$VULN2_A1_ID" --arg aid "$ASSET1_ID" --arg cve "$CVE_VULN2" \
+    --arg reason "$EXCEPTION_REASON_CANCEL" --arg exp "$future_date" \
+    '{vulnerabilityId:($vid|tonumber), subject:"CVE", scope:"ASSET",
+      subjectValue:$cve, assetId:($aid|tonumber),
+      reason:$reason, expirationDate:$exp}')" "$USER1_EMAIL")
+REQ_CANCEL_ID=$(echo "$res" | jq -r '.request.id')
+[[ -z "$REQ_CANCEL_ID" || "$REQ_CANCEL_ID" == "null" ]] && fail "Failed to create cancel-request: $res"
+ok "user1 created exception request id=$REQ_CANCEL_ID"
+
+res=$(mcp_call "cancel_exception_request" "$(jq -nc --arg id "$REQ_CANCEL_ID" \
+    '{requestId:($id|tonumber)}')" "$USER1_EMAIL")
+new_status=$(echo "$res" | jq -r '.request.status // .status // empty')
+[[ "$new_status" == "CANCELLED" ]] || fail "Expected CANCELLED, got '$new_status'"
+ok "user1 cancelled request $REQ_CANCEL_ID"
+
+# =============================================================================
+# Phase 7 (MCP): Authorization negatives
+# =============================================================================
+
+log "=== Phase 7: MCP authorization negatives ==="
+
+# user2 trying to approve user1's request → already terminal (APPROVED) but
+# the role check should fire first. Use the still-rejected request id to be safe.
+err=$(mcp_call "approve_exception_request" "$(jq -nc --arg id "$REQ_REJECT_ID" \
+    '{requestId:($id|tonumber)}')" "$USER2_EMAIL" --allow-error)
+err_code=$(echo "$err" | jq -r '.code // empty')
+[[ -n "$err_code" ]] || fail "Expected user2 approve to fail with role error, got success"
+ok "user2 cannot approve (code=$err_code)"
+
+# user1 trying to create exception for vuln on asset they don't own
+err=$(mcp_call "create_exception_request" "$(jq -nc \
+    --arg vid "$VULN2_A2_ID" --arg aid "$ASSET2_ID" --arg cve "$CVE_VULN2" \
+    --arg reason "$EXCEPTION_REASON_APPROVE" --arg exp "$future_date" \
+    '{vulnerabilityId:($vid|tonumber), subject:"CVE", scope:"ASSET",
+      subjectValue:$cve, assetId:($aid|tonumber),
+      reason:$reason, expirationDate:$exp}')" "$USER1_EMAIL" --allow-error)
+err_code=$(echo "$err" | jq -r '.code // empty')
+[[ -n "$err_code" ]] || fail "Expected user1 cross-asset request to fail, got success"
+ok "user1 cannot create exception on asset2 (code=$err_code)"
+
+# Missing X-MCP-User-Email — should fail with delegation error
+body=$(jq -nc '{jsonrpc:"2.0",id:"neg-1",method:"tools/call",params:{name:"get_vulnerabilities",arguments:{}}}')
+resp=$(curl -sS -X POST "${BASE_URL}/api/mcp/tools/call" \
+    -H "Content-Type: application/json" -H "X-MCP-API-Key: $SECMAN_MCP_KEY" -d "$body")
+no_deleg_code=$(echo "$resp" | jq -r '.error.code // empty')
+[[ -n "$no_deleg_code" ]] || warn "Call without delegation header succeeded (code unset) — endpoint may not enforce on read tools"
+ok "Call without X-MCP-User-Email surfaced (code='$no_deleg_code')"
+
+# =============================================================================
+# Phase 8 (UI): Playwright
+# =============================================================================
+
+if [[ "$SKIP_UI" == "true" ]]; then
+    warn "Skipping UI phase (SKIP_UI=true)"
+else
+    log "=== Phase 8: Web UI (Playwright) ==="
+
+    if ! curl -sf -o /dev/null --connect-timeout 5 "$FRONTEND_URL" 2>/dev/null; then
+        fail "Frontend not reachable at $FRONTEND_URL — start it with ./scriptpp/startfrontenddev.sh"
+    fi
+
+    if [[ -z "$ADMIN_USERNAME" || -z "$ADMIN_PASSWORD" ]]; then
+        fail "SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS required for UI phase"
+    fi
+
+    pushd "$(dirname "$0")/../../tests/e2e" >/dev/null
+
+    SECMAN_BASE_URL="$FRONTEND_URL" \
+    SECMAN_ADMIN_NAME="$ADMIN_USERNAME" \
+    SECMAN_ADMIN_PASS="$ADMIN_PASSWORD" \
+    E2E_USER1_NAME="$USER1_USERNAME" \
+    E2E_USER1_PASS="$USER1_PASSWORD" \
+    E2E_USER2_NAME="$USER2_USERNAME" \
+    E2E_USER2_PASS="$USER2_PASSWORD" \
+    E2E_ASSET1_NAME="$ASSET1_NAME" \
+    E2E_ASSET2_NAME="$ASSET2_NAME" \
+    E2E_CVE_VULN1="$CVE_VULN1" \
+    E2E_CVE_VULN2="$CVE_VULN2" \
+    E2E_REQ_APPROVE_ID="$REQ_APPROVE_ID" \
+    E2E_REQ_REJECT_ID="$REQ_REJECT_ID" \
+        npx playwright test vuln-exception-full.spec.ts --project=chrome --reporter=list
+
+    popd >/dev/null
+    ok "UI phase complete"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+ELAPSED=$(( $(date +%s) - START_TIME ))
+echo
+echo -e "${GREEN}=========================================${NC}"
+echo -e "${GREEN}  E2E VULN+EXCEPTION FULL TEST PASSED   ${NC}"
+echo -e "${GREEN}=========================================${NC}"
+echo "Elapsed: ${ELAPSED}s"
+echo "Users:        $USER1_USERNAME(id=$USER1_ID), $USER2_USERNAME(id=$USER2_ID)"
+echo "Assets:       $ASSET1_NAME(id=$ASSET1_ID), $ASSET2_NAME(id=$ASSET2_ID)"
+echo "Vulns:        vuln1=$VULN1_ID  vuln2_a1=$VULN2_A1_ID  vuln2_a2=$VULN2_A2_ID"
+echo "Exceptions:   approved=$REQ_APPROVE_ID  rejected=$REQ_REJECT_ID  cancelled=$REQ_CANCEL_ID"
+echo

--- a/tests/e2e/vuln-exception-full.spec.ts
+++ b/tests/e2e/vuln-exception-full.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Phase 8 (UI) of the full vulnerability + exception E2E test.
+ *
+ * Assumes the shell driver (scriptpp/test/test-e2e-vuln-exception-full.sh) has
+ * already created the testbed via MCP:
+ *   - Users:  e2etestuser1, e2etestuser2  (USER + VULN + REQ roles)
+ *   - Assets: testasset1 (owner=user1), testasset2 (owner=user2)
+ *   - Vulns:  vuln1 on asset1 (40d, CRITICAL, overdue),
+ *             vuln2 on both assets (5d, CRITICAL)
+ *   - Exception requests:
+ *       APPROVED on vuln1 (id = E2E_REQ_APPROVE_ID)
+ *       REJECTED on vuln2-asset2 (id = E2E_REQ_REJECT_ID)
+ *
+ * The spec verifies the UI reflects that state: scoped visibility, the admin
+ * approval dashboard, and the user's "my requests" view.
+ */
+
+const required = [
+    'SECMAN_ADMIN_NAME', 'SECMAN_ADMIN_PASS',
+    'E2E_USER1_NAME', 'E2E_USER1_PASS',
+    'E2E_USER2_NAME', 'E2E_USER2_PASS',
+    'E2E_ASSET1_NAME', 'E2E_ASSET2_NAME',
+    'E2E_CVE_VULN1', 'E2E_CVE_VULN2',
+    'E2E_REQ_APPROVE_ID', 'E2E_REQ_REJECT_ID',
+] as const;
+
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length > 0) {
+    throw new Error(
+        `Missing required env vars for vuln-exception-full.spec.ts: ${missing.join(', ')}. ` +
+        `Run via scriptpp/test/test-e2e-vuln-exception-full.sh which sets them.`,
+    );
+}
+
+const ADMIN = { user: process.env.SECMAN_ADMIN_NAME!, pass: process.env.SECMAN_ADMIN_PASS! };
+const USER1 = { user: process.env.E2E_USER1_NAME!,    pass: process.env.E2E_USER1_PASS! };
+const USER2 = { user: process.env.E2E_USER2_NAME!,    pass: process.env.E2E_USER2_PASS! };
+
+const ASSET1 = process.env.E2E_ASSET1_NAME!;
+const ASSET2 = process.env.E2E_ASSET2_NAME!;
+const CVE_V1 = process.env.E2E_CVE_VULN1!;
+const CVE_V2 = process.env.E2E_CVE_VULN2!;
+const REQ_APPROVE_ID = process.env.E2E_REQ_APPROVE_ID!;
+const REQ_REJECT_ID  = process.env.E2E_REQ_REJECT_ID!;
+
+async function login(page: Page, username: string, password: string) {
+    await page.goto('/login');
+    await page.waitForLoadState('domcontentloaded');
+    const submitBtn = page.locator('button[type="submit"]');
+    await submitBtn.waitFor({ state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1000); // React hydration
+    await page.locator('#username').fill(username);
+    await page.locator('#password').fill(password);
+    await submitBtn.click();
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+}
+
+async function logout(page: Page) {
+    await page.evaluate(() => localStorage.clear());
+    await page.context().clearCookies();
+}
+
+test.describe.serial('Vulnerability + exception lifecycle (UI)', () => {
+
+    test('admin sees both test assets and all CVEs in vulnerability list', async ({ page }) => {
+        await login(page, ADMIN.user, ADMIN.pass);
+
+        await page.goto('/vulnerabilities/current');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        // Both CVEs should be on the page (admin sees everything).
+        expect(body).toContain(CVE_V1);
+        expect(body).toContain(CVE_V2);
+        // Both assets are referenced (vuln rows show asset names).
+        expect(body).toContain(ASSET1);
+        expect(body).toContain(ASSET2);
+
+        await logout(page);
+    });
+
+    test('admin sees testasset1 in the outdated/overdue assets view', async ({ page }) => {
+        await login(page, ADMIN.user, ADMIN.pass);
+
+        await page.goto('/outdated-assets');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        expect(body).toContain(ASSET1);
+        // testasset2 has only a 5-day vuln, so it must NOT appear as overdue.
+        expect(body).not.toContain(ASSET2);
+
+        await logout(page);
+    });
+
+    test('e2etestuser1 sees only their own scoped assets/vulnerabilities', async ({ page }) => {
+        await login(page, USER1.user, USER1.pass);
+
+        await page.goto('/account-vulns');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        // user1 owns testasset1 — sees vuln1 + vuln2 on it
+        expect(body).toContain(CVE_V1);
+        expect(body).toContain(ASSET1);
+        // user1 must NOT see testasset2 (owned by user2)
+        expect(body).not.toContain(ASSET2);
+
+        await logout(page);
+    });
+
+    test('e2etestuser2 sees only their own scoped assets/vulnerabilities', async ({ page }) => {
+        await login(page, USER2.user, USER2.pass);
+
+        await page.goto('/account-vulns');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        // user2 owns testasset2 — sees vuln2 there. Must NOT see asset1 or vuln1.
+        expect(body).toContain(ASSET2);
+        expect(body).not.toContain(ASSET1);
+        expect(body).not.toContain(CVE_V1);
+
+        await logout(page);
+    });
+
+    test('e2etestuser1 sees their APPROVED exception request on My Exception Requests', async ({ page }) => {
+        await login(page, USER1.user, USER1.pass);
+
+        await page.goto('/my-exception-requests');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        // The approved request references vuln1 / asset1
+        expect(body).toContain(CVE_V1);
+        expect(body).toMatch(/APPROVED|Approved/);
+
+        await logout(page);
+    });
+
+    test('e2etestuser2 sees their REJECTED exception request on My Exception Requests', async ({ page }) => {
+        await login(page, USER2.user, USER2.pass);
+
+        await page.goto('/my-exception-requests');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        expect(body).toContain(CVE_V2);
+        expect(body).toMatch(/REJECTED|Rejected/);
+
+        await logout(page);
+    });
+
+    test('admin exception-approvals dashboard reflects the reviewed requests', async ({ page }) => {
+        await login(page, ADMIN.user, ADMIN.pass);
+
+        await page.goto('/exception-approvals');
+        await page.waitForLoadState('domcontentloaded');
+        await page.waitForTimeout(2500);
+
+        const body = (await page.textContent('body')) ?? '';
+        // Both reviewed requests should be present (the dashboard usually shows
+        // all states or supports filtering — we just look for the CVEs).
+        expect(body).toContain(CVE_V1);
+        expect(body).toContain(CVE_V2);
+
+        await logout(page);
+    });
+});


### PR DESCRIPTION
… Web UI

Adds a single re-runnable test that exercises the complete vulnerability management and exception lifecycle through both the MCP JSON-RPC interface and the Astro/React web UI. The driver provisions a clean testbed (two users, two assets, three vulnerability rows including a 40-day overdue CRITICAL), then asserts visibility/RBAC, overdue detection, and the approve/reject/cancel paths plus authorization negatives. A Playwright spec verifies the same state through the UI. Cleanup runs both before the run (unconditional) and after (trap EXIT), so the test is idempotent.

Files:
- scriptpp/test/test-e2e-vuln-exception-full.sh - shell driver (MCP phase)
- tests/e2e/vuln-exception-full.spec.ts - Playwright spec (UI phase)
- .claude/skills/e2evulnexception/SKILL.md - orchestration skill that runs the start-fix-restart loop, mirroring the e2eexception skill's pattern