### PR TITLE
feat: add admin email broadcast (HTML, WYSIWYG, async send)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/EmailBroadcastController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/EmailBroadcastController.kt
@@ -1,0 +1,77 @@
+package com.secman.controller
+
+import com.secman.domain.EmailBroadcastJob
+import com.secman.service.EmailBroadcastService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.*
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.slf4j.LoggerFactory
+
+/**
+ * Admin-only email broadcast.
+ *
+ * Endpoints:
+ *  - GET  /api/admin/email-broadcast/recipients   -> { count }
+ *  - POST /api/admin/email-broadcast              -> creates job, kicks off async send
+ *  - GET  /api/admin/email-broadcast/jobs         -> recent jobs (newest first)
+ *  - GET  /api/admin/email-broadcast/jobs/{id}    -> job status
+ */
+@Controller("/api/admin/email-broadcast")
+@Secured("ADMIN")
+@ExecuteOn(TaskExecutors.IO)
+open class EmailBroadcastController(
+    private val emailBroadcastService: EmailBroadcastService
+) {
+    private val log = LoggerFactory.getLogger(EmailBroadcastController::class.java)
+
+    @Get("/recipients")
+    open fun recipientCount(): HttpResponse<Map<String, Long>> =
+        HttpResponse.ok(mapOf("count" to emailBroadcastService.recipientCount()))
+
+    @Post
+    open fun createBroadcast(
+        @Body @Valid request: BroadcastRequest,
+        authentication: Authentication
+    ): HttpResponse<EmailBroadcastJob> {
+        val htmlText = request.htmlContent.trim()
+        if (htmlText.isEmpty()) {
+            return HttpResponse.badRequest()
+        }
+
+        val job = emailBroadcastService.createJob(
+            subject = request.subject,
+            htmlContent = htmlText,
+            createdBy = authentication.name
+        )
+
+        if (job.totalRecipients == 0) {
+            log.warn("Broadcast {} created with 0 recipients", job.id)
+        }
+
+        emailBroadcastService.runJobAsync(job.id!!)
+        log.info("Broadcast job {} kicked off by {} for {} recipients", job.id, authentication.name, job.totalRecipients)
+        return HttpResponse.created(job)
+    }
+
+    @Get("/jobs")
+    open fun listJobs(): HttpResponse<List<EmailBroadcastJob>> =
+        HttpResponse.ok(emailBroadcastService.listRecentJobs())
+
+    @Get("/jobs/{id}")
+    open fun getJob(@PathVariable id: Long): HttpResponse<EmailBroadcastJob> {
+        val job = emailBroadcastService.getJob(id) ?: return HttpResponse.notFound()
+        return HttpResponse.ok(job)
+    }
+
+    @io.micronaut.serde.annotation.Serdeable
+    data class BroadcastRequest(
+        @field:NotBlank @field:Size(max = 255) val subject: String,
+        @field:NotBlank @field:Size(max = 1_000_000) val htmlContent: String
+    )
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
@@ -1,0 +1,72 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotBlank
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "email_broadcast_jobs",
+    indexes = [
+        Index(name = "idx_email_broadcast_status", columnList = "status"),
+        Index(name = "idx_email_broadcast_created_at", columnList = "created_at")
+    ]
+)
+@Serdeable
+class EmailBroadcastJob(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: EmailBroadcastStatus = EmailBroadcastStatus.PENDING,
+
+    @Column(nullable = false, length = 255)
+    @NotBlank
+    var subject: String,
+
+    @Column(name = "html_content", nullable = false, columnDefinition = "MEDIUMTEXT")
+    @NotBlank
+    var htmlContent: String,
+
+    @Column(name = "total_recipients", nullable = false)
+    var totalRecipients: Int = 0,
+
+    @Column(name = "sent_count", nullable = false)
+    var sentCount: Int = 0,
+
+    @Column(name = "failed_count", nullable = false)
+    var failedCount: Int = 0,
+
+    @Column(name = "error_message", length = 2000)
+    var errorMessage: String? = null,
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    var createdBy: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "started_at")
+    var startedAt: LocalDateTime? = null,
+
+    @Column(name = "completed_at")
+    var completedAt: LocalDateTime? = null
+) {
+    fun progressPercent(): Int {
+        if (totalRecipients == 0) return 0
+        return (((sentCount + failedCount).toLong() * 100) / totalRecipients).toInt().coerceIn(0, 100)
+    }
+}
+
+enum class EmailBroadcastStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/EmailBroadcastJobRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/EmailBroadcastJobRepository.kt
@@ -1,0 +1,11 @@
+package com.secman.repository
+
+import com.secman.domain.EmailBroadcastJob
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+
+@Repository
+interface EmailBroadcastJobRepository : JpaRepository<EmailBroadcastJob, Long> {
+    @io.micronaut.data.annotation.Query("SELECT j FROM EmailBroadcastJob j ORDER BY j.createdAt DESC")
+    fun listRecent(): List<EmailBroadcastJob>
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/UserRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/UserRepository.kt
@@ -107,6 +107,14 @@ interface UserRepository : JpaRepository<User, Long> {
     """)
     fun findByRolesContaining(role: User.Role): List<User>
 
+    /**
+     * Find all users that have logged in at least once.
+     * Used by the admin broadcast feature to skip pending (never-activated) accounts.
+     */
+    fun findByLastLoginIsNotNull(): List<User>
+
+    fun countByLastLoginIsNotNull(): Long
+
     // Note: For other admin user queries, use findAll() and filter in service layer
     // (e.g., users.filter { it.hasRole(Role.ADMIN) })
 }

--- a/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
@@ -1,0 +1,199 @@
+package com.secman.service
+
+import com.secman.domain.EmailBroadcastJob
+import com.secman.domain.EmailBroadcastStatus
+import com.secman.repository.EmailBroadcastJobRepository
+import com.secman.repository.UserRepository
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+import org.jsoup.Jsoup
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Async broadcast service. Each broadcast renders the admin-supplied HTML inside a
+ * SecMan branded shell (logo + footer) and sends to every user with `lastLogin != null`.
+ */
+@Singleton
+@ExecuteOn(TaskExecutors.IO)
+open class EmailBroadcastService(
+    private val emailBroadcastJobRepository: EmailBroadcastJobRepository,
+    private val userRepository: UserRepository,
+    private val emailService: EmailService
+) {
+    private val log = LoggerFactory.getLogger(EmailBroadcastService::class.java)
+
+    @Transactional
+    open fun createJob(subject: String, htmlContent: String, createdBy: String): EmailBroadcastJob {
+        val total = userRepository.countByLastLoginIsNotNull().toInt()
+        val job = EmailBroadcastJob(
+            status = EmailBroadcastStatus.PENDING,
+            subject = subject.trim(),
+            htmlContent = htmlContent,
+            totalRecipients = total,
+            createdBy = createdBy,
+            createdAt = LocalDateTime.now()
+        )
+        return emailBroadcastJobRepository.save(job)
+    }
+
+    /**
+     * Kicks off the send loop. Returns a CompletableFuture so callers may join during tests.
+     */
+    fun runJobAsync(jobId: Long): CompletableFuture<Void> {
+        return CompletableFuture.runAsync {
+            try {
+                runJob(jobId)
+            } catch (e: Exception) {
+                log.error("Email broadcast job {} crashed: {}", jobId, e.message, e)
+                markFailed(jobId, e.message ?: e.javaClass.simpleName)
+            }
+        }
+    }
+
+    private fun runJob(jobId: Long) {
+        val job = emailBroadcastJobRepository.findById(jobId).orElse(null) ?: run {
+            log.warn("Broadcast job {} not found", jobId)
+            return
+        }
+
+        markProcessing(jobId)
+
+        val recipients = userRepository.findByLastLoginIsNotNull()
+        log.info("Broadcast job {}: dispatching to {} recipients", jobId, recipients.size)
+
+        val wrappedHtml = wrapWithBrand(job.subject, job.htmlContent)
+        val textContent = htmlToText(job.htmlContent)
+        val logo = loadLogoInlineImage()
+
+        var sent = 0
+        var failed = 0
+        recipients.forEach { user ->
+            val ok = try {
+                emailService.sendEmailWithInlineImages(
+                    to = user.email,
+                    subject = job.subject,
+                    textContent = textContent,
+                    htmlContent = wrappedHtml,
+                    inlineImages = logo
+                ).get()
+            } catch (e: Exception) {
+                log.warn("Broadcast job {}: send to {} failed: {}", jobId, user.email, e.message)
+                false
+            }
+            if (ok) sent++ else failed++
+
+            // Persist progress every 25 messages so the UI poller has fresh data.
+            if ((sent + failed) % 25 == 0) {
+                updateProgress(jobId, sent, failed)
+            }
+        }
+
+        finalize(jobId, sent, failed)
+        log.info("Broadcast job {} complete: {} sent, {} failed", jobId, sent, failed)
+    }
+
+    @Transactional
+    open fun markProcessing(jobId: Long) {
+        emailBroadcastJobRepository.findById(jobId).ifPresent { job ->
+            job.status = EmailBroadcastStatus.PROCESSING
+            job.startedAt = LocalDateTime.now()
+            emailBroadcastJobRepository.update(job)
+        }
+    }
+
+    @Transactional
+    open fun updateProgress(jobId: Long, sent: Int, failed: Int) {
+        emailBroadcastJobRepository.findById(jobId).ifPresent { job ->
+            job.sentCount = sent
+            job.failedCount = failed
+            emailBroadcastJobRepository.update(job)
+        }
+    }
+
+    @Transactional
+    open fun finalize(jobId: Long, sent: Int, failed: Int) {
+        emailBroadcastJobRepository.findById(jobId).ifPresent { job ->
+            job.sentCount = sent
+            job.failedCount = failed
+            // FAILED only when nothing got through; partial success stays COMPLETED with failedCount > 0.
+            job.status = if (sent == 0 && failed > 0) EmailBroadcastStatus.FAILED else EmailBroadcastStatus.COMPLETED
+            job.completedAt = LocalDateTime.now()
+            emailBroadcastJobRepository.update(job)
+        }
+    }
+
+    @Transactional
+    open fun markFailed(jobId: Long, message: String) {
+        emailBroadcastJobRepository.findById(jobId).ifPresent { job ->
+            job.status = EmailBroadcastStatus.FAILED
+            job.errorMessage = message.take(2000)
+            job.completedAt = LocalDateTime.now()
+            emailBroadcastJobRepository.update(job)
+        }
+    }
+
+    fun listRecentJobs(limit: Int = 50): List<EmailBroadcastJob> =
+        emailBroadcastJobRepository.listRecent().take(limit)
+
+    fun getJob(id: Long): EmailBroadcastJob? = emailBroadcastJobRepository.findById(id).orElse(null)
+
+    fun recipientCount(): Long = userRepository.countByLastLoginIsNotNull()
+
+    private fun loadLogoInlineImage(): Map<String, Pair<ByteArray, String>> {
+        return try {
+            val bytes = javaClass.getResourceAsStream("/email-templates/SecManLogo.png")?.readAllBytes()
+            if (bytes != null) mapOf("secman-logo" to (bytes to "image/png")) else emptyMap()
+        } catch (e: Exception) {
+            log.warn("Failed to load SecManLogo.png: {}", e.message)
+            emptyMap()
+        }
+    }
+
+    private fun wrapWithBrand(subject: String, body: String): String {
+        val safeSubject = Jsoup.parse(subject).text()
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8" />
+                <title>${safeSubject}</title>
+            </head>
+            <body style="margin:0;padding:0;background-color:#f4f4f4;font-family:Arial,sans-serif;color:#333;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f4f4;padding:20px 0;">
+                    <tr>
+                        <td align="center">
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="background-color:#ffffff;border-radius:6px;overflow:hidden;">
+                                <tr>
+                                    <td style="padding:24px 24px 0 24px;text-align:center;">
+                                        <img src="cid:secman-logo" alt="SecMan" style="max-width:180px;height:auto;" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:24px;line-height:1.6;font-size:14px;color:#333;">
+                                        ${body}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:16px 24px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;text-align:center;">
+                                        This is an automated notification from SecMan. Please do not reply to this email.
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun htmlToText(html: String): String = try {
+        Jsoup.parse(html).text()
+    } catch (_: Exception) {
+        html.replace(Regex("<[^>]*>"), "").replace(Regex("\\s+"), " ").trim()
+    }
+}

--- a/src/backendng/src/main/resources/db/migration/V211__email_broadcast_jobs.sql
+++ b/src/backendng/src/main/resources/db/migration/V211__email_broadcast_jobs.sql
@@ -1,0 +1,19 @@
+-- Feature: Admin email broadcast
+-- Stores HTML broadcast jobs (subject + body) and per-recipient progress.
+
+CREATE TABLE email_broadcast_jobs (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    status VARCHAR(20) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    html_content MEDIUMTEXT NOT NULL,
+    total_recipients INT NOT NULL DEFAULT 0,
+    sent_count INT NOT NULL DEFAULT 0,
+    failed_count INT NOT NULL DEFAULT 0,
+    error_message VARCHAR(2000) NULL,
+    created_by VARCHAR(100) NOT NULL,
+    created_at DATETIME NOT NULL,
+    started_at DATETIME NULL,
+    completed_at DATETIME NULL,
+    INDEX idx_email_broadcast_status (status),
+    INDEX idx_email_broadcast_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/frontend/src/components/AdminPage.tsx
+++ b/src/frontend/src/components/AdminPage.tsx
@@ -253,6 +253,21 @@ const AdminPage = () => {
                     <div className="card">
                         <div className="card-body">
                             <h5 className="card-title">
+                                <i className="bi bi-megaphone-fill me-2"></i>
+                                Email Broadcast
+                            </h5>
+                            <p className="card-text">Compose and send a one-off HTML email to every active SecMan user.</p>
+                            <a href="/admin/email-broadcast" className="btn btn-primary">
+                                Compose Broadcast
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="col-md-4 mb-3">
+                    <div className="card">
+                        <div className="card-body">
+                            <h5 className="card-title">
                                 <i className="bi bi-exclamation-triangle-fill text-warning me-2"></i>
                                 Maintenance Banners
                             </h5>

--- a/src/frontend/src/components/admin/EmailBroadcastManager.tsx
+++ b/src/frontend/src/components/admin/EmailBroadcastManager.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import HtmlEditor from './HtmlEditor';
+import {
+  createBroadcast,
+  getJob,
+  getRecipientCount,
+  listJobs,
+  type EmailBroadcastJob,
+} from '../../services/emailBroadcastService';
+
+const ACTIVE_STATUSES = new Set<EmailBroadcastJob['status']>(['PENDING', 'PROCESSING']);
+
+function StatusBadge({ status }: { status: EmailBroadcastJob['status'] }) {
+  const cls =
+    status === 'COMPLETED'
+      ? 'bg-success'
+      : status === 'FAILED'
+      ? 'bg-danger'
+      : status === 'PROCESSING'
+      ? 'bg-primary'
+      : 'bg-secondary';
+  return <span className={`badge ${cls}`}>{status}</span>;
+}
+
+function progressPercent(job: EmailBroadcastJob): number {
+  if (!job.totalRecipients) return 0;
+  return Math.min(100, Math.round(((job.sentCount + job.failedCount) * 100) / job.totalRecipients));
+}
+
+export default function EmailBroadcastManager() {
+  const [recipientCount, setRecipientCount] = useState<number | null>(null);
+  const [subject, setSubject] = useState('');
+  const [html, setHtml] = useState('<p>Hello,</p><p>Type your announcement here.</p>');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [jobs, setJobs] = useState<EmailBroadcastJob[]>([]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [activeJobId, setActiveJobId] = useState<number | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refresh = async () => {
+    try {
+      const [count, list] = await Promise.all([getRecipientCount(), listJobs()]);
+      setRecipientCount(count);
+      setJobs(list);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Failed to load broadcast data';
+      setError(msg);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  // Poll while there's an active job in the list.
+  useEffect(() => {
+    const hasActive = jobs.some((j) => ACTIVE_STATUSES.has(j.status));
+    if (!hasActive) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+    if (!pollRef.current) {
+      pollRef.current = setInterval(() => {
+        listJobs()
+          .then(setJobs)
+          .catch(() => {});
+      }, 2500);
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [jobs]);
+
+  const canSubmit = useMemo(() => {
+    return subject.trim().length > 0 && html.replace(/<[^>]*>/g, '').trim().length > 0 && !submitting;
+  }, [subject, html, submitting]);
+
+  const handleSend = async () => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      const job = await createBroadcast({ subject: subject.trim(), htmlContent: html });
+      setActiveJobId(job.id);
+      setJobs((prev) => [job, ...prev]);
+      setConfirmOpen(false);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Failed to start broadcast';
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const activeJob = activeJobId ? jobs.find((j) => j.id === activeJobId) || null : null;
+
+  // Poll the active job for live progress.
+  useEffect(() => {
+    if (!activeJobId) return;
+    const id = activeJobId;
+    const t = setInterval(async () => {
+      try {
+        const fresh = await getJob(id);
+        setJobs((prev) => {
+          const next = [...prev];
+          const idx = next.findIndex((j) => j.id === id);
+          if (idx >= 0) next[idx] = fresh;
+          return next;
+        });
+        if (!ACTIVE_STATUSES.has(fresh.status)) {
+          clearInterval(t);
+        }
+      } catch {
+        /* ignore */
+      }
+    }, 2000);
+    return () => clearInterval(t);
+  }, [activeJobId]);
+
+  return (
+    <div>
+      <div className="row mt-3">
+        <div className="col-lg-8">
+          <div className="card">
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <h5 className="mb-0">Compose Broadcast</h5>
+              <span className="text-muted small">
+                Recipients:{' '}
+                <strong>
+                  {recipientCount === null ? '…' : recipientCount}
+                </strong>{' '}
+                user{recipientCount === 1 ? '' : 's'} (excludes pending accounts that have never logged in)
+              </span>
+            </div>
+            <div className="card-body">
+              {error && (
+                <div className="alert alert-danger" role="alert">
+                  {error}
+                </div>
+              )}
+
+              <div className="mb-3">
+                <label htmlFor="subject" className="form-label">
+                  Subject
+                </label>
+                <input
+                  id="subject"
+                  className="form-control"
+                  value={subject}
+                  maxLength={255}
+                  onChange={(e) => setSubject(e.target.value)}
+                  placeholder="e.g. Scheduled maintenance this Saturday"
+                />
+              </div>
+
+              <div className="mb-3">
+                <label className="form-label">Message</label>
+                <HtmlEditor value={html} onChange={setHtml} />
+                <div className="form-text">
+                  The SecMan logo and a footer are added automatically when sent.
+                </div>
+              </div>
+
+              <div className="d-flex gap-2">
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={!canSubmit}
+                  onClick={() => setConfirmOpen(true)}
+                >
+                  <i className="bi bi-send me-1"></i>
+                  Send to {recipientCount ?? '…'} user{recipientCount === 1 ? '' : 's'}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={() => {
+                    setSubject('');
+                    setHtml('<p></p>');
+                  }}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="card mt-4">
+            <div className="card-header">
+              <h5 className="mb-0">Live Preview</h5>
+            </div>
+            <div className="card-body p-0" style={{ background: '#f4f4f4' }}>
+              <div
+                style={{
+                  maxWidth: 600,
+                  margin: '20px auto',
+                  background: '#fff',
+                  borderRadius: 6,
+                  overflow: 'hidden',
+                }}
+              >
+                <div style={{ padding: '24px 24px 0 24px', textAlign: 'center' }}>
+                  <img
+                    src="/SecManLogo.png"
+                    alt="SecMan"
+                    style={{ maxWidth: 180, height: 'auto' }}
+                  />
+                </div>
+                <div
+                  style={{ padding: 24, lineHeight: 1.6, fontSize: 14, color: '#333' }}
+                  dangerouslySetInnerHTML={{ __html: html }}
+                />
+                <div
+                  style={{
+                    padding: '16px 24px',
+                    borderTop: '1px solid #e5e5e5',
+                    fontSize: 12,
+                    color: '#888',
+                    textAlign: 'center',
+                  }}
+                >
+                  This is an automated notification from SecMan. Please do not reply to this email.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-lg-4">
+          <div className="card">
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <h5 className="mb-0">Recent broadcasts</h5>
+              <button type="button" className="btn btn-sm btn-outline-secondary" onClick={refresh}>
+                <i className="bi bi-arrow-clockwise"></i>
+              </button>
+            </div>
+            <div className="list-group list-group-flush">
+              {jobs.length === 0 && <div className="list-group-item text-muted">No broadcasts yet.</div>}
+              {jobs.map((j) => (
+                <div key={j.id} className="list-group-item">
+                  <div className="d-flex justify-content-between align-items-start">
+                    <div className="me-2" style={{ minWidth: 0, flex: 1 }}>
+                      <div className="text-truncate fw-semibold" title={j.subject}>
+                        {j.subject}
+                      </div>
+                      <div className="small text-muted">
+                        {j.createdBy} · {new Date(j.createdAt).toLocaleString()}
+                      </div>
+                    </div>
+                    <StatusBadge status={j.status} />
+                  </div>
+                  <div className="progress mt-2" style={{ height: 6 }}>
+                    <div
+                      className={`progress-bar ${j.status === 'FAILED' ? 'bg-danger' : ''}`}
+                      role="progressbar"
+                      style={{ width: `${progressPercent(j)}%` }}
+                      aria-valuenow={progressPercent(j)}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    />
+                  </div>
+                  <div className="small text-muted mt-1">
+                    {j.sentCount} sent
+                    {j.failedCount > 0 && (
+                      <span className="text-danger ms-2">{j.failedCount} failed</span>
+                    )}{' '}
+                    of {j.totalRecipients}
+                  </div>
+                  {j.errorMessage && (
+                    <div className="small text-danger mt-1" title={j.errorMessage}>
+                      {j.errorMessage}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Confirm modal */}
+      {confirmOpen && (
+        <div
+          className="modal show d-block"
+          tabIndex={-1}
+          role="dialog"
+          style={{ background: 'rgba(0,0,0,0.5)' }}
+          onClick={() => !submitting && setConfirmOpen(false)}
+        >
+          <div className="modal-dialog modal-dialog-centered" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Confirm broadcast</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  disabled={submitting}
+                  onClick={() => setConfirmOpen(false)}
+                />
+              </div>
+              <div className="modal-body">
+                <p>
+                  This will send the email to{' '}
+                  <strong>
+                    {recipientCount ?? 0} user{recipientCount === 1 ? '' : 's'}
+                  </strong>
+                  . Pending accounts that have never logged in are excluded.
+                </p>
+                <p className="mb-0">
+                  Subject: <em>{subject}</em>
+                </p>
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={submitting}
+                  onClick={() => setConfirmOpen(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={submitting}
+                  onClick={handleSend}
+                >
+                  {submitting ? 'Sending…' : 'Send now'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeJob && ACTIVE_STATUSES.has(activeJob.status) && (
+        <div
+          className="position-fixed bottom-0 end-0 m-4 p-3 bg-white border rounded shadow"
+          style={{ width: 320, zIndex: 1080 }}
+        >
+          <div className="d-flex justify-content-between align-items-center mb-2">
+            <strong>Sending broadcast…</strong>
+            <StatusBadge status={activeJob.status} />
+          </div>
+          <div className="progress" style={{ height: 6 }}>
+            <div
+              className="progress-bar progress-bar-striped progress-bar-animated"
+              style={{ width: `${progressPercent(activeJob)}%` }}
+            />
+          </div>
+          <div className="small text-muted mt-1">
+            {activeJob.sentCount + activeJob.failedCount} / {activeJob.totalRecipients}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/HtmlEditor.tsx
+++ b/src/frontend/src/components/admin/HtmlEditor.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (html: string) => void;
+  minHeight?: number;
+}
+
+interface ToolbarButton {
+  cmd: string;
+  arg?: string;
+  icon: string;
+  title: string;
+}
+
+const TOOLBAR: ToolbarButton[] = [
+  { cmd: 'bold', icon: 'bi-type-bold', title: 'Bold' },
+  { cmd: 'italic', icon: 'bi-type-italic', title: 'Italic' },
+  { cmd: 'underline', icon: 'bi-type-underline', title: 'Underline' },
+  { cmd: 'formatBlock', arg: 'h2', icon: 'bi-type-h2', title: 'Heading' },
+  { cmd: 'formatBlock', arg: 'p', icon: 'bi-paragraph', title: 'Paragraph' },
+  { cmd: 'insertUnorderedList', icon: 'bi-list-ul', title: 'Bullet list' },
+  { cmd: 'insertOrderedList', icon: 'bi-list-ol', title: 'Numbered list' },
+];
+
+export default function HtmlEditor({ value, onChange, minHeight = 280 }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [showSource, setShowSource] = useState(false);
+  const lastEmittedRef = useRef(value);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    if (value !== lastEmittedRef.current) {
+      ref.current.innerHTML = value;
+      lastEmittedRef.current = value;
+    }
+  }, [value]);
+
+  const exec = (cmd: string, arg?: string) => {
+    ref.current?.focus();
+    document.execCommand(cmd, false, arg);
+    handleInput();
+  };
+
+  const insertLink = () => {
+    const url = window.prompt('Link URL (https://...)');
+    if (!url) return;
+    exec('createLink', url);
+  };
+
+  const handleInput = () => {
+    if (!ref.current) return;
+    const html = ref.current.innerHTML;
+    lastEmittedRef.current = html;
+    onChange(html);
+  };
+
+  return (
+    <div className="border rounded">
+      <div className="d-flex flex-wrap align-items-center gap-1 px-2 py-1 border-bottom bg-light">
+        {TOOLBAR.map((b) => (
+          <button
+            key={`${b.cmd}-${b.arg ?? ''}`}
+            type="button"
+            className="btn btn-sm btn-outline-secondary"
+            title={b.title}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => exec(b.cmd, b.arg)}
+          >
+            <i className={`bi ${b.icon}`}></i>
+          </button>
+        ))}
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-secondary"
+          title="Insert link"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={insertLink}
+        >
+          <i className="bi bi-link-45deg"></i>
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-secondary"
+          title="Remove formatting"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => exec('removeFormat')}
+        >
+          <i className="bi bi-eraser"></i>
+        </button>
+        <div className="ms-auto">
+          <button
+            type="button"
+            className={`btn btn-sm ${showSource ? 'btn-secondary' : 'btn-outline-secondary'}`}
+            onClick={() => setShowSource((v) => !v)}
+          >
+            <i className="bi bi-code-slash me-1"></i>
+            {showSource ? 'Editor' : 'HTML'}
+          </button>
+        </div>
+      </div>
+
+      {showSource ? (
+        <textarea
+          className="form-control border-0"
+          style={{ minHeight, fontFamily: 'monospace', fontSize: 13, resize: 'vertical' }}
+          value={value}
+          onChange={(e) => {
+            lastEmittedRef.current = e.target.value;
+            onChange(e.target.value);
+          }}
+        />
+      ) : (
+        <div
+          ref={ref}
+          contentEditable
+          suppressContentEditableWarning
+          className="p-3"
+          style={{ minHeight, outline: 'none' }}
+          onInput={handleInput}
+          onBlur={handleInput}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/admin/email-broadcast.astro
+++ b/src/frontend/src/pages/admin/email-broadcast.astro
@@ -1,0 +1,31 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import EmailBroadcastManager from '../../components/admin/EmailBroadcastManager';
+---
+
+<Layout title="Admin - Email Broadcast">
+    <div class="container-fluid mt-4">
+        <div class="row">
+            <div class="col-12">
+                <h2 class="mb-3">
+                    <i class="bi bi-megaphone-fill me-2"></i>
+                    Email Broadcast
+                </h2>
+                <p class="text-muted">
+                    Send a one-off HTML email to every SecMan user that has logged in at least once.
+                    Pending accounts (never logged in) are excluded automatically. The SecMan logo and
+                    footer are added to every message.
+                </p>
+            </div>
+        </div>
+
+        <EmailBroadcastManager client:load />
+
+        <div class="mt-4">
+            <a href="/admin" class="btn btn-secondary">
+                <i class="bi bi-arrow-left me-2"></i>
+                Back to Admin
+            </a>
+        </div>
+    </div>
+</Layout>

--- a/src/frontend/src/services/emailBroadcastService.ts
+++ b/src/frontend/src/services/emailBroadcastService.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.PUBLIC_API_URL || '/api';
+const ROOT = `${API_BASE}/admin/email-broadcast`;
+
+export type EmailBroadcastStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+
+export interface EmailBroadcastJob {
+  id: number;
+  status: EmailBroadcastStatus;
+  subject: string;
+  htmlContent: string;
+  totalRecipients: number;
+  sentCount: number;
+  failedCount: number;
+  errorMessage: string | null;
+  createdBy: string;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface BroadcastRequest {
+  subject: string;
+  htmlContent: string;
+}
+
+export async function getRecipientCount(): Promise<number> {
+  const res = await axios.get<{ count: number }>(`${ROOT}/recipients`);
+  return res.data.count;
+}
+
+export async function createBroadcast(payload: BroadcastRequest): Promise<EmailBroadcastJob> {
+  const res = await axios.post<EmailBroadcastJob>(ROOT, payload);
+  return res.data;
+}
+
+export async function listJobs(): Promise<EmailBroadcastJob[]> {
+  const res = await axios.get<EmailBroadcastJob[]>(`${ROOT}/jobs`);
+  return res.data;
+}
+
+export async function getJob(id: number): Promise<EmailBroadcastJob> {
+  const res = await axios.get<EmailBroadcastJob>(`${ROOT}/jobs/${id}`);
+  return res.data;
+}


### PR DESCRIPTION
Adds an ADMIN-only feature to compose and send a one-off HTML email to
every SecMan user that has logged in at least once (i.e. excludes pending
accounts). Sending is async and progress is tracked per job.

Backend:
- Flyway V211: email_broadcast_jobs table.
- EmailBroadcastJob entity + repository (recent-jobs query).
- UserRepository: findByLastLoginIsNotNull / countByLastLoginIsNotNull.
- EmailBroadcastService: creates a job, runs the send loop on the IO
  pool, wraps the admin's HTML in a SecMan-branded shell with the logo
  embedded as a CID inline image (loaded from /email-templates/SecManLogo.png),
  and persists progress every 25 messages. Auto-derives plain-text via Jsoup.
- EmailBroadcastController under /api/admin/email-broadcast: recipient
  count, create job (kicks off async send), list recent jobs, fetch by id.

Frontend:
- /admin/email-broadcast page with a card on the admin landing.
- HtmlEditor: contentEditable WYSIWYG with a small toolbar
  (bold/italic/underline/heading/lists/link) plus an HTML source toggle.
- EmailBroadcastManager: subject + editor + recipient counter, live
  preview of the SecMan-branded email shell, confirm modal, and a recent-
  broadcasts pane that polls active jobs for live progress.