### PR TITLE
feat: add admin functions for delete-asset, delete-outdated-assets, broadcast-email to MCP and CLI

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -92,7 +92,10 @@ class McpToolRegistry(
     // Feature: Workgroup AWS Account Assignment
     @Inject private val listWorkgroupAwsAccountsTool: ListWorkgroupAwsAccountsTool,
     @Inject private val addWorkgroupAwsAccountTool: AddWorkgroupAwsAccountTool,
-    @Inject private val removeWorkgroupAwsAccountTool: RemoveWorkgroupAwsAccountTool
+    @Inject private val removeWorkgroupAwsAccountTool: RemoveWorkgroupAwsAccountTool,
+    // Admin tools: outdated-asset cleanup + broadcast email
+    @Inject private val deleteOutdatedAssetsTool: DeleteOutdatedAssetsTool,
+    @Inject private val broadcastEmailTool: BroadcastEmailTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -181,7 +184,10 @@ class McpToolRegistry(
             // Feature: Workgroup AWS Account Assignment
             listWorkgroupAwsAccountsTool,
             addWorkgroupAwsAccountTool,
-            removeWorkgroupAwsAccountTool
+            removeWorkgroupAwsAccountTool,
+            // Admin tools: outdated-asset cleanup + broadcast email
+            deleteOutdatedAssetsTool,
+            broadcastEmailTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -450,6 +456,14 @@ class McpToolRegistry(
             // Feature: Workgroup AWS Account Assignment (ADMIN only via User Delegation)
             "list_workgroup_aws_accounts", "add_workgroup_aws_account", "remove_workgroup_aws_account" -> {
                 permissions.contains(McpPermission.WORKGROUPS_WRITE) // ADMIN role checked in tool execute()
+            }
+
+            // Admin tools: outdated-asset cleanup + broadcast email (ADMIN only via User Delegation)
+            "delete_outdated_assets" -> {
+                permissions.contains(McpPermission.ASSETS_READ) // ADMIN role checked in tool execute()
+            }
+            "broadcast_email" -> {
+                permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/BroadcastEmailTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/BroadcastEmailTool.kt
@@ -1,0 +1,112 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.EmailBroadcastService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for sending a custom HTML email broadcast to every user with a recorded login.
+ *
+ * Wraps EmailBroadcastService.createJob() + runJobAsync() so a job row is persisted and
+ * progress is queryable through the same admin job history (POST /api/admin/email-broadcast).
+ *
+ * ADMIN role is required via User Delegation. dryRun returns the recipient count without
+ * creating a job.
+ */
+@Singleton
+class BroadcastEmailTool(
+    @Inject private val emailBroadcastService: EmailBroadcastService
+) : McpTool {
+
+    override val name = "broadcast_email"
+    override val description = "Send a custom HTML email broadcast to every user with a recorded login (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "subject" to mapOf(
+                "type" to "string",
+                "description" to "Email subject line (1-255 characters)"
+            ),
+            "htmlContent" to mapOf(
+                "type" to "string",
+                "description" to "HTML body content (rendered inside the SecMan branded shell). Required unless dryRun=true."
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "If true, returns the recipient count without creating a broadcast job. Default: false."
+            )
+        ),
+        "required" to listOf("subject")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to send email broadcasts"
+            )
+        }
+
+        val subject = (arguments["subject"] as? String)?.trim()
+        if (subject.isNullOrBlank()) {
+            return McpToolResult.error("VALIDATION_ERROR", "subject is required and must not be blank")
+        }
+        if (subject.length > 255) {
+            return McpToolResult.error("VALIDATION_ERROR", "subject must be 255 characters or fewer")
+        }
+
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+
+        return try {
+            if (dryRun) {
+                val count = emailBroadcastService.recipientCount()
+                McpToolResult.success(
+                    mapOf(
+                        "dryRun" to true,
+                        "recipientCount" to count,
+                        "message" to "Dry run: would send to $count recipient(s)"
+                    )
+                )
+            } else {
+                val htmlContent = (arguments["htmlContent"] as? String)?.trim()
+                if (htmlContent.isNullOrBlank()) {
+                    return McpToolResult.error("VALIDATION_ERROR", "htmlContent is required when dryRun is false")
+                }
+                if (htmlContent.length > 1_000_000) {
+                    return McpToolResult.error("VALIDATION_ERROR", "htmlContent must be 1,000,000 characters or fewer")
+                }
+
+                val createdBy = context.delegatedUserEmail ?: "mcp-system"
+                val job = emailBroadcastService.createJob(
+                    subject = subject,
+                    htmlContent = htmlContent,
+                    createdBy = createdBy
+                )
+                emailBroadcastService.runJobAsync(job.id!!)
+
+                McpToolResult.success(
+                    mapOf(
+                        "dryRun" to false,
+                        "jobId" to job.id,
+                        "totalRecipients" to job.totalRecipients,
+                        "status" to job.status.name,
+                        "message" to "Broadcast job ${job.id} queued for ${job.totalRecipients} recipient(s)"
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to send email broadcast: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteOutdatedAssetsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteOutdatedAssetsTool.kt
@@ -1,0 +1,119 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.CrowdStrikeCleanupAuditService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool for deleting outdated CrowdStrike-imported assets (cleanup of stale assets).
+ *
+ * Wraps CrowdStrikeCleanupAuditService.run() so manual MCP-triggered cleanups are
+ * persisted in crowdstrike_cleanup_run alongside scheduled and HTTP-API runs.
+ *
+ * ADMIN role is required via User Delegation.
+ */
+@Singleton
+class DeleteOutdatedAssetsTool(
+    @Inject private val crowdStrikeCleanupAuditService: CrowdStrikeCleanupAuditService
+) : McpTool {
+
+    override val name = "delete_outdated_assets"
+    override val description = "Delete CrowdStrike-imported assets not seen in CrowdStrike for more than N days, with cascade deletion (ADMIN only, requires User Delegation). Defaults to dry-run."
+    override val operation = McpOperation.DELETE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "days" to mapOf(
+                "type" to "number",
+                "description" to "Stale-threshold in days (must be > 0). Assets whose CrowdStrike import timestamp (or COALESCE of timestamps when includeLegacy=true) is older than this are candidates for deletion."
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "If true, returns matching candidates without deleting anything. Default: true."
+            ),
+            "includeLegacy" to mapOf(
+                "type" to "boolean",
+                "description" to "Feature 087: also include legacy CrowdStrike-owned assets without an import timestamp. Default: use the configured server-side default (secman.crowdstrike.cleanup.include-legacy)."
+            )
+        ),
+        "required" to listOf("days")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error(
+                "DELEGATION_REQUIRED",
+                "User Delegation must be enabled to use this tool"
+            )
+        }
+
+        if (!context.isAdmin) {
+            return McpToolResult.error(
+                "ADMIN_REQUIRED",
+                "ADMIN role required to delete outdated assets"
+            )
+        }
+
+        val days = (arguments["days"] as? Number)?.toInt()
+        if (days == null || days <= 0) {
+            return McpToolResult.error("VALIDATION_ERROR", "days is required and must be a positive integer")
+        }
+
+        // Default to dryRun = true for safety (destructive operation).
+        val dryRun = arguments["dryRun"] as? Boolean ?: true
+        val includeLegacy = arguments["includeLegacy"] as? Boolean
+
+        val triggeredBy = context.delegatedUserEmail ?: "mcp-system"
+
+        return try {
+            val response = crowdStrikeCleanupAuditService.run(
+                days = days,
+                dryRun = dryRun,
+                triggeredBy = triggeredBy,
+                maxDeletePercent = null,
+                includeLegacy = includeLegacy
+            )
+
+            val payload = mapOf(
+                "days" to response.days,
+                "cutoff" to response.cutoff.toString(),
+                "dryRun" to response.dryRun,
+                "candidateCount" to response.candidateCount,
+                "deletedCount" to response.deletedCount,
+                "skippedCount" to response.skippedCount,
+                "legacyCandidateCount" to response.legacyCandidateCount,
+                "legacyDeletedCount" to response.legacyDeletedCount,
+                "candidates" to response.candidates.map {
+                    mapOf(
+                        "assetId" to it.assetId,
+                        "name" to it.name,
+                        "crowdStrikeLastImportedAt" to it.crowdStrikeLastImportedAt?.toString(),
+                        "reason" to it.reason.name
+                    )
+                },
+                "errors" to response.errors.map {
+                    mapOf(
+                        "assetId" to it.assetId,
+                        "assetName" to it.assetName,
+                        "message" to it.message
+                    )
+                },
+                "message" to if (response.dryRun) {
+                    "Dry run: ${response.candidateCount} candidate(s) would be deleted (cutoff=${response.cutoff})"
+                } else {
+                    "Deleted ${response.deletedCount}/${response.candidateCount} candidate(s) (skipped=${response.skippedCount})"
+                }
+            )
+
+            McpToolResult.success(payload)
+
+        } catch (e: IllegalArgumentException) {
+            McpToolResult.error("VALIDATION_ERROR", e.message ?: "Invalid cleanup request")
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to delete outdated assets: ${e.message}")
+        }
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -2,8 +2,11 @@ package com.secman.cli
 
 import com.secman.cli.commands.AddRequirementCommand
 import com.secman.cli.commands.AddVulnerabilityCommand
+import com.secman.cli.commands.BroadcastEmailCommand
 import com.secman.cli.commands.ConfigCommand
 import com.secman.cli.commands.DeduplicateVulnerabilitiesCommand
+import com.secman.cli.commands.DeleteAllAssetsCommand
+import com.secman.cli.commands.DeleteAssetCommand
 import com.secman.cli.commands.DeleteAssetNotSeenCommand
 import com.secman.cli.commands.DeleteAllRequirementsCommand
 import com.secman.cli.commands.ExportRequirementsCommand
@@ -298,6 +301,27 @@ class SecmanCli {
                 }
                 0
             }
+            args[0] == "delete-asset" -> {
+                val subArgs = args.drop(1).toTypedArray()
+                createCliContext().use { ctx ->
+                    PicocliRunner.run(DeleteAssetCommand::class.java, ctx, *subArgs)
+                }
+                0
+            }
+            args[0] == "delete-all-assets" -> {
+                val subArgs = args.drop(1).toTypedArray()
+                createCliContext().use { ctx ->
+                    PicocliRunner.run(DeleteAllAssetsCommand::class.java, ctx, *subArgs)
+                }
+                0
+            }
+            args[0] == "broadcast-email" -> {
+                val subArgs = args.drop(1).toTypedArray()
+                createCliContext().use { ctx ->
+                    PicocliRunner.run(BroadcastEmailCommand::class.java, ctx, *subArgs)
+                }
+                0
+            }
             args[0] == "port-scan" -> {
                 // Port-scan internet-facing assets using nmap
                 val subArgs = args.drop(1).toTypedArray()
@@ -350,6 +374,7 @@ class SecmanCli {
                 send-notifications     Send email notifications for outdated assets
                 send-admin-summary     Send system statistics summary email to ADMIN users
                 send-notification-users  Send vulnerability notifications to users by AWS account
+                broadcast-email        Send a custom HTML email to every user with a recorded login (ADMIN)
 
               User & Access Management:
                 manage-user-mappings   Manage user mappings for domains and AWS accounts
@@ -361,6 +386,10 @@ class SecmanCli {
               Vulnerabilities:
                 add-vulnerability      Add or update a vulnerability for an asset
                 deduplicate-vulnerabilities  Remove duplicate vulnerability records (ADMIN)
+
+              Assets (ADMIN, destructive):
+                delete-asset           Delete a single asset by ID with cascade (ADMIN)
+                delete-all-assets      Delete ALL assets with cascade (ADMIN, --confirm)
                 delete-asset-not-seen  Delete CrowdStrike assets not imported for N days (ADMIN)
 
               Requirements:
@@ -717,6 +746,84 @@ class SecmanCli {
                   secman deduplicate-vulnerabilities --username admin --password secret
                   secman deduplicate-vulnerabilities --verbose
                   secman deduplicate-vulnerabilities --backend-url http://prod:8080
+            """.trimIndent(),
+
+            "delete-asset" to """
+                secman delete-asset - Delete a single asset by ID with cascade deletion
+
+                Usage: secman delete-asset <id> [options]
+
+                Requires: ADMIN role
+
+                Cascade deletes:
+                  - vulnerabilities
+                  - vulnerability exception requests
+                  - ASSET-type vulnerability exceptions
+
+                Options:
+                  --force-timeout          Force deletion even if it may exceed the server timeout estimate
+                  --backend-url <url>      Backend API URL (default: SECMAN_HOST, SECMAN_BACKEND_URL, or http://localhost:8080)
+                  --username <user>        Backend username with ADMIN role (or SECMAN_ADMIN_NAME env var)
+                  --password <pass>        Backend password (or SECMAN_ADMIN_PASS env var)
+                  --verbose, -v            Verbose output
+
+                Examples:
+                  secman delete-asset 42
+                  secman delete-asset 42 --force-timeout
+                  secman delete-asset 42 --backend-url https://secman.example.com
+            """.trimIndent(),
+
+            "delete-all-assets" to """
+                secman delete-all-assets - Delete ALL assets with cascade deletion
+
+                Usage: secman delete-all-assets --confirm [options]
+
+                WARNING: This is a destructive operation! Requires ADMIN role.
+
+                Cascade deletes:
+                  - vulnerabilities
+                  - scan results and scan ports
+                  - asset-workgroup links
+                  - demand.existing_asset_id references (nullified, demand rows preserved)
+
+                Options:
+                  --confirm                Required safety flag. Without --confirm, the command refuses to run.
+                  --backend-url <url>      Backend API URL (default: SECMAN_HOST, SECMAN_BACKEND_URL, or http://localhost:8080)
+                  --username <user>        Backend username with ADMIN role (or SECMAN_ADMIN_NAME env var)
+                  --password <pass>        Backend password (or SECMAN_ADMIN_PASS env var)
+                  --verbose, -v            Verbose output
+
+                Examples:
+                  secman delete-all-assets --confirm
+                  secman delete-all-assets --confirm --verbose
+            """.trimIndent(),
+
+            "broadcast-email" to """
+                secman broadcast-email - Send a custom HTML email broadcast to every user with a recorded login
+
+                Usage: secman broadcast-email --subject <subject> (--html <html> | --html-file <path>) [options]
+
+                Requires: ADMIN role
+
+                Options:
+                  --subject <text>         Email subject (1-255 characters, required)
+                  --html <html>            HTML body content
+                  --html-file <path>       Path to a file containing the HTML body
+                  --dry-run                Report planned recipient count without creating a broadcast job
+                  --backend-url <url>      Backend API URL (default: SECMAN_HOST, SECMAN_BACKEND_URL, or http://localhost:8080)
+                  --username <user>        Backend username with ADMIN role (or SECMAN_ADMIN_NAME env var)
+                  --password <pass>        Backend password (or SECMAN_ADMIN_PASS env var)
+                  --verbose, -v            Verbose output
+
+                Notes:
+                  Recipients are every user with `lastLogin != null`. The HTML body is rendered
+                  inside the SecMan branded shell (logo + footer). Use --dry-run to preview the
+                  recipient count before queueing a real broadcast.
+
+                Examples:
+                  secman broadcast-email --subject "Maintenance window" --dry-run
+                  secman broadcast-email --subject "Outage notice" --html "<p>The system will be down...</p>"
+                  secman broadcast-email --subject "Release notes" --html-file release-notes.html
             """.trimIndent(),
 
             "delete-asset-not-seen" to """

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/BroadcastEmailCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/BroadcastEmailCommand.kt
@@ -1,0 +1,154 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.CliHttpClient
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * CLI command to send a custom HTML email broadcast to every user with a recorded login.
+ *
+ * Wraps POST /api/admin/email-broadcast (and GET /api/admin/email-broadcast/recipients
+ * for the dry-run path). Requires ADMIN role.
+ */
+@Singleton
+@Command(
+    name = "broadcast-email",
+    description = ["Send a custom HTML email broadcast to every user with a recorded login (ADMIN role required)"],
+    mixinStandardHelpOptions = true
+)
+class BroadcastEmailCommand : Runnable {
+
+    @Inject
+    lateinit var cliHttpClient: CliHttpClient
+
+    @Option(names = ["--subject"], required = true, description = ["Email subject (1-255 characters)"])
+    var subject: String = ""
+
+    @Option(names = ["--html"], description = ["HTML body content (required unless --html-file is provided or --dry-run)"])
+    var html: String? = null
+
+    @Option(names = ["--html-file"], description = ["Path to a file containing the HTML body (alternative to --html)"])
+    var htmlFile: String? = null
+
+    @Option(names = ["--dry-run"], description = ["Report planned recipient count without creating a broadcast job"])
+    var dryRun: Boolean = false
+
+    @Option(names = ["--username"], description = ["Backend username (or set SECMAN_ADMIN_NAME env var)"])
+    var username: String? = null
+
+    @Option(names = ["--password"], description = ["Backend password (or set SECMAN_ADMIN_PASS env var)"])
+    var password: String? = null
+
+    @Option(names = ["--backend-url"], description = ["Backend API URL (or set SECMAN_HOST/SECMAN_BACKEND_URL env var)"])
+    var backendUrl: String? = null
+
+    @Option(names = ["--verbose", "-v"], description = ["Verbose output"])
+    var verbose: Boolean = false
+
+    override fun run() {
+        try {
+            val trimmedSubject = subject.trim()
+            if (trimmedSubject.isBlank()) {
+                throw IllegalArgumentException("--subject is required and must not be blank")
+            }
+            if (trimmedSubject.length > 255) {
+                throw IllegalArgumentException("--subject must be 255 characters or fewer")
+            }
+
+            val effectiveUrl = getEffectiveBackendUrl()
+            val effectiveUsername = getEffectiveUsername()
+            val effectivePassword = getEffectivePassword()
+
+            println("============================================================")
+            println("SecMan Email Broadcast")
+            println("============================================================")
+            println("Subject: $trimmedSubject")
+            if (dryRun) println("Mode:    dry-run") else println("Mode:    send")
+            println()
+
+            val authToken = cliHttpClient.authenticate(effectiveUsername, effectivePassword, effectiveUrl)
+                ?: throw RuntimeException("Authentication failed. Check credentials.")
+
+            if (dryRun) {
+                val recipientResp = cliHttpClient.getMap(
+                    "$effectiveUrl/api/admin/email-broadcast/recipients",
+                    authToken
+                ) ?: throw RuntimeException("Failed to fetch recipient count from server")
+                val count = (recipientResp["count"] as? Number)?.toLong() ?: 0
+                println("Would send to $count recipient(s) (users with lastLogin != null).")
+                return
+            }
+
+            val htmlContent = resolveHtmlContent()
+            if (htmlContent.isBlank()) {
+                throw IllegalArgumentException("HTML body is required (use --html or --html-file)")
+            }
+
+            val (status, body) = cliHttpClient.postMapWithStatus(
+                "$effectiveUrl/api/admin/email-broadcast",
+                mapOf(
+                    "subject" to trimmedSubject,
+                    "htmlContent" to htmlContent
+                ),
+                authToken
+            )
+
+            if (status !in 200..299) {
+                val message = body?.get("message")?.toString()
+                    ?: body?.get("error")?.toString()
+                    ?: "Backend returned HTTP $status"
+                throw RuntimeException("Broadcast failed (HTTP $status): $message")
+            }
+
+            val jobId = (body?.get("id") as? Number)?.toLong()
+            val total = (body?.get("totalRecipients") as? Number)?.toInt() ?: 0
+            val jobStatus = body?.get("status")?.toString() ?: "?"
+
+            println("Broadcast job queued:")
+            println("  Job ID:         ${jobId ?: "?"}")
+            println("  Status:         $jobStatus")
+            println("  Recipients:     $total")
+            if (jobId != null) {
+                println()
+                println("Poll progress with:")
+                println("  GET $effectiveUrl/api/admin/email-broadcast/jobs/$jobId")
+            }
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            System.exit(1)
+        }
+    }
+
+    private fun resolveHtmlContent(): String {
+        if (htmlFile != null) {
+            val path = Path.of(htmlFile!!)
+            if (!Files.isRegularFile(path)) {
+                throw IllegalArgumentException("--html-file does not exist or is not a regular file: ${htmlFile}")
+            }
+            return Files.readString(path).trim()
+        }
+        return (html ?: "").trim()
+    }
+
+    private fun getEffectiveUsername(): String {
+        return username ?: System.getenv("SECMAN_ADMIN_NAME")
+            ?: throw IllegalArgumentException("Backend username required. Use --username flag or set SECMAN_ADMIN_NAME environment variable")
+    }
+
+    private fun getEffectivePassword(): String {
+        return password ?: System.getenv("SECMAN_ADMIN_PASS")
+            ?: throw IllegalArgumentException("Backend password required. Use --password flag or set SECMAN_ADMIN_PASS environment variable")
+    }
+
+    private fun getEffectiveBackendUrl(): String {
+        val url = backendUrl ?: System.getenv("SECMAN_HOST") ?: System.getenv("SECMAN_BACKEND_URL") ?: "http://localhost:8080"
+        return if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/DeleteAllAssetsCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/DeleteAllAssetsCommand.kt
@@ -1,0 +1,120 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.CliHttpClient
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * CLI command to delete EVERY asset and cascade-delete related rows
+ * (vulnerabilities, scan results, scan ports). Requires ADMIN role and the explicit
+ * --confirm flag.
+ *
+ * Wraps DELETE /api/assets/bulk.
+ */
+@Singleton
+@Command(
+    name = "delete-all-assets",
+    description = ["Delete ALL assets with cascade deletion (ADMIN role + --confirm required). DESTRUCTIVE."],
+    mixinStandardHelpOptions = true
+)
+class DeleteAllAssetsCommand : Runnable {
+
+    @Inject
+    lateinit var cliHttpClient: CliHttpClient
+
+    @Option(names = ["--confirm"], description = ["Required safety flag. Without --confirm, the command refuses to run."])
+    var confirm: Boolean = false
+
+    @Option(names = ["--username"], description = ["Backend username (or set SECMAN_ADMIN_NAME env var)"])
+    var username: String? = null
+
+    @Option(names = ["--password"], description = ["Backend password (or set SECMAN_ADMIN_PASS env var)"])
+    var password: String? = null
+
+    @Option(names = ["--backend-url"], description = ["Backend API URL (or set SECMAN_HOST/SECMAN_BACKEND_URL env var)"])
+    var backendUrl: String? = null
+
+    @Option(names = ["--verbose", "-v"], description = ["Verbose output"])
+    var verbose: Boolean = false
+
+    override fun run() {
+        try {
+            if (!confirm) {
+                throw IllegalArgumentException(
+                    "Refusing to delete all assets without --confirm. " +
+                    "This is a destructive operation that cannot be undone."
+                )
+            }
+
+            val effectiveUrl = getEffectiveBackendUrl()
+            val effectiveUsername = getEffectiveUsername()
+            val effectivePassword = getEffectivePassword()
+
+            println("============================================================")
+            println("Delete ALL Assets (BULK)")
+            println("============================================================")
+            println("This will delete every asset and cascade-delete:")
+            println("  - vulnerabilities")
+            println("  - scan results and scan ports")
+            println("  - asset-workgroup links")
+            println("  - demand.existing_asset_id references (nullified, demand rows preserved)")
+            println()
+
+            val authToken = cliHttpClient.authenticate(effectiveUsername, effectivePassword, effectiveUrl)
+                ?: throw RuntimeException("Authentication failed. Check credentials.")
+
+            val (status, body) = cliHttpClient.deleteMapWithStatus(
+                "$effectiveUrl/api/assets/bulk",
+                authToken
+            )
+
+            if (status == 409) {
+                throw RuntimeException(
+                    "Another bulk delete operation is already in progress. Wait for it to finish, then retry."
+                )
+            }
+            if (status !in 200..299) {
+                val message = body?.get("message")?.toString()
+                    ?: body?.get("error")?.toString()
+                    ?: "Backend returned HTTP $status"
+                throw RuntimeException("Bulk delete failed (HTTP $status): $message")
+            }
+
+            val deletedAssets = (body?.get("deletedAssets") as? Number)?.toInt() ?: 0
+            val deletedVulns = (body?.get("deletedVulnerabilities") as? Number)?.toInt() ?: 0
+            val deletedScanResults = (body?.get("deletedScanResults") as? Number)?.toInt() ?: 0
+            val message = body?.get("message")?.toString() ?: ""
+
+            println("Bulk delete complete:")
+            println("  Assets deleted:        $deletedAssets")
+            println("  Vulnerabilities:       $deletedVulns")
+            println("  Scan results:          $deletedScanResults")
+            if (message.isNotBlank()) {
+                println("  Message:               $message")
+            }
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            System.exit(1)
+        }
+    }
+
+    private fun getEffectiveUsername(): String {
+        return username ?: System.getenv("SECMAN_ADMIN_NAME")
+            ?: throw IllegalArgumentException("Backend username required. Use --username flag or set SECMAN_ADMIN_NAME environment variable")
+    }
+
+    private fun getEffectivePassword(): String {
+        return password ?: System.getenv("SECMAN_ADMIN_PASS")
+            ?: throw IllegalArgumentException("Backend password required. Use --password flag or set SECMAN_ADMIN_PASS environment variable")
+    }
+
+    private fun getEffectiveBackendUrl(): String {
+        val url = backendUrl ?: System.getenv("SECMAN_HOST") ?: System.getenv("SECMAN_BACKEND_URL") ?: "http://localhost:8080"
+        return if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/DeleteAssetCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/DeleteAssetCommand.kt
@@ -1,0 +1,111 @@
+package com.secman.cli.commands
+
+import com.secman.cli.service.CliHttpClient
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+
+/**
+ * CLI command to delete a single asset by ID with cascade deletion of related rows
+ * (vulnerabilities, exception requests, ASSET-type vulnerability exceptions).
+ *
+ * Wraps DELETE /api/assets/{id}. Requires ADMIN role.
+ */
+@Singleton
+@Command(
+    name = "delete-asset",
+    description = ["Delete a single asset by ID with cascade deletion (ADMIN role required)"],
+    mixinStandardHelpOptions = true
+)
+class DeleteAssetCommand : Runnable {
+
+    @Inject
+    lateinit var cliHttpClient: CliHttpClient
+
+    @Parameters(index = "0", description = ["Asset ID to delete"])
+    var assetId: Long = 0
+
+    @Option(names = ["--force-timeout"], description = ["Force deletion even if it may exceed the server timeout estimate"])
+    var forceTimeout: Boolean = false
+
+    @Option(names = ["--username"], description = ["Backend username (or set SECMAN_ADMIN_NAME env var)"])
+    var username: String? = null
+
+    @Option(names = ["--password"], description = ["Backend password (or set SECMAN_ADMIN_PASS env var)"])
+    var password: String? = null
+
+    @Option(names = ["--backend-url"], description = ["Backend API URL (or set SECMAN_HOST/SECMAN_BACKEND_URL env var)"])
+    var backendUrl: String? = null
+
+    @Option(names = ["--verbose", "-v"], description = ["Verbose output"])
+    var verbose: Boolean = false
+
+    override fun run() {
+        try {
+            if (assetId <= 0) {
+                throw IllegalArgumentException("Asset ID must be a positive integer")
+            }
+
+            val effectiveUrl = getEffectiveBackendUrl()
+            val effectiveUsername = getEffectiveUsername()
+            val effectivePassword = getEffectivePassword()
+
+            println("============================================================")
+            println("Delete Asset")
+            println("============================================================")
+            println("Asset ID:      $assetId")
+            println("Force timeout: $forceTimeout")
+            println()
+
+            val authToken = cliHttpClient.authenticate(effectiveUsername, effectivePassword, effectiveUrl)
+                ?: throw RuntimeException("Authentication failed. Check credentials.")
+
+            val query = if (forceTimeout) "?forceTimeout=true" else ""
+            val url = "$effectiveUrl/api/assets/$assetId$query"
+
+            val (status, body) = cliHttpClient.deleteMapWithStatus(url, authToken)
+
+            if (status !in 200..299) {
+                val message = body?.get("message")?.toString()
+                    ?: body?.get("error")?.toString()
+                    ?: "Backend returned HTTP $status"
+                throw RuntimeException("Delete failed (HTTP $status): $message")
+            }
+
+            val deletedVulns = (body?.get("deletedVulnerabilities") as? Number)?.toInt() ?: 0
+            val deletedExceptions = (body?.get("deletedExceptions") as? Number)?.toInt() ?: 0
+            val deletedRequests = (body?.get("deletedRequests") as? Number)?.toInt() ?: 0
+            val assetName = body?.get("assetName")?.toString()
+                ?: body?.get("name")?.toString()
+                ?: "Asset #$assetId"
+
+            println("Asset deleted: $assetName (id=$assetId)")
+            println("  Vulnerabilities deleted:        $deletedVulns")
+            println("  Vulnerability exceptions:       $deletedExceptions")
+            println("  Vulnerability exception reqs:   $deletedRequests")
+        } catch (e: Exception) {
+            System.err.println("Error: ${e.message}")
+            if (verbose) {
+                e.printStackTrace()
+            }
+            System.exit(1)
+        }
+    }
+
+    private fun getEffectiveUsername(): String {
+        return username ?: System.getenv("SECMAN_ADMIN_NAME")
+            ?: throw IllegalArgumentException("Backend username required. Use --username flag or set SECMAN_ADMIN_NAME environment variable")
+    }
+
+    private fun getEffectivePassword(): String {
+        return password ?: System.getenv("SECMAN_ADMIN_PASS")
+            ?: throw IllegalArgumentException("Backend password required. Use --password flag or set SECMAN_ADMIN_PASS environment variable")
+    }
+
+    private fun getEffectiveBackendUrl(): String {
+        val url = backendUrl ?: System.getenv("SECMAN_HOST") ?: System.getenv("SECMAN_BACKEND_URL") ?: "http://localhost:8080"
+        return if (url.startsWith("http://") || url.startsWith("https://")) url else "https://$url"
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/service/CliHttpClient.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/service/CliHttpClient.kt
@@ -234,6 +234,34 @@ class CliHttpClient(
     }
 
     /**
+     * Send a DELETE request returning the HTTP status code and (optionally) the parsed
+     * body. Used by destructive admin operations (delete asset, bulk delete) so the
+     * caller can distinguish 200 / 403 / 404 / 409 / 422 / 500 for clear exit codes.
+     */
+    fun deleteMapWithStatus(url: String, authToken: String): Pair<Int, Map<*, *>?> {
+        val request = HttpRequest.DELETE<Any>(url)
+            .header("Authorization", "Bearer $authToken")
+            .accept(MediaType.APPLICATION_JSON)
+
+        return try {
+            val response = httpClient.toBlocking().exchange(request, Map::class.java)
+            response.status.code to response.body()
+        } catch (e: io.micronaut.http.client.exceptions.HttpClientResponseException) {
+            val status = e.status.code
+            val errorBody = try {
+                e.response.getBody(Map::class.java).orElse(null)
+            } catch (_: Exception) {
+                null
+            }
+            log.warn("DELETE {} returned {}: {}", url, status, e.message)
+            status to errorBody
+        } catch (e: Exception) {
+            log.error("DELETE {} error: {}", url, e.message)
+            -1 to null
+        }
+    }
+
+    /**
      * Send a GET request returning a list of maps (for array responses)
      */
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Make three admin operations reachable from both the MCP toolset and the secman CLI:

MCP tools (ADMIN-only via User Delegation):
- delete_outdated_assets: wraps CrowdStrikeCleanupAuditService.run() so manual
  MCP-triggered cleanups are persisted in crowdstrike_cleanup_run alongside
  scheduled and HTTP-API runs. Defaults to dry-run for safety.
- broadcast_email: wraps EmailBroadcastService.createJob() + runJobAsync() so
  a job row is persisted and progress is queryable through the existing admin
  job history. dryRun returns the recipient count without queueing.

CLI commands (ADMIN role required):
- delete-asset <id>: DELETE /api/assets/{id} with cascade.
- delete-all-assets --confirm: DELETE /api/assets/bulk (destructive).
- broadcast-email --subject ... --html | --html-file: POST /api/admin/email-broadcast.

Supporting changes:
- Register the two new MCP tools in McpToolRegistry (constructor inject, tool list,
  permission map). Permissions follow the existing pattern: ASSETS_READ /
  NOTIFICATIONS_SEND with ADMIN re-checked in tool execute().
- Add CliHttpClient.deleteMapWithStatus so destructive admin commands can map
  HTTP 200/403/404/409/422/500 to clear exit codes.
- Wire the three new commands into SecmanCli dispatch + help text.

Existing pieces kept as-is:
- delete_asset, delete_all_assets, send_admin_summary MCP tools were already
  present.
- delete-asset-not-seen, send-admin-summary, send-notifications,
  send-notification-users CLI commands were already present.