### PR TITLE
feat: expose last CrowdStrike import date via CLI and MCP

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -92,7 +92,9 @@ class McpToolRegistry(
     // Feature: Workgroup AWS Account Assignment
     @Inject private val listWorkgroupAwsAccountsTool: ListWorkgroupAwsAccountsTool,
     @Inject private val addWorkgroupAwsAccountTool: AddWorkgroupAwsAccountTool,
-    @Inject private val removeWorkgroupAwsAccountTool: RemoveWorkgroupAwsAccountTool
+    @Inject private val removeWorkgroupAwsAccountTool: RemoveWorkgroupAwsAccountTool,
+    // CrowdStrike import status
+    @Inject private val getCrowdStrikeLastImportTool: GetCrowdStrikeLastImportTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -181,7 +183,9 @@ class McpToolRegistry(
             // Feature: Workgroup AWS Account Assignment
             listWorkgroupAwsAccountsTool,
             addWorkgroupAwsAccountTool,
-            removeWorkgroupAwsAccountTool
+            removeWorkgroupAwsAccountTool,
+            // CrowdStrike import status
+            getCrowdStrikeLastImportTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -450,6 +454,11 @@ class McpToolRegistry(
             // Feature: Workgroup AWS Account Assignment (ADMIN only via User Delegation)
             "list_workgroup_aws_accounts", "add_workgroup_aws_account", "remove_workgroup_aws_account" -> {
                 permissions.contains(McpPermission.WORKGROUPS_WRITE) // ADMIN role checked in tool execute()
+            }
+
+            // CrowdStrike import status (ADMIN/VULN role checked in tool execute())
+            "get_crowdstrike_last_import" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ)
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetCrowdStrikeLastImportTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetCrowdStrikeLastImportTool.kt
@@ -1,0 +1,80 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.CrowdStrikeVulnerabilityImportService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+/**
+ * MCP tool exposing the timestamp and metadata of the most recent CrowdStrike
+ * vulnerability import. Mirrors the controller endpoint `/api/crowdstrike/servers/import/latest`.
+ *
+ * Requires ADMIN or VULN role via User Delegation, matching the REST controller's
+ * `@Secured("ADMIN", "VULN")` guard.
+ */
+@Singleton
+class GetCrowdStrikeLastImportTool(
+    @Inject private val importService: CrowdStrikeVulnerabilityImportService
+) : McpTool {
+
+    private val logger = LoggerFactory.getLogger(GetCrowdStrikeLastImportTool::class.java)
+
+    override val name = "get_crowdstrike_last_import"
+    override val description = "Get the timestamp and metadata of the most recent CrowdStrike vulnerability import (ADMIN or VULN only, requires User Delegation). Returns null when no import has ever run."
+    override val operation = McpOperation.READ
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>(),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        val hasRequiredRole = context.isAdmin ||
+            context.delegatedUserRoles?.contains("VULN") == true
+
+        if (!hasRequiredRole) {
+            return McpToolResult.error(
+                "ROLE_REQUIRED",
+                "ADMIN or VULN role required to read CrowdStrike import status"
+            )
+        }
+
+        return try {
+            val status = importService.getLatestImportStatus()
+
+            val response = if (status == null) {
+                mapOf(
+                    "lastImportAt" to null,
+                    "message" to "No CrowdStrike import has ever run"
+                )
+            } else {
+                mapOf(
+                    "lastImportAt" to status.importedAt.toString(),
+                    "importedBy" to status.importedBy,
+                    "serversProcessed" to status.serversProcessed,
+                    "serversCreated" to status.serversCreated,
+                    "serversUpdated" to status.serversUpdated,
+                    "vulnerabilitiesImported" to status.vulnerabilitiesImported,
+                    "vulnerabilitiesSkipped" to status.vulnerabilitiesSkipped,
+                    "vulnerabilitiesWithPatchDate" to status.vulnerabilitiesWithPatchDate,
+                    "errorCount" to status.errorCount
+                )
+            }
+
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            logger.error("Failed to retrieve CrowdStrike last import status via MCP", e)
+            McpToolResult.error("EXECUTION_ERROR", "Failed to retrieve last import: ${e.message}")
+        }
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -3,6 +3,7 @@ package com.secman.cli
 import com.secman.cli.commands.AddRequirementCommand
 import com.secman.cli.commands.AddVulnerabilityCommand
 import com.secman.cli.commands.ConfigCommand
+import com.secman.cli.commands.CrowdStrikeLastImportCommand
 import com.secman.cli.commands.DeduplicateVulnerabilitiesCommand
 import com.secman.cli.commands.DeleteAssetNotSeenCommand
 import com.secman.cli.commands.DeleteAllRequirementsCommand
@@ -306,6 +307,14 @@ class SecmanCli {
                 }
                 0
             }
+            args[0] == "crowdstrike-last-import" -> {
+                // Show timestamp and metadata of the most recent CrowdStrike import
+                val subArgs = args.drop(1).toTypedArray()
+                createCliContext().use { ctx ->
+                    PicocliRunner.run(CrowdStrikeLastImportCommand::class.java, ctx, *subArgs)
+                }
+                0
+            }
             else -> {
                 System.err.println("ERROR: Unknown command: '${args[0]}'")
 
@@ -345,6 +354,7 @@ class SecmanCli {
                 query servers          Batch query and import server vulnerabilities
                 monitor                Continuously monitor for HIGH/CRITICAL vulnerabilities
                 config                 Configure CrowdStrike API credentials
+                crowdstrike-last-import  Show timestamp of the most recent CrowdStrike import
 
               Notifications:
                 send-notifications     Send email notifications for outdated assets
@@ -810,6 +820,27 @@ class SecmanCli {
                   secman delete-all-requirements --confirm
                   secman delete-all-requirements --confirm --verbose
                   secman delete-all-requirements --confirm --backend-url http://test-server:8080
+            """.trimIndent(),
+
+            "crowdstrike-last-import" to """
+                secman crowdstrike-last-import - Show the timestamp of the most recent CrowdStrike import
+
+                Usage: secman crowdstrike-last-import [options]
+
+                Requires: ADMIN or VULN role
+
+                Options:
+                  --backend-url <url>      Backend API URL (default: SECMAN_HOST, SECMAN_BACKEND_URL, or http://localhost:8080)
+                  --username <user>        Backend username (or SECMAN_ADMIN_NAME env var)
+                  --password <pass>        Backend password (or SECMAN_ADMIN_PASS env var)
+                  --format <text|json>     Output format (default: text)
+                  --insecure               Accept self-signed TLS certificates (or SECMAN_INSECURE=true env var)
+                  --verbose, -v            Enable verbose output
+
+                Examples:
+                  secman crowdstrike-last-import
+                  secman crowdstrike-last-import --format json
+                  secman crowdstrike-last-import --verbose
             """.trimIndent(),
 
             "port-scan" to """

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/CrowdStrikeLastImportCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/CrowdStrikeLastImportCommand.kt
@@ -1,0 +1,128 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.CliHttpClient
+import jakarta.inject.Inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+@Command(
+    name = "crowdstrike-last-import",
+    description = ["Show the timestamp and metadata of the most recent CrowdStrike vulnerability import"],
+    mixinStandardHelpOptions = true
+)
+class CrowdStrikeLastImportCommand : Runnable {
+
+    @Inject
+    lateinit var cliHttpClient: CliHttpClient
+
+    @Option(names = ["--username"], description = ["Backend username (or set SECMAN_ADMIN_NAME env var)"])
+    var username: String? = null
+
+    @Option(names = ["--password"], description = ["Backend password (or set SECMAN_ADMIN_PASS env var)"])
+    var password: String? = null
+
+    @Option(names = ["--backend-url"], description = ["Backend API URL (or set SECMAN_HOST / SECMAN_BACKEND_URL env var)"])
+    var backendUrl: String? = null
+
+    @Option(names = ["--format"], description = ["Output format: text (default) or json"])
+    var format: String = "text"
+
+    @Option(
+        names = ["--insecure"],
+        description = ["Disable SSL certificate verification (accept self-signed certs). Can also set SECMAN_INSECURE=true"]
+    )
+    var insecure: Boolean = false
+
+    @Option(names = ["--verbose", "-v"], description = ["Enable verbose output"])
+    var verbose: Boolean = false
+
+    override fun run() {
+        try {
+            val effectiveUrl = resolveBackendUrl()
+            val effectiveUsername = resolveUsername()
+            val effectivePassword = resolvePassword()
+
+            if (verbose) {
+                System.err.println("Backend URL: $effectiveUrl")
+                System.err.println("Username   : $effectiveUsername")
+            }
+
+            val authToken = cliHttpClient.authenticate(effectiveUsername, effectivePassword, effectiveUrl)
+                ?: throw RuntimeException(
+                    "Authentication failed (HTTP 401 / invalid credentials). " +
+                    "Re-run with --verbose to see exactly which username and backend URL were used."
+                )
+
+            val url = "$effectiveUrl/api/crowdstrike/servers/import/latest"
+            val body = cliHttpClient.getMap(url, authToken)
+
+            if (format.equals("json", ignoreCase = true)) {
+                if (body == null) {
+                    println("null")
+                } else {
+                    println(cliHttpClient.getObjectMapper().writeValueAsString(body))
+                }
+                return
+            }
+
+            // Text format
+            if (body == null) {
+                println("Last CrowdStrike import: never")
+                return
+            }
+
+            val importedAt = body["importedAt"]?.toString() ?: "unknown"
+            val importedBy = body["importedBy"]?.toString() ?: "(unknown)"
+            val serversProcessed = body["serversProcessed"] ?: 0
+            val serversCreated = body["serversCreated"] ?: 0
+            val serversUpdated = body["serversUpdated"] ?: 0
+            val vulnerabilitiesImported = body["vulnerabilitiesImported"] ?: 0
+            val vulnerabilitiesSkipped = body["vulnerabilitiesSkipped"] ?: 0
+            val vulnerabilitiesWithPatchDate = body["vulnerabilitiesWithPatchDate"] ?: 0
+            val errorCount = body["errorCount"] ?: 0
+
+            println("============================================================")
+            println("CrowdStrike Last Import")
+            println("============================================================")
+            println("Imported at                     : $importedAt")
+            println("Imported by                     : $importedBy")
+            println("Servers processed               : $serversProcessed")
+            println("Servers created                 : $serversCreated")
+            println("Servers updated                 : $serversUpdated")
+            println("Vulnerabilities imported        : $vulnerabilitiesImported")
+            println("Vulnerabilities skipped         : $vulnerabilitiesSkipped")
+            println("Vulnerabilities with patch date : $vulnerabilitiesWithPatchDate")
+            println("Error count                     : $errorCount")
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            System.exit(1)
+        }
+    }
+
+    private fun resolveUsername(): String {
+        username?.let { return it }
+        System.getenv("SECMAN_ADMIN_NAME")?.let { return it }
+        throw IllegalArgumentException(
+            "Backend username required. Use --username flag or set SECMAN_ADMIN_NAME environment variable"
+        )
+    }
+
+    private fun resolvePassword(): String {
+        password?.let { return it }
+        System.getenv("SECMAN_ADMIN_PASS")?.let { return it }
+        throw IllegalArgumentException(
+            "Backend password required. Use --password flag or set SECMAN_ADMIN_PASS environment variable"
+        )
+    }
+
+    private fun resolveBackendUrl(): String {
+        val raw = backendUrl
+            ?: System.getenv("SECMAN_HOST")
+            ?: System.getenv("SECMAN_BACKEND_URL")
+            ?: "http://localhost:8080"
+        return if (raw.startsWith("http://") || raw.startsWith("https://")) raw else "https://$raw"
+    }
+}


### PR DESCRIPTION
Adds two read-only surfaces for the timestamp/metadata of the most
recent CrowdStrike vulnerability import, both backed by the existing
CrowdStrikeVulnerabilityImportService.getLatestImportStatus().

- New MCP tool get_crowdstrike_last_import (ADMIN/VULN via delegation,
  VULNERABILITIES_READ permission); mirrors the role guard on
  /api/crowdstrike/servers/import/latest.
- New CLI command secman crowdstrike-last-import with text/json output
  that calls the same backend endpoint.