### PR TITLE
feat(crowdstrike): scheduled stale-asset cleanup with audit history and admin UI

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -64,6 +64,17 @@ Monitor: `GET /memory` (used/max/free/total MB). Set to `false` to roll back.
 | `VULN_USE_PATCH_PUBLICATION_DATE` | `false` | `false`: `daysOpen = now − detection`. `true`: `now − patchPublicationDate`. |
 | `VULN_REQUIRE_PATCH_PUBLICATION_DATE` | `false` | only import vulns with patch-publication date |
 
+### CrowdStrike stale-asset cleanup
+Daily scheduled job (02:30 server TZ) that deletes assets whose `crowdStrikeLastImportedAt` is older than `STALE_DAYS`. Manual runs (admin UI / CLI `delete-asset-not-seen`) ignore the brake but are still recorded in `crowdstrike_cleanup_run`.
+
+| Var | Default | Effect |
+|---|---|---|
+| `CROWDSTRIKE_CLEANUP_ENABLED` | `false` | opt-in master switch for the scheduled job |
+| `CROWDSTRIKE_CLEANUP_STALE_DAYS` | `30` | delete CrowdStrike-tracked assets last imported > N days ago |
+| `CROWDSTRIKE_CLEANUP_MAX_DELETE_PERCENT` | `10` | abort the scheduled run if candidates exceed this % of CrowdStrike-tracked assets; set `100` to disable the brake |
+
+Notifications: ADMIN users receive an email whenever a run deletes ≥1 asset, hits errors, or trips the safety brake. "Boring" runs (0 deletions, 0 errors) are silent.
+
 ### Debug & logging
 | Var | Default | Effect |
 |---|---|---|
@@ -145,6 +156,9 @@ SECMAN_AUTH_COOKIE_SECURE=true
 # OAUTH_STATE_RETRY_BACKOFF_MULTIPLIER=1.5
 # OAUTH_TOKEN_EXCHANGE_MAX_RETRIES=2
 # OAUTH_TOKEN_EXCHANGE_RETRY_DELAY=500
+# CROWDSTRIKE_CLEANUP_ENABLED=false
+# CROWDSTRIKE_CLEANUP_STALE_DAYS=30
+# CROWDSTRIKE_CLEANUP_MAX_DELETE_PERCENT=10
 ```
 
 `/etc/secman/frontend.env`:

--- a/src/backendng/src/main/kotlin/com/secman/controller/AssetController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AssetController.kt
@@ -52,7 +52,8 @@ open class AssetController(
     private val assetExportService: com.secman.service.AssetExportService,
     private val assetCascadeDeleteService: com.secman.service.AssetCascadeDeleteService,
     private val assetMergeService: com.secman.service.AssetMergeService,
-    private val crowdStrikeAssetCleanupService: com.secman.service.CrowdStrikeAssetCleanupService
+    private val crowdStrikeAssetCleanupService: com.secman.service.CrowdStrikeAssetCleanupService,
+    private val crowdStrikeCleanupAuditService: com.secman.service.CrowdStrikeCleanupAuditService
 ) {
     
     private val log = LoggerFactory.getLogger(AssetController::class.java)
@@ -848,10 +849,15 @@ open class AssetController(
         authentication: Authentication
     ): HttpResponse<*> {
         return try {
-            val result = crowdStrikeAssetCleanupService.cleanup(
+            // Manual runs go through the audit service so they are persisted in
+            // crowdstrike_cleanup_run alongside scheduled runs. The safety brake
+            // is intentionally not applied here — the admin already chose this
+            // action (typically after a --dry-run).
+            val result = crowdStrikeCleanupAuditService.run(
                 days = request.days,
                 dryRun = request.dryRun,
-                username = authentication.name
+                triggeredBy = authentication.name,
+                maxDeletePercent = null
             )
             HttpResponse.ok(result)
         } catch (e: IllegalArgumentException) {

--- a/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeCleanupController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CrowdStrikeCleanupController.kt
@@ -1,0 +1,64 @@
+package com.secman.controller
+
+import com.secman.domain.CrowdStrikeCleanupRun
+import com.secman.repository.CrowdStrikeCleanupRunRepository
+import io.micronaut.context.annotation.Value
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.security.annotation.Secured
+import io.micronaut.serde.annotation.Serdeable
+import org.slf4j.LoggerFactory
+
+/**
+ * Read-only views into the CrowdStrike stale-asset cleanup history and config.
+ *
+ * Backs the admin "Stale Asset Cleanup" panel on the Falcon config page.
+ * The cleanup itself is fired via POST /api/assets/delete-not-seen-by-crowdstrike
+ * (manual) or by the daily scheduler (CrowdStrikeStaleAssetCleanupScheduler).
+ */
+@Controller("/api/crowdstrike/cleanup")
+@Secured("ADMIN")
+@ExecuteOn(TaskExecutors.BLOCKING)
+open class CrowdStrikeCleanupController(
+    private val runRepository: CrowdStrikeCleanupRunRepository,
+    @Value("\${secman.crowdstrike.cleanup.enabled:false}") private val enabled: Boolean,
+    @Value("\${secman.crowdstrike.cleanup.stale-days:30}") private val staleDays: Int,
+    @Value("\${secman.crowdstrike.cleanup.max-delete-percent:10}") private val maxDeletePercent: Int
+) {
+    private val log = LoggerFactory.getLogger(CrowdStrikeCleanupController::class.java)
+
+    @Serdeable
+    data class CleanupConfigDto(
+        val enabled: Boolean,
+        val staleDays: Int,
+        val maxDeletePercent: Int,
+        val cron: String
+    )
+
+    @Get("/config")
+    open fun getConfig(): HttpResponse<CleanupConfigDto> {
+        return HttpResponse.ok(
+            CleanupConfigDto(
+                enabled = enabled,
+                staleDays = staleDays,
+                maxDeletePercent = maxDeletePercent,
+                cron = "0 30 2 * * ?"
+            )
+        )
+    }
+
+    @Get("/runs")
+    open fun listRuns(
+        @QueryValue(defaultValue = "20") limit: Int
+    ): HttpResponse<List<CrowdStrikeCleanupRun>> {
+        val safeLimit = limit.coerceIn(1, 200)
+        val pageable = Pageable.from(0, safeLimit, Sort.of(Sort.Order.desc("startedAt")))
+        return HttpResponse.ok(runRepository.findAll(pageable).content)
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/CrowdStrikeCleanupRun.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/CrowdStrikeCleanupRun.kt
@@ -1,0 +1,76 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.LocalDateTime
+
+@Serdeable
+enum class CrowdStrikeCleanupStatus {
+    SUCCESS,
+    PARTIAL,
+    ABORTED_SAFETY_BRAKE,
+    FAILED
+}
+
+@Entity
+@Serdeable
+@Table(
+    name = "crowdstrike_cleanup_run",
+    indexes = [
+        Index(name = "idx_cs_cleanup_started", columnList = "started_at"),
+        Index(name = "idx_cs_cleanup_status", columnList = "status")
+    ]
+)
+data class CrowdStrikeCleanupRun(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    var status: CrowdStrikeCleanupStatus,
+
+    @Column(name = "triggered_by", nullable = false, length = 100)
+    var triggeredBy: String,
+
+    @Column(name = "stale_days", nullable = false)
+    var staleDays: Int,
+
+    @Column(name = "cutoff", nullable = false)
+    var cutoff: LocalDateTime,
+
+    @Column(name = "candidate_count", nullable = false)
+    var candidateCount: Int = 0,
+
+    @Column(name = "deleted_count", nullable = false)
+    var deletedCount: Int = 0,
+
+    @Column(name = "error_count", nullable = false)
+    var errorCount: Int = 0,
+
+    @Column(name = "total_crowdstrike_tracked", nullable = false)
+    var totalCrowdStrikeTracked: Long = 0,
+
+    @Column(name = "started_at", nullable = false)
+    var startedAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "completed_at")
+    var completedAt: LocalDateTime? = null,
+
+    @Column(name = "duration_ms")
+    var durationMs: Long? = null,
+
+    @Column(name = "error_message", length = 1000)
+    var errorMessage: String? = null
+)

--- a/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeAssetCleanupDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/CrowdStrikeAssetCleanupDto.kt
@@ -32,5 +32,10 @@ data class CrowdStrikeAssetCleanupResponse(
     val deletedCount: Int,
     val skippedCount: Int,
     val candidates: List<CrowdStrikeAssetCleanupCandidateDto>,
-    val errors: List<CrowdStrikeAssetCleanupErrorDto>
+    val errors: List<CrowdStrikeAssetCleanupErrorDto>,
+    // Optional run status — populated by CrowdStrikeCleanupAuditService.
+    // One of: SUCCESS, PARTIAL, ABORTED_SAFETY_BRAKE, FAILED. Null on legacy paths.
+    val status: String? = null,
+    // Audit-row id, present when the run was persisted to crowdstrike_cleanup_run.
+    val runId: Long? = null
 )

--- a/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
@@ -142,6 +142,15 @@ interface AssetRepository : JpaRepository<Asset, Long> {
 
     fun findByCrowdStrikeLastImportedAtBefore(cutoff: LocalDateTime): List<Asset>
 
+    /**
+     * Count assets that have ever been imported by CrowdStrike (timestamp not null).
+     * Used as the denominator for the stale-asset cleanup safety brake.
+     */
+    @io.micronaut.data.annotation.Query(
+        "SELECT COUNT(a) FROM Asset a WHERE a.crowdStrikeLastImportedAt IS NOT NULL"
+    )
+    fun countCrowdStrikeTracked(): Long
+
     // MCP Tool Support - Feature 006: Asset inventory queries with pagination
 
     /**

--- a/src/backendng/src/main/kotlin/com/secman/repository/CrowdStrikeCleanupRunRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/CrowdStrikeCleanupRunRepository.kt
@@ -1,0 +1,8 @@
+package com.secman.repository
+
+import com.secman.domain.CrowdStrikeCleanupRun
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+
+@Repository
+interface CrowdStrikeCleanupRunRepository : JpaRepository<CrowdStrikeCleanupRun, Long>

--- a/src/backendng/src/main/kotlin/com/secman/scheduler/CrowdStrikeStaleAssetCleanupScheduler.kt
+++ b/src/backendng/src/main/kotlin/com/secman/scheduler/CrowdStrikeStaleAssetCleanupScheduler.kt
@@ -1,0 +1,64 @@
+package com.secman.scheduler
+
+import com.secman.service.CrowdStrikeCleanupAuditService
+import io.micronaut.context.annotation.Value
+import io.micronaut.scheduling.annotation.Scheduled
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * Scheduled cleanup of CrowdStrike-tracked assets that have not been re-imported
+ * for `staleDays` days. Off by default; flip `secman.crowdstrike.cleanup.enabled=true`
+ * (or env `CROWDSTRIKE_CLEANUP_ENABLED=true`) to opt in per environment.
+ *
+ * The orchestration (safety brake, audit row, admin notification) lives in
+ * CrowdStrikeCleanupAuditService — this class only owns the cron timing and
+ * the configuration plumbing.
+ */
+@Singleton
+open class CrowdStrikeStaleAssetCleanupScheduler(
+    @Inject private val auditService: CrowdStrikeCleanupAuditService,
+    @Value("\${secman.crowdstrike.cleanup.enabled:false}") private val enabled: Boolean,
+    @Value("\${secman.crowdstrike.cleanup.stale-days:30}") private val staleDays: Int,
+    @Value("\${secman.crowdstrike.cleanup.max-delete-percent:10}") private val maxDeletePercent: Int
+) {
+    private val logger = LoggerFactory.getLogger(CrowdStrikeStaleAssetCleanupScheduler::class.java)
+
+    /**
+     * Daily at 02:30 — after typical CrowdStrike imports settle and before
+     * business hours, so a notification reaches admins by morning.
+     */
+    @Scheduled(cron = "0 30 2 * * ?")
+    open fun runScheduledCleanup() {
+        if (!enabled) {
+            logger.debug("CrowdStrike scheduled cleanup is disabled (secman.crowdstrike.cleanup.enabled=false)")
+            return
+        }
+        if (staleDays <= 0) {
+            logger.warn("CrowdStrike scheduled cleanup misconfigured: stale-days={} (must be > 0). Skipping run.", staleDays)
+            return
+        }
+
+        logger.info(
+            "Running CrowdStrike scheduled cleanup: staleDays={} maxDeletePercent={}",
+            staleDays, maxDeletePercent
+        )
+
+        try {
+            val response = auditService.run(
+                days = staleDays,
+                dryRun = false,
+                triggeredBy = "scheduler",
+                maxDeletePercent = maxDeletePercent
+            )
+            logger.info(
+                "CrowdStrike scheduled cleanup finished: status={} candidates={} deleted={} errors={} runId={}",
+                response.status, response.candidateCount, response.deletedCount,
+                response.errors.size, response.runId
+            )
+        } catch (e: Exception) {
+            logger.error("CrowdStrike scheduled cleanup threw an unhandled exception", e)
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeCleanupAuditService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeCleanupAuditService.kt
@@ -1,0 +1,229 @@
+package com.secman.service
+
+import com.secman.domain.CrowdStrikeCleanupRun
+import com.secman.domain.CrowdStrikeCleanupStatus
+import com.secman.dto.CrowdStrikeAssetCleanupErrorDto
+import com.secman.dto.CrowdStrikeAssetCleanupResponse
+import com.secman.repository.AssetRepository
+import com.secman.repository.CrowdStrikeCleanupRunRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDateTime
+
+/**
+ * Orchestrates CrowdStrike stale-asset cleanup runs:
+ * - applies the optional safety brake (max-delete percent)
+ * - persists a CrowdStrikeCleanupRun audit row for non-dry-run executions
+ * - notifies admins when the run produced deletions, errors, or was aborted
+ *
+ * Manual API runs and the scheduled job both go through this service so the
+ * history view shows every actual deletion regardless of trigger.
+ */
+@Singleton
+open class CrowdStrikeCleanupAuditService(
+    @Inject private val cleanupService: CrowdStrikeAssetCleanupService,
+    @Inject private val runRepository: CrowdStrikeCleanupRunRepository,
+    @Inject private val assetRepository: AssetRepository,
+    @Inject private val notificationService: CrowdStrikeCleanupNotificationService
+) {
+    private val logger = LoggerFactory.getLogger(CrowdStrikeCleanupAuditService::class.java)
+    private var clock: Clock = Clock.systemDefaultZone()
+
+    constructor(
+        cleanupService: CrowdStrikeAssetCleanupService,
+        runRepository: CrowdStrikeCleanupRunRepository,
+        assetRepository: AssetRepository,
+        notificationService: CrowdStrikeCleanupNotificationService,
+        clock: Clock
+    ) : this(cleanupService, runRepository, assetRepository, notificationService) {
+        this.clock = clock
+    }
+
+    /**
+     * Execute a cleanup run.
+     *
+     * @param days stale threshold in days (must be > 0)
+     * @param dryRun if true, no deletes occur and no audit row is written
+     * @param triggeredBy short identifier of the caller (username, "scheduler", ...)
+     * @param maxDeletePercent if set (0..100), aborts the run when the candidate
+     *                         set exceeds this percentage of CrowdStrike-tracked
+     *                         assets. Manual runs typically pass null.
+     */
+    fun run(
+        days: Int,
+        dryRun: Boolean,
+        triggeredBy: String,
+        maxDeletePercent: Int? = null
+    ): CrowdStrikeAssetCleanupResponse {
+        require(days > 0) { "Days must be greater than zero" }
+
+        if (dryRun) {
+            return cleanupService.cleanup(days, dryRun = true, username = triggeredBy)
+        }
+
+        val startedAt = LocalDateTime.now(clock)
+
+        if (maxDeletePercent != null) {
+            val brakeOutcome = checkSafetyBrake(days, triggeredBy, startedAt, maxDeletePercent)
+            if (brakeOutcome != null) return brakeOutcome
+        }
+
+        val response = try {
+            cleanupService.cleanup(days, dryRun = false, username = triggeredBy)
+        } catch (e: Exception) {
+            logger.error("CrowdStrike cleanup run failed (triggeredBy={})", triggeredBy, e)
+            val failed = persistRun(
+                status = CrowdStrikeCleanupStatus.FAILED,
+                triggeredBy = triggeredBy,
+                staleDays = days,
+                cutoff = LocalDateTime.now(clock).minusDays(days.toLong()),
+                candidateCount = 0,
+                deletedCount = 0,
+                errorCount = 1,
+                totalTracked = safeTotal(),
+                startedAt = startedAt,
+                errorMessage = e.message?.take(1000) ?: e.javaClass.simpleName
+            )
+            notificationService.notifyAdmins(failed)
+            return CrowdStrikeAssetCleanupResponse(
+                days = days,
+                cutoff = failed.cutoff,
+                dryRun = false,
+                candidateCount = 0,
+                deletedCount = 0,
+                skippedCount = 0,
+                candidates = emptyList(),
+                errors = listOf(
+                    CrowdStrikeAssetCleanupErrorDto(
+                        assetId = 0L,
+                        assetName = "(run-level error)",
+                        message = failed.errorMessage ?: "Unknown error"
+                    )
+                ),
+                status = CrowdStrikeCleanupStatus.FAILED.name,
+                runId = failed.id
+            )
+        }
+
+        val status = when {
+            response.errors.isNotEmpty() -> CrowdStrikeCleanupStatus.PARTIAL
+            else -> CrowdStrikeCleanupStatus.SUCCESS
+        }
+
+        val saved = persistRun(
+            status = status,
+            triggeredBy = triggeredBy,
+            staleDays = days,
+            cutoff = response.cutoff,
+            candidateCount = response.candidateCount,
+            deletedCount = response.deletedCount,
+            errorCount = response.errors.size,
+            totalTracked = safeTotal(),
+            startedAt = startedAt,
+            errorMessage = null
+        )
+
+        if (response.deletedCount > 0 || response.errors.isNotEmpty()) {
+            notificationService.notifyAdmins(saved)
+        }
+
+        return response.copy(status = status.name, runId = saved.id)
+    }
+
+    private fun checkSafetyBrake(
+        days: Int,
+        triggeredBy: String,
+        startedAt: LocalDateTime,
+        maxDeletePercent: Int
+    ): CrowdStrikeAssetCleanupResponse? {
+        if (maxDeletePercent >= 100) return null
+
+        val cutoff = LocalDateTime.now(clock).minusDays(days.toLong())
+        val candidates = assetRepository.findByCrowdStrikeLastImportedAtBefore(cutoff)
+            .count { it.crowdStrikeLastImportedAt != null && it.id != null }
+        val totalTracked = safeTotal()
+        if (totalTracked <= 0L) return null
+
+        val percent = (candidates.toDouble() / totalTracked.toDouble()) * 100.0
+        if (percent <= maxDeletePercent.toDouble()) return null
+
+        logger.warn(
+            "CrowdStrike cleanup safety brake tripped: {} of {} tracked assets ({}%) exceeds max {}%",
+            candidates, totalTracked, "%.2f".format(percent), maxDeletePercent
+        )
+
+        val saved = persistRun(
+            status = CrowdStrikeCleanupStatus.ABORTED_SAFETY_BRAKE,
+            triggeredBy = triggeredBy,
+            staleDays = days,
+            cutoff = cutoff,
+            candidateCount = candidates,
+            deletedCount = 0,
+            errorCount = 0,
+            totalTracked = totalTracked,
+            startedAt = startedAt,
+            errorMessage = "Safety brake: ${"%.2f".format(percent)}% of CrowdStrike-tracked assets " +
+                "would be deleted (limit ${maxDeletePercent}%). Investigate before re-running."
+        )
+        notificationService.notifyAdmins(saved)
+
+        return CrowdStrikeAssetCleanupResponse(
+            days = days,
+            cutoff = cutoff,
+            dryRun = false,
+            candidateCount = candidates,
+            deletedCount = 0,
+            skippedCount = candidates,
+            candidates = emptyList(),
+            errors = listOf(
+                CrowdStrikeAssetCleanupErrorDto(
+                    assetId = 0L,
+                    assetName = "(safety-brake)",
+                    message = saved.errorMessage ?: "Safety brake aborted run"
+                )
+            ),
+            status = CrowdStrikeCleanupStatus.ABORTED_SAFETY_BRAKE.name,
+            runId = saved.id
+        )
+    }
+
+    private fun persistRun(
+        status: CrowdStrikeCleanupStatus,
+        triggeredBy: String,
+        staleDays: Int,
+        cutoff: LocalDateTime,
+        candidateCount: Int,
+        deletedCount: Int,
+        errorCount: Int,
+        totalTracked: Long,
+        startedAt: LocalDateTime,
+        errorMessage: String?
+    ): CrowdStrikeCleanupRun {
+        val completedAt = LocalDateTime.now(clock)
+        val run = CrowdStrikeCleanupRun(
+            status = status,
+            triggeredBy = triggeredBy.take(100),
+            staleDays = staleDays,
+            cutoff = cutoff,
+            candidateCount = candidateCount,
+            deletedCount = deletedCount,
+            errorCount = errorCount,
+            totalCrowdStrikeTracked = totalTracked,
+            startedAt = startedAt,
+            completedAt = completedAt,
+            durationMs = Duration.between(startedAt, completedAt).toMillis(),
+            errorMessage = errorMessage
+        )
+        return runRepository.save(run)
+    }
+
+    private fun safeTotal(): Long = try {
+        assetRepository.countCrowdStrikeTracked()
+    } catch (e: Exception) {
+        logger.warn("Failed to count CrowdStrike-tracked assets: {}", e.message)
+        0L
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeCleanupNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeCleanupNotificationService.kt
@@ -1,0 +1,97 @@
+package com.secman.service
+
+import com.secman.domain.CrowdStrikeCleanupRun
+import com.secman.domain.CrowdStrikeCleanupStatus
+import com.secman.domain.User
+import com.secman.repository.UserRepository
+import io.micronaut.scheduling.annotation.Async
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.CompletableFuture
+
+@Singleton
+open class CrowdStrikeCleanupNotificationService(
+    @Inject private val userRepository: UserRepository,
+    @Inject private val emailService: EmailService
+) {
+    private val logger = LoggerFactory.getLogger(CrowdStrikeCleanupNotificationService::class.java)
+
+    @Async
+    open fun notifyAdmins(run: CrowdStrikeCleanupRun): CompletableFuture<Void> {
+        return CompletableFuture.runAsync {
+            try {
+                val admins = userRepository.findAll().filter { it.hasRole(User.Role.ADMIN) }
+                if (admins.isEmpty()) {
+                    logger.warn("No ADMIN users to notify of CrowdStrike cleanup run {}", run.id)
+                    return@runAsync
+                }
+
+                val subject = buildSubject(run)
+                val html = buildHtml(run)
+
+                admins.forEach { admin ->
+                    val email = admin.email
+                    if (email.isNullOrBlank() || !isValidEmail(email)) {
+                        logger.warn("Skipping admin {} (invalid/missing email)", admin.username)
+                        return@forEach
+                    }
+                    emailService.sendHtmlEmail(email, subject, html)
+                        .whenComplete { ok, err ->
+                            if (err != null) {
+                                logger.error("Failed to send cleanup notification to {}: {}", email, err.message, err)
+                            } else if (ok != true) {
+                                logger.warn("Cleanup notification email returned false for {}", email)
+                            }
+                        }
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to dispatch CrowdStrike cleanup notifications", e)
+            }
+        }
+    }
+
+    private fun buildSubject(run: CrowdStrikeCleanupRun): String {
+        val tag = when (run.status) {
+            CrowdStrikeCleanupStatus.SUCCESS -> "completed"
+            CrowdStrikeCleanupStatus.PARTIAL -> "completed with errors"
+            CrowdStrikeCleanupStatus.ABORTED_SAFETY_BRAKE -> "aborted (safety brake)"
+            CrowdStrikeCleanupStatus.FAILED -> "FAILED"
+        }
+        return "[secman] CrowdStrike stale-asset cleanup $tag — ${run.deletedCount} deleted"
+    }
+
+    private fun buildHtml(run: CrowdStrikeCleanupRun): String {
+        val cutoff = run.cutoff.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        val started = run.startedAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        val completed = run.completedAt?.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) ?: "—"
+        val errorBlock = run.errorMessage?.let {
+            """<p><b>Error:</b> ${escape(it)}</p>"""
+        } ?: ""
+        return """
+            <html><body style="font-family: sans-serif">
+              <h2>CrowdStrike stale-asset cleanup ${escape(run.status.name)}</h2>
+              <table cellpadding="4" style="border-collapse: collapse">
+                <tr><td><b>Triggered by</b></td><td>${escape(run.triggeredBy)}</td></tr>
+                <tr><td><b>Stale threshold</b></td><td>${run.staleDays} days</td></tr>
+                <tr><td><b>Cutoff</b></td><td>$cutoff</td></tr>
+                <tr><td><b>CrowdStrike-tracked assets (total)</b></td><td>${run.totalCrowdStrikeTracked}</td></tr>
+                <tr><td><b>Stale candidates</b></td><td>${run.candidateCount}</td></tr>
+                <tr><td><b>Deleted</b></td><td>${run.deletedCount}</td></tr>
+                <tr><td><b>Errors</b></td><td>${run.errorCount}</td></tr>
+                <tr><td><b>Started</b></td><td>$started</td></tr>
+                <tr><td><b>Completed</b></td><td>$completed</td></tr>
+                <tr><td><b>Duration</b></td><td>${run.durationMs ?: "—"} ms</td></tr>
+              </table>
+              $errorBlock
+            </body></html>
+        """.trimIndent()
+    }
+
+    private fun escape(s: String): String =
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    private fun isValidEmail(email: String): Boolean =
+        email.contains("@") && email.contains(".")
+}

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -253,6 +253,17 @@ secman:
     # When true: vulnerabilities without patch_publication_date are skipped during import
     # When false: all vulnerabilities are imported (current behavior)
     require-patch-publication-date: ${VULN_REQUIRE_PATCH_PUBLICATION_DATE:false}
+  crowdstrike:
+    # Scheduled cleanup of assets that have not been re-imported by CrowdStrike
+    # for `stale-days` days. Opt-in: disabled by default so existing deployments
+    # keep current behavior until ops flips the flag.
+    cleanup:
+      enabled: ${CROWDSTRIKE_CLEANUP_ENABLED:false}
+      stale-days: ${CROWDSTRIKE_CLEANUP_STALE_DAYS:30}
+      # Safety brake: abort the run if more than this percent of CrowdStrike-tracked
+      # assets would be deleted in a single pass (protects against import outages).
+      # Setting to 100 disables the brake.
+      max-delete-percent: ${CROWDSTRIKE_CLEANUP_MAX_DELETE_PERCENT:10}
   http:
     services:
       translation:

--- a/src/backendng/src/test/kotlin/com/secman/service/CrowdStrikeCleanupAuditServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/CrowdStrikeCleanupAuditServiceTest.kt
@@ -1,0 +1,218 @@
+package com.secman.service
+
+import com.secman.domain.Asset
+import com.secman.domain.CrowdStrikeCleanupRun
+import com.secman.domain.CrowdStrikeCleanupStatus
+import com.secman.dto.CrowdStrikeAssetCleanupCandidateDto
+import com.secman.dto.CrowdStrikeAssetCleanupErrorDto
+import com.secman.dto.CrowdStrikeAssetCleanupResponse
+import com.secman.repository.AssetRepository
+import com.secman.repository.CrowdStrikeCleanupRunRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class CrowdStrikeCleanupAuditServiceTest {
+
+    private lateinit var cleanupService: CrowdStrikeAssetCleanupService
+    private lateinit var runRepository: CrowdStrikeCleanupRunRepository
+    private lateinit var assetRepository: AssetRepository
+    private lateinit var notificationService: CrowdStrikeCleanupNotificationService
+    private lateinit var service: CrowdStrikeCleanupAuditService
+
+    private val now = Instant.parse("2026-05-08T02:30:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val nowLdt = LocalDateTime.ofInstant(now, ZoneOffset.UTC)
+
+    @BeforeEach
+    fun setUp() {
+        cleanupService = mockk()
+        runRepository = mockk()
+        assetRepository = mockk()
+        notificationService = mockk(relaxed = true)
+        service = CrowdStrikeCleanupAuditService(
+            cleanupService, runRepository, assetRepository, notificationService, clock
+        )
+    }
+
+    @Test
+    fun `dry run delegates to cleanup service and never persists or notifies`() {
+        every { cleanupService.cleanup(7, true, "admin") } returns CrowdStrikeAssetCleanupResponse(
+            days = 7,
+            cutoff = nowLdt.minusDays(7),
+            dryRun = true,
+            candidateCount = 3,
+            deletedCount = 0,
+            skippedCount = 3,
+            candidates = emptyList(),
+            errors = emptyList()
+        )
+
+        val result = service.run(days = 7, dryRun = true, triggeredBy = "admin")
+
+        assertThat(result.candidateCount).isEqualTo(3)
+        verify(exactly = 0) { runRepository.save(any()) }
+        verify(exactly = 0) { notificationService.notifyAdmins(any()) }
+    }
+
+    @Test
+    fun `successful run with deletions persists SUCCESS audit and notifies admins`() {
+        val cutoff = nowLdt.minusDays(30)
+        every { cleanupService.cleanup(30, false, "scheduler") } returns CrowdStrikeAssetCleanupResponse(
+            days = 30,
+            cutoff = cutoff,
+            dryRun = false,
+            candidateCount = 2,
+            deletedCount = 2,
+            skippedCount = 0,
+            candidates = listOf(CrowdStrikeAssetCleanupCandidateDto(1, "a", cutoff.minusDays(1))),
+            errors = emptyList()
+        )
+        every { assetRepository.countCrowdStrikeTracked() } returns 100L
+        val saved = slot<CrowdStrikeCleanupRun>()
+        every { runRepository.save(capture(saved)) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 42L } }
+
+        val result = service.run(days = 30, dryRun = false, triggeredBy = "scheduler")
+
+        assertThat(result.status).isEqualTo("SUCCESS")
+        assertThat(result.runId).isEqualTo(42L)
+        assertThat(saved.captured.status).isEqualTo(CrowdStrikeCleanupStatus.SUCCESS)
+        assertThat(saved.captured.deletedCount).isEqualTo(2)
+        assertThat(saved.captured.totalCrowdStrikeTracked).isEqualTo(100L)
+        verify(exactly = 1) { notificationService.notifyAdmins(any()) }
+    }
+
+    @Test
+    fun `run with errors records PARTIAL status and notifies`() {
+        val cutoff = nowLdt.minusDays(30)
+        every { cleanupService.cleanup(30, false, "admin") } returns CrowdStrikeAssetCleanupResponse(
+            days = 30,
+            cutoff = cutoff,
+            dryRun = false,
+            candidateCount = 2,
+            deletedCount = 1,
+            skippedCount = 1,
+            candidates = emptyList(),
+            errors = listOf(CrowdStrikeAssetCleanupErrorDto(9, "bad", "lock"))
+        )
+        every { assetRepository.countCrowdStrikeTracked() } returns 50L
+        every { runRepository.save(any()) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 7L } }
+
+        val result = service.run(days = 30, dryRun = false, triggeredBy = "admin")
+
+        assertThat(result.status).isEqualTo("PARTIAL")
+        verify(exactly = 1) { notificationService.notifyAdmins(any()) }
+    }
+
+    @Test
+    fun `safety brake aborts when candidate ratio exceeds limit and never calls cleanup service`() {
+        val cutoff = nowLdt.minusDays(30)
+        // 6 candidates / 50 tracked = 12% > 10% limit
+        every { assetRepository.findByCrowdStrikeLastImportedAtBefore(cutoff) } returns
+            (1..6).map { i ->
+                Asset(
+                    id = i.toLong(),
+                    name = "a$i",
+                    type = "SERVER",
+                    owner = "x",
+                    crowdStrikeLastImportedAt = cutoff.minusDays(1)
+                )
+            }
+        every { assetRepository.countCrowdStrikeTracked() } returns 50L
+        every { runRepository.save(any()) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 99L } }
+
+        val result = service.run(
+            days = 30, dryRun = false, triggeredBy = "scheduler", maxDeletePercent = 10
+        )
+
+        assertThat(result.status).isEqualTo("ABORTED_SAFETY_BRAKE")
+        assertThat(result.deletedCount).isEqualTo(0)
+        assertThat(result.candidateCount).isEqualTo(6)
+        assertThat(result.errors).hasSize(1)
+        verify(exactly = 0) { cleanupService.cleanup(any(), any(), any()) }
+        verify(exactly = 1) { notificationService.notifyAdmins(any()) }
+    }
+
+    @Test
+    fun `safety brake passes through when ratio is within limit`() {
+        val cutoff = nowLdt.minusDays(30)
+        every { assetRepository.findByCrowdStrikeLastImportedAtBefore(cutoff) } returns
+            listOf(
+                Asset(
+                    id = 1L,
+                    name = "a",
+                    type = "SERVER",
+                    owner = "x",
+                    crowdStrikeLastImportedAt = cutoff.minusDays(1)
+                )
+            )
+        every { assetRepository.countCrowdStrikeTracked() } returns 100L
+        every { cleanupService.cleanup(30, false, "scheduler") } returns CrowdStrikeAssetCleanupResponse(
+            days = 30,
+            cutoff = cutoff,
+            dryRun = false,
+            candidateCount = 1,
+            deletedCount = 1,
+            skippedCount = 0,
+            candidates = emptyList(),
+            errors = emptyList()
+        )
+        every { runRepository.save(any()) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 1L } }
+
+        val result = service.run(
+            days = 30, dryRun = false, triggeredBy = "scheduler", maxDeletePercent = 10
+        )
+
+        assertThat(result.status).isEqualTo("SUCCESS")
+        verify(exactly = 1) { cleanupService.cleanup(30, false, "scheduler") }
+    }
+
+    @Test
+    fun `safety brake skipped when total tracked is zero`() {
+        every { assetRepository.findByCrowdStrikeLastImportedAtBefore(any()) } returns emptyList()
+        every { assetRepository.countCrowdStrikeTracked() } returns 0L
+        every { cleanupService.cleanup(any(), any(), any()) } returns CrowdStrikeAssetCleanupResponse(
+            days = 30,
+            cutoff = nowLdt.minusDays(30),
+            dryRun = false,
+            candidateCount = 0,
+            deletedCount = 0,
+            skippedCount = 0,
+            candidates = emptyList(),
+            errors = emptyList()
+        )
+        every { runRepository.save(any()) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 1L } }
+
+        val result = service.run(
+            days = 30, dryRun = false, triggeredBy = "scheduler", maxDeletePercent = 10
+        )
+
+        // No deletions, no errors → SUCCESS, no notification (boring run).
+        assertThat(result.status).isEqualTo("SUCCESS")
+        verify(exactly = 0) { notificationService.notifyAdmins(any()) }
+    }
+
+    @Test
+    fun `cleanup service exception is captured as FAILED audit row and notified`() {
+        every { assetRepository.findByCrowdStrikeLastImportedAtBefore(any()) } returns emptyList()
+        every { assetRepository.countCrowdStrikeTracked() } returns 100L
+        every { cleanupService.cleanup(any(), any(), any()) } throws RuntimeException("DB down")
+        every { runRepository.save(any()) } answers { firstArg<CrowdStrikeCleanupRun>().apply { id = 11L } }
+
+        val result = service.run(
+            days = 30, dryRun = false, triggeredBy = "scheduler", maxDeletePercent = 10
+        )
+
+        assertThat(result.status).isEqualTo("FAILED")
+        assertThat(result.errors).hasSize(1)
+        verify(exactly = 1) { notificationService.notifyAdmins(any()) }
+    }
+}

--- a/src/frontend/src/components/CrowdStrikeStaleAssetCleanup.tsx
+++ b/src/frontend/src/components/CrowdStrikeStaleAssetCleanup.tsx
@@ -1,0 +1,265 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface CleanupConfig {
+    enabled: boolean;
+    staleDays: number;
+    maxDeletePercent: number;
+    cron: string;
+}
+
+interface CleanupRun {
+    id: number;
+    status: 'SUCCESS' | 'PARTIAL' | 'ABORTED_SAFETY_BRAKE' | 'FAILED';
+    triggeredBy: string;
+    staleDays: number;
+    cutoff: string;
+    candidateCount: number;
+    deletedCount: number;
+    errorCount: number;
+    totalCrowdStrikeTracked: number;
+    startedAt: string;
+    completedAt: string | null;
+    durationMs: number | null;
+    errorMessage: string | null;
+}
+
+const STATUS_BADGE: Record<CleanupRun['status'], string> = {
+    SUCCESS: 'bg-success',
+    PARTIAL: 'bg-warning text-dark',
+    ABORTED_SAFETY_BRAKE: 'bg-danger',
+    FAILED: 'bg-danger'
+};
+
+const CrowdStrikeStaleAssetCleanup: React.FC = () => {
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [config, setConfig] = useState<CleanupConfig | null>(null);
+    const [runs, setRuns] = useState<CleanupRun[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [info, setInfo] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [days, setDays] = useState<number>(30);
+
+    useEffect(() => {
+        const user = (window as any).currentUser;
+        const admin = user?.roles?.includes('ADMIN') || false;
+        setIsAdmin(admin);
+        if (admin) {
+            void load();
+        } else {
+            setLoading(false);
+        }
+    }, []);
+
+    const load = async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            const [cfgRes, runsRes] = await Promise.all([
+                axios.get<CleanupConfig>('/api/crowdstrike/cleanup/config'),
+                axios.get<CleanupRun[]>('/api/crowdstrike/cleanup/runs?limit=20')
+            ]);
+            setConfig(cfgRes.data);
+            setDays(cfgRes.data.staleDays);
+            setRuns(runsRes.data);
+        } catch (e: any) {
+            setError(e.response?.data?.error || 'Failed to load cleanup data');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const trigger = async (dryRun: boolean) => {
+        if (!isAdmin) return;
+        if (!dryRun) {
+            const ok = window.confirm(
+                `Delete all CrowdStrike-tracked assets not re-imported in the last ${days} days?\n\n` +
+                `This cascades to vulnerabilities, scan results, and workgroup links. ` +
+                `It cannot be undone. Run a dry-run first if you have not.`
+            );
+            if (!ok) return;
+        }
+        try {
+            setBusy(true);
+            setError(null);
+            setInfo(null);
+            const res = await axios.post('/api/assets/delete-not-seen-by-crowdstrike', {
+                days,
+                dryRun
+            });
+            const r = res.data || {};
+            const verb = dryRun ? 'Dry-run' : 'Cleanup';
+            setInfo(
+                `${verb} complete — candidates: ${r.candidateCount ?? 0}, ` +
+                `deleted: ${r.deletedCount ?? 0}, errors: ${(r.errors?.length) ?? 0}` +
+                (r.status ? ` (status: ${r.status})` : '')
+            );
+            await load();
+        } catch (e: any) {
+            setError(e.response?.data?.error || 'Cleanup request failed');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (!isAdmin && !loading) {
+        return null;
+    }
+
+    return (
+        <div className="card mt-4">
+            <div className="card-header d-flex justify-content-between align-items-center">
+                <h5 className="mb-0">
+                    <i className="bi bi-trash3 me-2"></i>
+                    Stale Asset Cleanup
+                </h5>
+                <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary"
+                    onClick={load}
+                    disabled={loading || busy}
+                    title="Refresh"
+                >
+                    <i className="bi bi-arrow-clockwise"></i>
+                </button>
+            </div>
+            <div className="card-body">
+                {error && <div className="alert alert-danger">{error}</div>}
+                {info && <div className="alert alert-info">{info}</div>}
+
+                {loading ? (
+                    <div>Loading…</div>
+                ) : (
+                    <>
+                        <div className="row g-3 mb-3">
+                            <div className="col-md-3">
+                                <div className="border rounded p-2">
+                                    <small className="text-muted">Scheduler</small>
+                                    <div>
+                                        {config?.enabled ? (
+                                            <span className="badge bg-success">Enabled</span>
+                                        ) : (
+                                            <span className="badge bg-secondary">Disabled</span>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="col-md-3">
+                                <div className="border rounded p-2">
+                                    <small className="text-muted">Stale threshold</small>
+                                    <div>{config?.staleDays} days</div>
+                                </div>
+                            </div>
+                            <div className="col-md-3">
+                                <div className="border rounded p-2">
+                                    <small className="text-muted">Safety brake</small>
+                                    <div>
+                                        {config?.maxDeletePercent}%
+                                        {config && config.maxDeletePercent >= 100 && (
+                                            <span className="text-muted ms-2">(off)</span>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="col-md-3">
+                                <div className="border rounded p-2">
+                                    <small className="text-muted">Cron (server TZ)</small>
+                                    <div><code>{config?.cron}</code></div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="row g-2 align-items-end mb-3">
+                            <div className="col-auto">
+                                <label className="form-label">Stale days for manual run</label>
+                                <input
+                                    type="number"
+                                    min={1}
+                                    max={3650}
+                                    className="form-control"
+                                    value={days}
+                                    onChange={e => setDays(Number(e.target.value) || 0)}
+                                    disabled={busy}
+                                />
+                            </div>
+                            <div className="col-auto">
+                                <button
+                                    type="button"
+                                    className="btn btn-outline-primary"
+                                    onClick={() => trigger(true)}
+                                    disabled={busy || days <= 0}
+                                >
+                                    <i className="bi bi-eye me-1"></i>
+                                    Dry-run
+                                </button>
+                            </div>
+                            <div className="col-auto">
+                                <button
+                                    type="button"
+                                    className="btn btn-danger"
+                                    onClick={() => trigger(false)}
+                                    disabled={busy || days <= 0}
+                                >
+                                    <i className="bi bi-trash me-1"></i>
+                                    Run cleanup now
+                                </button>
+                            </div>
+                            <div className="col text-muted small">
+                                Manual runs do not apply the safety brake. Always dry-run first.
+                            </div>
+                        </div>
+
+                        <h6>Recent runs</h6>
+                        {runs.length === 0 ? (
+                            <p className="text-muted mb-0">No cleanup runs recorded yet.</p>
+                        ) : (
+                            <div className="table-responsive">
+                                <table className="table table-sm align-middle">
+                                    <thead>
+                                        <tr>
+                                            <th>Started</th>
+                                            <th>Status</th>
+                                            <th>Trigger</th>
+                                            <th className="text-end">Stale days</th>
+                                            <th className="text-end">Candidates</th>
+                                            <th className="text-end">Deleted</th>
+                                            <th className="text-end">Errors</th>
+                                            <th className="text-end">Duration</th>
+                                            <th>Note</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {runs.map(r => (
+                                            <tr key={r.id}>
+                                                <td><code>{r.startedAt}</code></td>
+                                                <td>
+                                                    <span className={`badge ${STATUS_BADGE[r.status]}`}>
+                                                        {r.status}
+                                                    </span>
+                                                </td>
+                                                <td>{r.triggeredBy}</td>
+                                                <td className="text-end">{r.staleDays}</td>
+                                                <td className="text-end">{r.candidateCount}</td>
+                                                <td className="text-end">{r.deletedCount}</td>
+                                                <td className="text-end">{r.errorCount}</td>
+                                                <td className="text-end">
+                                                    {r.durationMs != null ? `${r.durationMs} ms` : '—'}
+                                                </td>
+                                                <td className="text-muted small" style={{ maxWidth: 320 }}>
+                                                    {r.errorMessage ?? ''}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default CrowdStrikeStaleAssetCleanup;

--- a/src/frontend/src/pages/admin/falcon-config.astro
+++ b/src/frontend/src/pages/admin/falcon-config.astro
@@ -1,10 +1,12 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import FalconConfigManagement from '../../components/FalconConfigManagement';
+import CrowdStrikeStaleAssetCleanup from '../../components/CrowdStrikeStaleAssetCleanup';
 ---
 
 <Layout title="CrowdStrike Falcon Configuration - Admin">
   <FalconConfigManagement client:load />
+  <CrowdStrikeStaleAssetCleanup client:load />
   <div class="mt-4">
     <a href="/admin" class="btn btn-secondary">Back to Admin</a>
   </div>


### PR DESCRIPTION
Adds a daily scheduled job (02:30 server TZ) that deletes assets whose
CrowdStrike-import timestamp is older than `stale-days` days, plus a per-run
safety brake, an audit-row history, admin-email notifications, and a
"Stale Asset Cleanup" panel on the Falcon config page. Manual runs (existing
endpoint + CLI) now also persist audit rows so the history view captures every
deletion regardless of trigger.

- Opt-in: `secman.crowdstrike.cleanup.enabled=false` by default; flip via
  `CROWDSTRIKE_CLEANUP_ENABLED=true`.
- Safety brake: aborts the scheduled run when candidates exceed
  `max-delete-percent` of CrowdStrike-tracked assets (default 10%); manual
  runs bypass the brake.
- Audit table `crowdstrike_cleanup_run` is Hibernate auto-created.
- Notifications fire only on non-boring runs (deletions > 0, errors, or brake).

New endpoints (ADMIN):
  GET /api/crowdstrike/cleanup/config  — current config snapshot
  GET /api/crowdstrike/cleanup/runs    — recent run history

Tests: CrowdStrikeCleanupAuditServiceTest covers dry-run skip, success/partial
audit, safety-brake abort, brake-disabled passthrough, zero-tracked passthrough,
and cleanup-service exception capture. `./gradlew :backendng:test` 74/74 pass;
`npm run build` (Astro) clean. Live runtime + E2E gates require pass-cli (not
available in this environment) and should be run before merge.

https://claude.ai/code/session_0184aTgSL7k3c4k5zf7cv7iu