### PR TITLE
feat: add AWS Secrets Manager dev launchers

### DIFF
--- a/AWS.md
+++ b/AWS.md
@@ -1,0 +1,274 @@
+# AWS dev scripts (alternative to pass-cli)
+
+This document covers the AWS-flavored dev launchers:
+
+- `scripts/startbackenddevaws.sh` — backend dev (counterpart to `scripts/startbackenddev.sh`)
+- `scripts/startfrontenddevaws.sh` — frontend dev (counterpart to `scripts/startfrontenddev.sh`)
+
+They behave exactly like the canonical `pass-cli` versions but pull credentials from
+**AWS Secrets Manager** instead of Proton Pass. Useful when running secman on EC2
+(Amazon Linux 2 / 2023) where pass-cli is not the natural choice and the EC2 instance
+already has an IAM role.
+
+The original `pass-cli` scripts remain canonical (per `CLAUDE.md`). The AWS variants
+are an alternative entry point — they are not intended to replace pass-cli for local
+developer workflows.
+
+## How it works
+
+Both scripts:
+
+1. Read a single JSON secret from AWS Secrets Manager (default name `secman/dev`).
+2. Export each JSON field to the environment variable expected by the backend / frontend.
+3. Exec the appropriate dev command (`gradle :backendng:run` or `npm run dev`).
+
+Stop scripts (`stopbackenddev.sh`, `stopfrontenddev.sh`) work unchanged for both
+flavors — they kill whatever is bound to ports 8080 / 4321.
+
+## Required tools on Amazon Linux
+
+### Amazon Linux 2023
+
+```bash
+# AWS CLI v2 (preinstalled on most AL2023 AMIs — verify with: aws --version)
+sudo dnf install -y awscli
+
+# JSON parser
+sudo dnf install -y jq
+
+# OpenSSL + lsof (typically already installed)
+sudo dnf install -y openssl lsof
+
+# Java 21 (Corretto)
+sudo dnf install -y java-21-amazon-corretto-devel
+
+# Node.js 20+ (for the frontend)
+curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+sudo dnf install -y nodejs
+
+# Git
+sudo dnf install -y git
+```
+
+### Amazon Linux 2
+
+```bash
+sudo yum install -y jq openssl lsof git
+
+# AWS CLI v2 (replaces preinstalled v1)
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip awscliv2.zip && sudo ./aws/install --update
+
+# Java 21 (Corretto)
+sudo amazon-linux-extras enable corretto21
+sudo yum install -y java-21-amazon-corretto-devel
+
+# Node.js 20+
+curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+sudo yum install -y nodejs
+```
+
+### Gradle
+
+The project ships a Gradle wrapper (`./gradlew`), so a system Gradle install is
+optional — `startbackenddevaws.sh` falls back to `./gradlew` if `gradle` is not
+on `PATH`. To install a system Gradle (matching the project's 9.5.0):
+
+```bash
+curl -fsSL https://services.gradle.org/distributions/gradle-9.5-bin.zip -o /tmp/gradle.zip
+sudo mkdir -p /opt/gradle && sudo unzip -d /opt/gradle /tmp/gradle.zip
+echo 'export PATH=$PATH:/opt/gradle/gradle-9.5/bin' | sudo tee /etc/profile.d/gradle.sh
+. /etc/profile.d/gradle.sh
+```
+
+## AWS authentication
+
+The scripts use the standard AWS credential provider chain. Pick whichever fits
+the environment:
+
+| Environment | Recommended |
+|---|---|
+| EC2 (Amazon Linux) | **Instance profile** — attach an IAM role to the instance, no static keys needed |
+| Local dev | `aws configure` (creates `~/.aws/credentials`) or `AWS_PROFILE=...` |
+| CI | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars |
+
+### IAM permissions
+
+The principal that runs the script needs permission to read the secret:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:<region>:<account>:secret:secman/dev-*"
+    }
+  ]
+}
+```
+
+If the secret was created with a customer-managed KMS key, also grant
+`kms:Decrypt` on that key.
+
+## Creating the secret
+
+Store all required keys as a single JSON object. Keys mirror the field names
+used by `pass-cli` under `test/secman` (see `docs/PASS_CLI.md`).
+
+```bash
+aws secretsmanager create-secret \
+  --name secman/dev \
+  --description "Secman backend + frontend dev secrets" \
+  --secret-string file://secman-dev.json \
+  --region eu-central-1
+```
+
+`secman-dev.json` (template — fill in the real values):
+
+```json
+{
+  "DB_CONNECT": "jdbc:mariadb://localhost:3306/secman?useSSL=false",
+  "SECMAN_BACKEND_BASE_URL": "https://secman.example.com",
+  "SECMAN_HOST": "https://secman.example.com",
+  "SECMAN_SSL_ACCEPT_ALL": "false",
+
+  "SECMAN_ADMIN_NAME": "admin",
+  "SECMAN_ADMIN_PASS": "<bootstrap-admin-password>",
+  "SECMAN_ADMIN_EMAIL": "admin@example.com",
+  "SECMAN_MCP_KEY": "<mcp-bearer-key>",
+
+  "FALCON_CLIENT_ID": "<crowdstrike-client-id>",
+  "FALCON_CLIENT_SECRET": "<crowdstrike-client-secret>",
+  "FALCON_CLOUD_REGION": "us-1",
+
+  "OPENROUTER_API_KEY": "<openrouter-api-key>",
+
+  "SECMAN_AWS_ACCESS_KEY_ID": "",
+  "SECMAN_AWS_SECRET_ACCESS_KEY": "",
+  "SECMAN_AWS_ACCESS_TOKEN": ""
+}
+```
+
+The `SECMAN_AWS_*` fields are application-side AWS credentials (used by the backend
+to talk to S3/CrowdStrike on its own behalf). **Leave them empty when running on
+EC2 with an instance role** — the backend will then inherit the role automatically.
+Populate them only for local dev where no instance role is available.
+
+To update an existing secret:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id secman/dev \
+  --secret-string file://secman-dev.json \
+  --region eu-central-1
+```
+
+### Seeding from pass-cli (one-time migration)
+
+If the values already live in pass-cli, you can mint the JSON directly:
+
+```bash
+jq -n \
+  --arg DB_CONNECT              "$(pass-cli read 'test/secman/DB_CONNECT')" \
+  --arg SECMAN_BACKEND_BASE_URL "$(pass-cli read 'test/secman/SECMAN_BACKEND_BASE_URL')" \
+  --arg SECMAN_HOST             "$(pass-cli read 'test/secman/SECMAN_HOST')" \
+  --arg SECMAN_SSL_ACCEPT_ALL   "$(pass-cli read 'test/secman/SECMAN_SSL_ACCEPT_ALL')" \
+  --arg SECMAN_ADMIN_NAME       "$(pass-cli read 'test/secman/SECMAN_ADMIN_NAME')" \
+  --arg SECMAN_ADMIN_PASS       "$(pass-cli read 'test/secman/SECMAN_ADMIN_PASS')" \
+  --arg SECMAN_ADMIN_EMAIL      "$(pass-cli read 'test/secman/SECMAN_ADMIN_EMAIL')" \
+  --arg SECMAN_MCP_KEY          "$(pass-cli read 'test/secman/SECMAN_MCP_KEY')" \
+  --arg FALCON_CLIENT_ID        "$(pass-cli read 'test/secman/FALCON_CLIENT_ID')" \
+  --arg FALCON_CLIENT_SECRET    "$(pass-cli read 'test/secman/FALCON_CLIENT_SECRET')" \
+  --arg FALCON_CLOUD_REGION     "$(pass-cli read 'test/secman/FALCON_CLOUD_REGION')" \
+  --arg OPENROUTER_API_KEY      "$(pass-cli read 'test/secman/OPENROUTER_API_KEY')" \
+  '{$DB_CONNECT, $SECMAN_BACKEND_BASE_URL, $SECMAN_HOST, $SECMAN_SSL_ACCEPT_ALL,
+    $SECMAN_ADMIN_NAME, $SECMAN_ADMIN_PASS, $SECMAN_ADMIN_EMAIL, $SECMAN_MCP_KEY,
+    $FALCON_CLIENT_ID, $FALCON_CLIENT_SECRET, $FALCON_CLOUD_REGION,
+    $OPENROUTER_API_KEY}' \
+  > secman-dev.json
+```
+
+## Usage
+
+From the project root:
+
+```bash
+# Backend (port 8080)
+./scripts/startbackenddevaws.sh
+
+# Frontend (port 4321) — separate terminal
+./scripts/startfrontenddevaws.sh
+
+# Stop (same scripts as the pass-cli flavor)
+./scripts/stopbackenddev.sh
+./scripts/stopfrontenddev.sh
+```
+
+### Configuration via env vars
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SECMAN_AWS_SECRET_ID` | `secman/dev` | Secret name or full ARN to fetch |
+| `AWS_REGION`           | `eu-central-1` | Region containing the secret |
+| `AWS_DEFAULT_REGION`   | (fallback for `AWS_REGION`) | |
+| `AWS_PROFILE`          | (none) | Named profile from `~/.aws/credentials` |
+
+Examples:
+
+```bash
+# Custom secret in us-east-1
+SECMAN_AWS_SECRET_ID=secman/staging AWS_REGION=us-east-1 ./scripts/startbackenddevaws.sh
+
+# Local dev with a named profile
+AWS_PROFILE=secman-dev ./scripts/startbackenddevaws.sh
+```
+
+## Secret keys reference
+
+| JSON key in secret | Exported as | Used by |
+|---|---|---|
+| `DB_CONNECT` | `DB_CONNECT` | backend |
+| `SECMAN_BACKEND_BASE_URL` | `SECMAN_BACKEND_URL` (backend), `SECMAN_DOMAIN` (frontend) | both |
+| `SECMAN_HOST` | `SECMAN_HOST` | frontend |
+| `SECMAN_SSL_ACCEPT_ALL` | `SECMAN_INSECURE` | backend |
+| `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` / `SECMAN_ADMIN_EMAIL` | same names | backend bootstrap |
+| `SECMAN_MCP_KEY` | `SECMAN_MCP_KEY` | backend MCP |
+| `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` / `FALCON_CLOUD_REGION` | same names | backend CrowdStrike |
+| `OPENROUTER_API_KEY` | `SECMAN_OPENROUTER_API_KEY` | backend translation |
+| `SECMAN_AWS_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` | backend (optional override) |
+| `SECMAN_AWS_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` | backend (optional override) |
+| `SECMAN_AWS_ACCESS_TOKEN` | `AWS_SESSION_TOKEN` | backend (optional override) |
+
+Missing keys are skipped — they do not cause failure. This is intentional so an
+EC2 instance role can supply application-side AWS credentials without static
+keys having to live in the secret.
+
+`JWT_SECRET` is generated fresh on every backend start (`openssl rand -base64 48`),
+matching `startbackenddev.sh`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `aws: command not found` | Install AWS CLI v2 (see install section above). |
+| `Unable to locate credentials` | Configure credentials: attach an instance role, run `aws configure`, or set `AWS_PROFILE`. |
+| `AccessDeniedException ... GetSecretValue` | Add the IAM policy in *IAM permissions* above; if the secret uses a CMK, also grant `kms:Decrypt`. |
+| `ResourceNotFoundException` | The secret name is wrong, or the wrong region is in use. Set `SECMAN_AWS_SECRET_ID` and `AWS_REGION`. |
+| `jq: command not found` | `sudo dnf install -y jq` (AL2023) or `sudo yum install -y jq` (AL2). |
+| Backend starts but Flyway / DB connection fails | Verify `DB_CONNECT` in the secret points at a reachable MariaDB instance; remember the secret value must be a full JDBC URL. |
+| Backend starts but auth fails | Check that `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` exist in the secret. The first start bootstraps the admin user from these values. |
+
+## Relationship to canonical workflow
+
+- The `pass-cli` scripts remain canonical for local developer workflows
+  (per `CLAUDE.md`). Tests, E2E runners, and the CLI wrapper continue to
+  resolve secrets via pass-cli.
+- The AWS scripts target the deployed EC2 environment where pass-cli is
+  unavailable but Secrets Manager + IAM are already in place.
+- If you add new env vars to `startbackenddev.sh` / `startfrontenddev.sh`,
+  add the matching JSON key to `secman/dev` and update the table above.

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -1,28 +1,45 @@
 # AWS dev scripts (alternative to pass-cli)
 
-This document covers the AWS-flavored dev launchers:
+This document covers the AWS-flavored launchers — counterparts to every
+pass-cli script under `scripts/`. Each one resolves credentials from **AWS
+Secrets Manager** instead of Proton Pass, and is safe to run from cron and
+systemd on Amazon Linux.
 
-- `scripts/startbackenddevaws.sh` — backend dev (counterpart to `scripts/startbackenddev.sh`)
-- `scripts/startfrontenddevaws.sh` — frontend dev (counterpart to `scripts/startfrontenddev.sh`)
-
-They behave exactly like the canonical `pass-cli` versions but pull credentials from
-**AWS Secrets Manager** instead of Proton Pass. Useful when running secman on EC2
-(Amazon Linux 2 / 2023) where pass-cli is not the natural choice and the EC2 instance
-already has an IAM role.
-
-The original `pass-cli` scripts remain canonical (per `CLAUDE.md`). The AWS variants
-are an alternative entry point — they are not intended to replace pass-cli for local
+The original `pass-cli` scripts remain canonical (per `CLAUDE.md`). The AWS
+variants are an alternative entry point — not a replacement for local
 developer workflows.
 
-## How it works
+## Script index
 
-Both scripts:
+| pass-cli script | AWS variant | Purpose |
+|---|---|---|
+| `scripts/startbackenddev.sh` | `scripts/startbackenddevaws.sh` | Backend dev (port 8080) |
+| `scripts/startfrontenddev.sh` | `scripts/startfrontenddevaws.sh` | Frontend dev (port 4321) |
+| `scripts/backend` | `scripts/backendaws.sh` | Backend run via Gradle (no `:clean`) |
+| `scripts/deleteoutdated.sh` | `scripts/deleteoutdatedaws.sh` | CLI: dry-run delete-asset-not-seen |
+| `scripts/e2e-test.sh` | `scripts/e2e-testaws.sh` | E2E smoke + JS-error scanner |
+| `scripts/import.sh` | `scripts/importaws.sh` | CLI: query servers --save (CrowdStrike → backend) |
+| `scripts/release-e2e-test.sh` | `scripts/release-e2e-testaws.sh` | Release lifecycle E2E (REQADMIN) |
+| `scripts/secmancli` | `scripts/secmancliaws.sh` | General-purpose CLI wrapper |
+| `scripts/secmanng` | `scripts/secmanngaws.sh` | CLI wrapper with insecure-SSL flag |
+| `scripts/secmanreportenv` | `scripts/secmanreportenvaws.sh` | Report-env preset (sourceable) |
+| `scripts/secmanserverca` | `scripts/secmansercaaws.sh` | Runs `secmanclisupport` |
+| `scripts/test/provision-test-user.sh` | `scripts/test/provision-test-useraws.sh` | Idempotent test-user provisioning |
+| `scripts/test/test-e2e-exception-workflow.sh` | `scripts/test/test-e2e-exception-workflowaws.sh` | Exception workflow E2E |
+| `scripts/test/test-e2e-vuln-exception-full.sh` | `scripts/test/test-e2e-vuln-exception-fullaws.sh` | Full vuln + exception E2E (MCP + UI) |
 
-1. Read a single JSON secret from AWS Secrets Manager (default name `secman/dev`).
-2. Export each JSON field to the environment variable expected by the backend / frontend.
-3. Exec the appropriate dev command (`gradle :backendng:run` or `npm run dev`).
+All AWS variants share `scripts/lib/aws-secrets.sh` (sourced, not executed).
+The shared library:
 
-Stop scripts (`stopbackenddev.sh`, `stopfrontenddev.sh`) work unchanged for both
+1. Builds a cron-safe `PATH` and sources SDKMAN (and nvm if present), so
+   SDKMAN-managed `java`/`gradle` and nvm-managed `node`/`npm` are visible
+   even though cron does not read `~/.bashrc`.
+2. Reads a single JSON secret from AWS Secrets Manager (default name
+   `secman/dev`).
+3. Exposes `secman_aws_export_envfile` which exports the same env vars that
+   `pass-cli run --env-file secmanpp.env` would set.
+
+The stop helpers (`stopbackenddev.sh`, `stopfrontenddev.sh`) work for both
 flavors — they kill whatever is bound to ports 8080 / 4321.
 
 ## Required tools on Amazon Linux
@@ -338,26 +355,67 @@ SDKMAN/PATH bootstrap also handles the empty environment systemd provides.
 
 ## Secret keys reference
 
+The shared library (`scripts/lib/aws-secrets.sh::secman_aws_export_envfile`)
+maps every JSON field below to its env-var name. Missing keys are skipped — so
+optional fields (e.g. application-side AWS credentials when an EC2 instance
+role is in use) can simply be omitted from the secret.
+
 | JSON key in secret | Exported as | Used by |
 |---|---|---|
-| `DB_CONNECT` | `DB_CONNECT` | backend |
-| `SECMAN_BACKEND_BASE_URL` | `SECMAN_BACKEND_URL` (backend), `SECMAN_DOMAIN` (frontend) | both |
-| `SECMAN_HOST` | `SECMAN_HOST` | frontend |
-| `SECMAN_SSL_ACCEPT_ALL` | `SECMAN_INSECURE` | backend |
-| `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` / `SECMAN_ADMIN_EMAIL` | same names | backend bootstrap |
-| `SECMAN_MCP_KEY` | `SECMAN_MCP_KEY` | backend MCP |
-| `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` / `FALCON_CLOUD_REGION` | same names | backend CrowdStrike |
+| `DB_CONNECT` | `DB_CONNECT` | backend, CLI |
+| `SECMAN_BACKEND_BASE_URL` | `SECMAN_BACKEND_URL`, `SECMAN_DOMAIN` | backend dev, frontend dev |
+| `SECMAN_HOST` | `SECMAN_HOST` | frontend, test scripts |
+| `SECMAN_SSL_ACCEPT_ALL` | `SECMAN_INSECURE` | backend, CLI |
+| `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` / `SECMAN_ADMIN_EMAIL` | same names | backend bootstrap, CLI, E2E |
+| `SECMAN_USER_NAME` / `SECMAN_USER_PASS` | same names | E2E test-user provisioning |
+| `SECMAN_MCP_KEY` | `SECMAN_MCP_KEY` | backend MCP, MCP E2E |
+| `SECMAN_DB_HOST` / `SECMAN_DB_PORT` / `SECMAN_DB_NAME` | same names | CLI (paths that build JDBC themselves) |
+| `SECMAN_DB_USER` | `DB_USERNAME` | CLI |
+| `SECMAN_DB_PASSWORD` | `DB_PASSWORD` | CLI |
+| `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` / `FALCON_CLOUD_REGION` | same names | CrowdStrike import |
 | `OPENROUTER_API_KEY` | `SECMAN_OPENROUTER_API_KEY` | backend translation |
 | `SECMAN_AWS_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` | backend (optional override) |
 | `SECMAN_AWS_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` | backend (optional override) |
 | `SECMAN_AWS_ACCESS_TOKEN` | `AWS_SESSION_TOKEN` | backend (optional override) |
 
-Missing keys are skipped — they do not cause failure. This is intentional so an
-EC2 instance role can supply application-side AWS credentials without static
-keys having to live in the secret.
-
 `JWT_SECRET` is generated fresh on every backend start (`openssl rand -base64 48`),
 matching `startbackenddev.sh`.
+
+## Usage
+
+All AWS variants are invoked the same way as their pass-cli counterparts —
+just substitute the file name. Examples:
+
+```bash
+# Dev launchers
+./scripts/startbackenddevaws.sh
+./scripts/startfrontenddevaws.sh
+
+# Headless backend (no :clean) — useful for cron / systemd
+./scripts/backendaws.sh
+
+# CLI invocations
+./scripts/secmancliaws.sh help
+./scripts/secmancliaws.sh manage-user-mappings list-bucket --bucket my-bucket
+./scripts/secmanngaws.sh export-requirements --format xlsx
+./scripts/importaws.sh
+./scripts/deleteoutdatedaws.sh
+
+# Report-style env preset (sources the standard env block; useful for ad-hoc
+# `java -jar` invocations on AWS hosts)
+source ./scripts/secmanreportenvaws.sh
+java -jar src/cli/build/libs/cli-0.1.0-all.jar <some-report-command>
+
+# E2E tests
+./scripts/e2e-testaws.sh
+./scripts/release-e2e-testaws.sh
+./scripts/test/provision-test-useraws.sh
+./scripts/test/test-e2e-exception-workflowaws.sh
+./scripts/test/test-e2e-vuln-exception-fullaws.sh
+```
+
+Every variant requires the CLI shadow JAR (`./gradlew :cli:shadowJar`) to be
+built before first use, just like the pass-cli versions.
 
 ## Troubleshooting
 
@@ -371,12 +429,63 @@ matching `startbackenddev.sh`.
 | Backend starts but Flyway / DB connection fails | Verify `DB_CONNECT` in the secret points at a reachable MariaDB instance; remember the secret value must be a full JDBC URL. |
 | Backend starts but auth fails | Check that `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` exist in the secret. The first start bootstraps the admin user from these values. |
 
+## Cron usage for any AWS variant
+
+Every AWS variant inherits cron-safety from `scripts/lib/aws-secrets.sh`, so
+each one can be scheduled directly. Sample crontab entries:
+
+```cron
+# Hourly CrowdStrike import
+17 * * * * /home/ec2-user/secman/scripts/importaws.sh \
+            >> /var/log/secman/import.log 2>&1
+
+# Nightly stale-asset dry-run
+0 3 * * *  /home/ec2-user/secman/scripts/deleteoutdatedaws.sh \
+            >> /var/log/secman/deleteoutdated.log 2>&1
+
+# Reboot launchers
+@reboot    /home/ec2-user/secman/scripts/startbackenddevaws.sh  >> /var/log/secman/backend.log 2>&1
+@reboot    /home/ec2-user/secman/scripts/startfrontenddevaws.sh >> /var/log/secman/frontend.log 2>&1
+```
+
+Tips:
+
+- Run cron entries as the **same user that owns the SDKMAN install** — cron
+  uses that user's `$HOME` to find `~/.sdkman/bin/sdkman-init.sh`.
+- If SDKMAN lives elsewhere, put `SDKMAN_DIR=/opt/sdkman` (and similarly
+  `NVM_DIR=...`) at the top of the crontab.
+- Reproduce the cron environment locally before scheduling to confirm the
+  bootstrap works:
+  ```bash
+  env -i HOME="$HOME" PATH=/usr/bin:/bin /home/ec2-user/secman/scripts/secmancliaws.sh help
+  ```
+
+## Extending the AWS variants
+
+If you add a new pass-cli script, add a matching `*aws.sh` variant by sourcing
+the shared lib:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+secman_aws_export_envfile
+cd "${PROJECT_ROOT}"
+exec <your command>
+```
+
+If your script needs an env var that isn't in the table above, either add it
+to `secman_aws_export_envfile` in `scripts/lib/aws-secrets.sh` (preferred —
+keeps every script in sync) or call `secman_aws_export <ENV_VAR> <SECRET_KEY>`
+directly from your launcher.
+
 ## Relationship to canonical workflow
 
 - The `pass-cli` scripts remain canonical for local developer workflows
   (per `CLAUDE.md`). Tests, E2E runners, and the CLI wrapper continue to
-  resolve secrets via pass-cli.
+  resolve secrets via pass-cli during day-to-day development.
 - The AWS scripts target the deployed EC2 environment where pass-cli is
   unavailable but Secrets Manager + IAM are already in place.
-- If you add new env vars to `startbackenddev.sh` / `startfrontenddev.sh`,
-  add the matching JSON key to `secman/dev` and update the table above.
+- When you add new env vars to a pass-cli script, add the matching JSON key
+  to `secman/dev`, extend `secman_aws_export_envfile`, and create / update
+  the `*aws.sh` variant.

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -27,58 +27,86 @@ flavors — they kill whatever is bound to ports 8080 / 4321.
 
 ## Required tools on Amazon Linux
 
+The scripts need three OS-level packages plus a Java/Node toolchain. The
+toolchain can come from SDKMAN/nvm (recommended — see the next sections) or
+from system packages.
+
 ### Amazon Linux 2023
 
 ```bash
-# AWS CLI v2 (preinstalled on most AL2023 AMIs — verify with: aws --version)
+# AWS CLI v2 — preinstalled on most AL2023 AMIs (verify with: aws --version)
 sudo dnf install -y awscli
 
-# JSON parser
-sudo dnf install -y jq
-
-# OpenSSL + lsof (typically already installed)
-sudo dnf install -y openssl lsof
-
-# Java 21 (Corretto)
-sudo dnf install -y java-21-amazon-corretto-devel
-
-# Node.js 20+ (for the frontend)
-curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
-sudo dnf install -y nodejs
-
-# Git
-sudo dnf install -y git
+# Required: jq + openssl + lsof + git
+sudo dnf install -y jq openssl lsof git unzip zip curl
 ```
 
 ### Amazon Linux 2
 
 ```bash
-sudo yum install -y jq openssl lsof git
+sudo yum install -y jq openssl lsof git unzip zip curl
 
-# AWS CLI v2 (replaces preinstalled v1)
+# AWS CLI v2 (replaces the preinstalled v1)
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
 unzip awscliv2.zip && sudo ./aws/install --update
-
-# Java 21 (Corretto)
-sudo amazon-linux-extras enable corretto21
-sudo yum install -y java-21-amazon-corretto-devel
-
-# Node.js 20+
-curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
-sudo yum install -y nodejs
 ```
 
-### Gradle
+`unzip`, `zip`, and `curl` are needed by the SDKMAN installer.
 
-The project ships a Gradle wrapper (`./gradlew`), so a system Gradle install is
-optional — `startbackenddevaws.sh` falls back to `./gradlew` if `gradle` is not
-on `PATH`. To install a system Gradle (matching the project's 9.5.0):
+### Java + Gradle via SDKMAN (recommended)
+
+The launcher scripts source SDKMAN automatically if it's installed under
+`$SDKMAN_DIR` (default `$HOME/.sdkman`), so a system-wide Java/Gradle install
+is not required.
 
 ```bash
+# Install SDKMAN
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+
+# Java 21 (Amazon Corretto build via SDKMAN)
+sdk install java 21-amzn
+
+# Gradle 9.5.0 (project version)
+sdk install gradle 9.5
+```
+
+The scripts source `${SDKMAN_DIR}/bin/sdkman-init.sh` themselves, so a fresh
+shell (including a cron-spawned shell that does **not** read `~/.bashrc`)
+will see `java` and `gradle` once the above is done. You do not have to wire
+SDKMAN into your shell rc for the scripts to work.
+
+If SDKMAN lives somewhere other than `$HOME/.sdkman`, point `SDKMAN_DIR` at it
+in the cron environment.
+
+### Java + Gradle via system packages (alternative)
+
+```bash
+# Java 21 (Corretto)
+sudo dnf install -y java-21-amazon-corretto-devel   # AL2023
+# or, on AL2:
+sudo amazon-linux-extras enable corretto21 && sudo yum install -y java-21-amazon-corretto-devel
+
+# System Gradle (optional — ./gradlew works as a fallback)
 curl -fsSL https://services.gradle.org/distributions/gradle-9.5-bin.zip -o /tmp/gradle.zip
 sudo mkdir -p /opt/gradle && sudo unzip -d /opt/gradle /tmp/gradle.zip
 echo 'export PATH=$PATH:/opt/gradle/gradle-9.5/bin' | sudo tee /etc/profile.d/gradle.sh
-. /etc/profile.d/gradle.sh
+```
+
+The project ships a Gradle wrapper (`./gradlew`). `startbackenddevaws.sh` calls
+the system `gradle` if available; otherwise it falls back to `./gradlew`.
+
+### Node.js via nvm (optional)
+
+`startfrontenddevaws.sh` sources nvm (`$NVM_DIR/nvm.sh`, default
+`$HOME/.nvm/nvm.sh`) when present, so a Node managed by nvm is visible under
+cron without needing system Node installed.
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+. "$HOME/.nvm/nvm.sh"
+nvm install 20
+nvm alias default 20
 ```
 
 ## AWS authentication
@@ -217,6 +245,8 @@ From the project root:
 | `AWS_REGION`           | `eu-central-1` | Region containing the secret |
 | `AWS_DEFAULT_REGION`   | (fallback for `AWS_REGION`) | |
 | `AWS_PROFILE`          | (none) | Named profile from `~/.aws/credentials` |
+| `SDKMAN_DIR`           | `$HOME/.sdkman` | SDKMAN install location (sourced by both scripts) |
+| `NVM_DIR`              | `$HOME/.nvm` | nvm install location (sourced by `startfrontenddevaws.sh`) |
 
 Examples:
 
@@ -227,6 +257,84 @@ SECMAN_AWS_SECRET_ID=secman/staging AWS_REGION=us-east-1 ./scripts/startbackendd
 # Local dev with a named profile
 AWS_PROFILE=secman-dev ./scripts/startbackenddevaws.sh
 ```
+
+## Running under cron
+
+Both scripts are written to be cron-safe:
+
+- They build their own `PATH` (`$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`),
+  so they don't depend on whatever PATH cron passed in.
+- They source `${SDKMAN_DIR}/bin/sdkman-init.sh` if SDKMAN is installed, exposing
+  the SDKMAN-managed `java` and `gradle` to the script — even though cron does
+  not source `~/.bashrc` / `~/.profile`.
+- `startfrontenddevaws.sh` additionally sources `${NVM_DIR}/nvm.sh` if nvm is
+  installed.
+- They `cd` to the project root using their own location, so the working
+  directory cron starts in does not matter.
+- AWS credentials come from the standard provider chain. On EC2 the instance
+  profile is picked up automatically; otherwise set `AWS_PROFILE` (and
+  `AWS_SHARED_CREDENTIALS_FILE` / `AWS_CONFIG_FILE` if the user running cron
+  doesn't have `~/.aws/`).
+
+### Example crontab entry
+
+Run as the same user that owns the SDKMAN install (cron uses that user's
+`$HOME`):
+
+```cron
+# m h dom mon dow command
+@reboot /home/ec2-user/secman/scripts/startbackenddevaws.sh  >> /var/log/secman/backend.log 2>&1
+@reboot /home/ec2-user/secman/scripts/startfrontenddevaws.sh >> /var/log/secman/frontend.log 2>&1
+```
+
+If you keep SDKMAN somewhere else, override the path explicitly:
+
+```cron
+SDKMAN_DIR=/opt/sdkman
+NVM_DIR=/opt/nvm
+AWS_REGION=eu-central-1
+@reboot /home/ec2-user/secman/scripts/startbackenddevaws.sh >> /var/log/secman/backend.log 2>&1
+```
+
+### Verifying the cron environment
+
+Cron is notorious for "works in shell, fails in cron". To reproduce cron's
+minimal environment from an interactive shell and confirm the scripts still
+run, use `env -i`:
+
+```bash
+env -i HOME="$HOME" PATH=/usr/bin:/bin /home/ec2-user/secman/scripts/startbackenddevaws.sh
+```
+
+If that succeeds, the same invocation will succeed under cron.
+
+### systemd alternative
+
+For a long-running service, prefer a systemd unit over `@reboot` cron — it
+gives you proper restart-on-failure, log capture via `journalctl`, and graceful
+shutdown. Sketch:
+
+```ini
+# /etc/systemd/system/secman-backend.service
+[Unit]
+Description=Secman backend (dev)
+After=network-online.target
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user/secman
+Environment=AWS_REGION=eu-central-1
+ExecStart=/home/ec2-user/secman/scripts/startbackenddevaws.sh
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then `sudo systemctl enable --now secman-backend.service`. The script's
+SDKMAN/PATH bootstrap also handles the empty environment systemd provides.
 
 ## Secret keys reference
 

--- a/scripts/backendaws.sh
+++ b/scripts/backendaws.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# backendaws.sh — AWS Secrets Manager counterpart to scripts/backend.
+#
+# Replaces:  pass-cli run --env-file ./secmanpp.env -- gradle :backendng:run
+#
+# Cron-safe: relies on scripts/lib/aws-secrets.sh to bootstrap PATH, source
+# SDKMAN/nvm, and load the secret. See docs/AWS.md.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+if command -v gradle >/dev/null 2>&1; then
+  exec gradle :backendng:run
+else
+  exec ./gradlew :backendng:run
+fi

--- a/scripts/deleteoutdatedaws.sh
+++ b/scripts/deleteoutdatedaws.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# deleteoutdatedaws.sh — AWS Secrets Manager counterpart to scripts/deleteoutdated.sh.
+#
+# Runs the secman CLI's `delete-asset-not-seen` action in dry-run mode against
+# assets older than 30 days. Resolves the same env vars via Secrets Manager
+# instead of pass-cli. Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_require_cli_jar
+secman_aws_export_envfile
+
+export MICRONAUT_ENVIRONMENTS=dev
+export SECMAN_DEBUG=true
+
+cd "${PROJECT_ROOT}"
+
+# Mirror the parent script: SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS / SECMAN_INSECURE
+# are read from the environment by the CLI, never passed via argv (so a literal
+# placeholder cannot leak into the request).
+exec java -Xmx4g -Xms2g -jar "${CLI_JAR}" delete-asset-not-seen 30 --dry-run --verbose

--- a/scripts/e2e-testaws.sh
+++ b/scripts/e2e-testaws.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# e2e-testaws.sh — AWS Secrets Manager counterpart to scripts/e2e-test.sh.
+#
+# Loads secrets from Secrets Manager, generates a fresh JWT_SECRET, then
+# delegates to the existing scripts/e2e-test.2.sh harness. Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+export MICRONAUT_ENVIRONMENTS=dev
+export SECMAN_DEBUG=true
+export JWT_SECRET="$(openssl rand -base64 48)"
+
+cd "${PROJECT_ROOT}"
+
+exec ./scripts/e2e-test.2.sh

--- a/scripts/importaws.sh
+++ b/scripts/importaws.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# importaws.sh — AWS Secrets Manager counterpart to scripts/import.sh.
+#
+# Imports CrowdStrike "query servers" data into the backend. Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_require_cli_jar
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+# Override DB_CONNECT to the local-loopback default the original script uses
+# when running near the database. If the secret carried its own DB_CONNECT,
+# secman_aws_export_envfile already exported it; we only set the fallback when
+# it's still empty.
+export DB_CONNECT="${DB_CONNECT:-jdbc:mariadb://127.0.0.1:3306/secman?useSsl=true}"
+
+# Same caveat as deleteoutdatedaws.sh: --username/--password arrive via env
+# (the CLI reads SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS) or as literal CLI args.
+# Pass them as args using the *resolved* values so the CLI sees real credentials,
+# not pass:// placeholders.
+exec java -Xmx4g -Xms2g -jar "${CLI_JAR}" \
+  query servers \
+  --device-type SERVER \
+  --severity CRITICAL,HIGH \
+  --min-days-open 1 \
+  --save \
+  --username "${SECMAN_ADMIN_NAME}" \
+  --password "${SECMAN_ADMIN_PASS}" \
+  --last-seen-days 1

--- a/scripts/lib/aws-secrets.sh
+++ b/scripts/lib/aws-secrets.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# scripts/lib/aws-secrets.sh — shared bootstrap for the *aws.sh launchers.
+#
+# This file is sourced (not executed) by every scripts/*aws.sh launcher. It:
+#
+#   1. Builds a cron-safe PATH (cron does not source ~/.bashrc / ~/.profile).
+#   2. Sources SDKMAN (and nvm, if installed) so SDKMAN-managed java/gradle and
+#      nvm-managed node/npm are visible — even under cron / systemd.
+#   3. Fetches a single JSON secret from AWS Secrets Manager and exposes a
+#      `secman_aws_export_envfile` function that maps secret keys to env vars,
+#      mirroring what `pass-cli run --env-file secmanpp.env` does.
+#   4. Locates the project root and the CLI shadow JAR for callers that need
+#      them.
+#
+# Public API (functions that callers should use):
+#
+#   secman_aws_load_secret           Fetches the JSON secret. Stores it in
+#                                    SECMAN_AWS_SECRET_JSON. Idempotent.
+#   secman_aws_export_envfile        Exports the full pass-cli-equivalent set
+#                                    of env vars. Safe to call multiple times.
+#   secman_aws_extract <key>         Echoes one value from the secret JSON.
+#
+# Public variables set by this file:
+#   PROJECT_ROOT                     Absolute path to the secman repo root.
+#   CLI_JAR                          Path to src/cli/build/libs/cli-0.1.0-all.jar
+#
+# Configuration env vars consumed:
+#   SECMAN_AWS_SECRET_ID             Secrets Manager secret name or ARN.
+#                                    Default: secman/dev
+#   AWS_REGION / AWS_DEFAULT_REGION  Region for the secret. Default: eu-central-1
+#   SDKMAN_DIR                       SDKMAN install root. Default: $HOME/.sdkman
+#   NVM_DIR                          nvm install root. Default: $HOME/.nvm
+#
+# See docs/AWS.md for the canonical secret schema and IAM permissions.
+
+# Guard: only run the bootstrap once per shell, even if multiple launchers
+# source this file in the same process.
+if [ "${SECMAN_AWS_LIB_LOADED:-}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+SECMAN_AWS_LIB_LOADED=1
+
+# --- Cron-safe environment ---------------------------------------------------
+: "${HOME:=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)}"
+export HOME
+
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# Source SDKMAN. SDKMAN's init script touches unset variables, so we relax `-u`
+# while sourcing if the caller had it on.
+SDKMAN_DIR="${SDKMAN_DIR:-${HOME}/.sdkman}"
+if [ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]; then
+  case "$-" in *u*) _secman_aws_had_u=1; set +u ;; *) _secman_aws_had_u=0 ;; esac
+  # shellcheck disable=SC1091
+  source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+  [ "${_secman_aws_had_u:-0}" = "1" ] && set -u
+  unset _secman_aws_had_u
+fi
+
+# Source nvm if present (lets callers find node/npm under cron).
+NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  case "$-" in *u*) _secman_aws_had_u=1; set +u ;; *) _secman_aws_had_u=0 ;; esac
+  # shellcheck disable=SC1091
+  source "${NVM_DIR}/nvm.sh" --no-use
+  if [ -s "${NVM_DIR}/alias/default" ]; then
+    nvm use default >/dev/null 2>&1 || true
+  fi
+  [ "${_secman_aws_had_u:-0}" = "1" ] && set -u
+  unset _secman_aws_had_u
+fi
+
+# --- Project layout ----------------------------------------------------------
+# BASH_SOURCE[0] is this file; the project root is two levels up
+# (scripts/lib/aws-secrets.sh -> ../..).
+_SECMAN_AWS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${_SECMAN_AWS_LIB_DIR}/../.." && pwd)"
+CLI_JAR="${PROJECT_ROOT}/src/cli/build/libs/cli-0.1.0-all.jar"
+export PROJECT_ROOT CLI_JAR
+
+# --- AWS Secrets Manager fetch ----------------------------------------------
+SECMAN_AWS_SECRET_ID="${SECMAN_AWS_SECRET_ID:-secman/dev}"
+SECMAN_AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-central-1}}"
+SECMAN_AWS_SECRET_JSON=""
+
+secman_aws_require_tools() {
+  command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See docs/AWS.md."; return 1; }
+  command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See docs/AWS.md.";       return 1; }
+}
+
+secman_aws_load_secret() {
+  if [ -n "${SECMAN_AWS_SECRET_JSON:-}" ]; then return 0; fi
+  secman_aws_require_tools || return 1
+  echo "[aws-secrets] Fetching secret '${SECMAN_AWS_SECRET_ID}' from AWS Secrets Manager (region ${SECMAN_AWS_REGION})..." >&2
+  SECMAN_AWS_SECRET_JSON=$(aws secretsmanager get-secret-value \
+    --secret-id "${SECMAN_AWS_SECRET_ID}" \
+    --region "${SECMAN_AWS_REGION}" \
+    --query SecretString \
+    --output text) || {
+      echo "ERROR: failed to read secret '${SECMAN_AWS_SECRET_ID}' (region ${SECMAN_AWS_REGION})" >&2
+      return 1
+    }
+  if [ -z "${SECMAN_AWS_SECRET_JSON}" ] || [ "${SECMAN_AWS_SECRET_JSON}" = "None" ]; then
+    echo "ERROR: empty SecretString for ${SECMAN_AWS_SECRET_ID}" >&2
+    return 1
+  fi
+}
+
+# Echo one value from the secret JSON, or empty if absent.
+secman_aws_extract() {
+  printf '%s' "${SECMAN_AWS_SECRET_JSON}" | jq -r --arg k "$1" '.[$k] // empty'
+}
+
+# Helper: export an env var from a secret key. Skips if the key is missing or
+# empty, so optional fields don't clobber whatever's already set.
+secman_aws_export() {
+  local var="$1" key="$2" val
+  val="$(secman_aws_extract "$key")"
+  if [ -n "$val" ]; then export "$var=$val"; fi
+}
+
+# Export the full set of env vars that secmanpp.env normally provides via
+# pass-cli. Mirrors the `key -> env var` mapping the original launchers used.
+secman_aws_export_envfile() {
+  secman_aws_load_secret || return 1
+
+  # Backend connection / target URL
+  secman_aws_export DB_CONNECT                    DB_CONNECT
+  secman_aws_export SECMAN_BACKEND_URL            SECMAN_BACKEND_BASE_URL
+  secman_aws_export SECMAN_DOMAIN                 SECMAN_BACKEND_BASE_URL
+  secman_aws_export SECMAN_HOST                   SECMAN_HOST
+  secman_aws_export SECMAN_INSECURE               SECMAN_SSL_ACCEPT_ALL
+
+  # Database (used by some CLI paths that build the JDBC URL themselves)
+  secman_aws_export SECMAN_DB_HOST                SECMAN_DB_HOST
+  secman_aws_export SECMAN_DB_PORT                SECMAN_DB_PORT
+  secman_aws_export SECMAN_DB_NAME                SECMAN_DB_NAME
+  secman_aws_export DB_USERNAME                   SECMAN_DB_USER
+  secman_aws_export DB_PASSWORD                   SECMAN_DB_PASSWORD
+
+  # Admin + test user identities
+  secman_aws_export SECMAN_ADMIN_NAME             SECMAN_ADMIN_NAME
+  secman_aws_export SECMAN_ADMIN_PASS             SECMAN_ADMIN_PASS
+  secman_aws_export SECMAN_ADMIN_EMAIL            SECMAN_ADMIN_EMAIL
+  secman_aws_export SECMAN_USER_NAME              SECMAN_USER_NAME
+  secman_aws_export SECMAN_USER_PASS              SECMAN_USER_PASS
+
+  # Auth keys
+  secman_aws_export SECMAN_MCP_KEY                SECMAN_MCP_KEY
+
+  # Integrations
+  secman_aws_export FALCON_CLIENT_ID              FALCON_CLIENT_ID
+  secman_aws_export FALCON_CLIENT_SECRET          FALCON_CLIENT_SECRET
+  secman_aws_export FALCON_CLOUD_REGION           FALCON_CLOUD_REGION
+  secman_aws_export SECMAN_OPENROUTER_API_KEY     OPENROUTER_API_KEY
+
+  # Application-side AWS credentials. Only override the ambient identity if the
+  # secret carries them — leave empty in the secret to fall back to an EC2
+  # instance role.
+  secman_aws_export AWS_ACCESS_KEY_ID             SECMAN_AWS_ACCESS_KEY_ID
+  secman_aws_export AWS_SECRET_ACCESS_KEY         SECMAN_AWS_SECRET_ACCESS_KEY
+  secman_aws_export AWS_SESSION_TOKEN             SECMAN_AWS_ACCESS_TOKEN
+}
+
+# Fail if the CLI shadow JAR has not been built yet.
+secman_aws_require_cli_jar() {
+  if [ ! -f "${CLI_JAR}" ]; then
+    cat >&2 <<EOF
+ERROR: CLI JAR not found at ${CLI_JAR}
+
+Build it first with:
+  ./gradlew :cli:shadowJar
+EOF
+    return 1
+  fi
+}

--- a/scripts/release-e2e-testaws.sh
+++ b/scripts/release-e2e-testaws.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# release-e2e-testaws.sh — AWS Secrets Manager counterpart to scripts/release-e2e-test.sh.
+#
+# The original release-e2e-test.sh treats SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS /
+# SECMAN_MCP_KEY as either plain text or pass:// URIs. This wrapper resolves them
+# from Secrets Manager, exports the plain-text values, and re-execs the original
+# script — which then takes the plain-text path and skips its pass-cli branch.
+#
+# Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+# release-e2e-test.sh reads SECMAN_BASE_URL (note: BASE, not BACKEND) and falls
+# back to http://localhost:8080. Bridge SECMAN_BACKEND_URL → SECMAN_BASE_URL when
+# only the former is in the secret.
+if [ -z "${SECMAN_BASE_URL:-}" ] && [ -n "${SECMAN_BACKEND_URL:-}" ]; then
+  export SECMAN_BASE_URL="${SECMAN_BACKEND_URL}"
+fi
+
+cd "${PROJECT_ROOT}"
+
+exec ./scripts/release-e2e-test.sh "$@"

--- a/scripts/secmancliaws.sh
+++ b/scripts/secmancliaws.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# secmancliaws.sh — AWS Secrets Manager counterpart to scripts/secmancli.
+#
+# General-purpose CLI wrapper. All env secrets (CrowdStrike, admin auth,
+# AWS creds, MCP key, DB) come from Secrets Manager instead of pass-cli.
+#
+# Usage: ./scripts/secmancliaws.sh <command> [options]
+# Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_require_cli_jar
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+exec java -Xmx512m -jar "${CLI_JAR}" "$@"

--- a/scripts/secmanngaws.sh
+++ b/scripts/secmanngaws.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# secmanngaws.sh — AWS Secrets Manager counterpart to scripts/secmanng.
+#
+# Same as secmancliaws.sh but additionally:
+#   - Honours SECMAN_INSECURE → -Dsecman.ssl.insecure=true
+#   - Disables Micronaut's datasource init failure timeout
+#
+# Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_require_cli_jar
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+SSL_FLAG=""
+INSECURE_LOWER="$(printf '%s' "${SECMAN_INSECURE:-}" | tr '[:upper:]' '[:lower:]')"
+case "${INSECURE_LOWER}" in
+  true|1|yes) SSL_FLAG="-Dsecman.ssl.insecure=true" ;;
+esac
+
+exec java ${SSL_FLAG} \
+  -Ddatasources.default.initialization-fail-timeout=-1 \
+  -jar "${CLI_JAR}" "$@"

--- a/scripts/secmanreportenvaws.sh
+++ b/scripts/secmanreportenvaws.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# secmanreportenvaws.sh — AWS Secrets Manager counterpart to scripts/secmanreportenv.
+#
+# The original scripts/secmanreportenv only sets up the environment (Falcon,
+# admin auth, AWS, DB) and verifies the CLI JAR exists, but does not run a
+# command. This AWS variant mirrors that exactly — useful for sourcing when a
+# report-style invocation needs the same env block, e.g.:
+#
+#   source ./scripts/secmanreportenvaws.sh
+#   java -jar src/cli/build/libs/cli-0.1.0-all.jar <report command>
+#
+# Cron-safe via the shared lib.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+secman_aws_require_cli_jar
+
+cd "${PROJECT_ROOT}"

--- a/scripts/secmansercaaws.sh
+++ b/scripts/secmansercaaws.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# secmansercaaws.sh — AWS Secrets Manager counterpart to scripts/secmanserverca.
+#
+# The original wraps `pass-cli run --env-file ./secmanpp.env -- ./scripts/secmanclisupport`.
+# This variant resolves the same env from Secrets Manager and runs the same
+# support script directly. Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+exec ./scripts/secmanclisupport

--- a/scripts/startbackenddevaws.sh
+++ b/scripts/startbackenddevaws.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Backend dev start using AWS Secrets Manager (alternative to startbackenddev.sh + pass-cli).
+#
+# Resolves the secrets that ./scripts/startbackenddev.sh normally fetches via pass-cli,
+# but reads them from a single JSON-shaped secret in AWS Secrets Manager.
+#
+# Configuration (env vars):
+#   SECMAN_AWS_SECRET_ID  Secrets Manager secret name or ARN  (default: secman/dev)
+#   AWS_REGION            AWS region for the secret           (default: eu-central-1)
+#   AWS_PROFILE           Optional named profile from ~/.aws/credentials
+#
+# AWS authentication: any standard credential provider works (instance profile on EC2,
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars, AWS_PROFILE, SSO, etc.).
+#
+# Required tools: aws CLI v2, jq, openssl, gradle (or rely on ./gradlew).
+# See AWS.md for installation instructions on Amazon Linux.
+
+set -euo pipefail
+
+SECRET_ID="${SECMAN_AWS_SECRET_ID:-secman/dev}"
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-central-1}}"
+
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See AWS.md."; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See AWS.md.";       exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "ERROR: openssl is required.";          exit 1; }
+
+echo "Fetching secret '${SECRET_ID}' from AWS Secrets Manager (region ${REGION})..."
+SECRET_JSON=$(aws secretsmanager get-secret-value \
+  --secret-id "${SECRET_ID}" \
+  --region "${REGION}" \
+  --query SecretString \
+  --output text)
+
+if [ -z "${SECRET_JSON}" ] || [ "${SECRET_JSON}" = "None" ]; then
+  echo "ERROR: empty SecretString for ${SECRET_ID}"; exit 1
+fi
+
+# Extract a key from the JSON secret. Returns empty string if the key is absent.
+extract() { printf '%s' "${SECRET_JSON}" | jq -r --arg k "$1" '.[$k] // empty'; }
+
+# Conditional export: only set the env var when the secret actually contains the key.
+# Skipping AWS creds (which the application uses to call CrowdStrike, S3 etc.) lets the
+# script fall back to the EC2 instance role when no static keys are stored in the secret.
+maybe_export() {
+  local var="$1" key="$2" val
+  val="$(extract "$key")"
+  if [ -n "$val" ]; then export "$var=$val"; fi
+}
+
+export MICRONAUT_ENVIRONMENTS=dev
+export SECMAN_DEBUG=true
+
+maybe_export DB_CONNECT                 DB_CONNECT
+maybe_export SECMAN_BACKEND_URL         SECMAN_BACKEND_BASE_URL
+maybe_export FALCON_CLIENT_ID           FALCON_CLIENT_ID
+maybe_export FALCON_CLIENT_SECRET       FALCON_CLIENT_SECRET
+maybe_export FALCON_CLOUD_REGION        FALCON_CLOUD_REGION
+maybe_export SECMAN_OPENROUTER_API_KEY  OPENROUTER_API_KEY
+maybe_export SECMAN_ADMIN_NAME          SECMAN_ADMIN_NAME
+maybe_export SECMAN_ADMIN_PASS          SECMAN_ADMIN_PASS
+maybe_export SECMAN_MCP_KEY             SECMAN_MCP_KEY
+maybe_export SECMAN_ADMIN_EMAIL         SECMAN_ADMIN_EMAIL
+maybe_export SECMAN_INSECURE            SECMAN_SSL_ACCEPT_ALL
+
+# Application-side AWS credentials (used by backend for CrowdStrike, S3 etc.).
+# Only override the ambient AWS identity when the secret carries these keys.
+maybe_export AWS_ACCESS_KEY_ID          SECMAN_AWS_ACCESS_KEY_ID
+maybe_export AWS_SECRET_ACCESS_KEY      SECMAN_AWS_SECRET_ACCESS_KEY
+maybe_export AWS_SESSION_TOKEN          SECMAN_AWS_ACCESS_TOKEN
+
+export JWT_SECRET=$(openssl rand -base64 48)
+
+if command -v gradle >/dev/null 2>&1; then
+  exec gradle :backendng:clean backendng:run
+else
+  exec ./gradlew :backendng:clean :backendng:run
+fi

--- a/scripts/startbackenddevaws.sh
+++ b/scripts/startbackenddevaws.sh
@@ -4,25 +4,68 @@
 # Resolves the secrets that ./scripts/startbackenddev.sh normally fetches via pass-cli,
 # but reads them from a single JSON-shaped secret in AWS Secrets Manager.
 #
+# Cron-safe: the script does not rely on the caller's PATH or shell rc files. It sources
+# SDKMAN if installed (under SDKMAN_DIR or ~/.sdkman) so java/gradle become visible even
+# under the minimal cron environment, and changes the working directory to the project
+# root so relative paths and Gradle project discovery work regardless of where cron
+# launches it from.
+#
 # Configuration (env vars):
 #   SECMAN_AWS_SECRET_ID  Secrets Manager secret name or ARN  (default: secman/dev)
 #   AWS_REGION            AWS region for the secret           (default: eu-central-1)
 #   AWS_PROFILE           Optional named profile from ~/.aws/credentials
+#   SDKMAN_DIR            Override SDKMAN install location    (default: $HOME/.sdkman)
 #
 # AWS authentication: any standard credential provider works (instance profile on EC2,
 # AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars, AWS_PROFILE, SSO, etc.).
 #
 # Required tools: aws CLI v2, jq, openssl, gradle (or rely on ./gradlew).
-# See AWS.md for installation instructions on Amazon Linux.
+# See docs/AWS.md for installation instructions on Amazon Linux.
 
 set -euo pipefail
+
+# --- Cron-safe environment bootstrap -----------------------------------------
+# Cron runs with a minimal PATH (typically /usr/bin:/bin) and does NOT source
+# ~/.bashrc, ~/.profile, etc. Anything installed under /usr/local/bin or via
+# SDKMAN/nvm must be brought in explicitly.
+
+# Ensure HOME is set (some cron daemons pass it, some don't).
+: "${HOME:=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)}"
+export HOME
+
+# Pre-pend common locations so aws/jq/openssl/node are findable regardless of
+# whether cron set PATH. Keep the caller's PATH at the end so explicit overrides
+# still take effect.
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# Resolve and switch to the project root (one level above scripts/) so Gradle
+# discovers the build and ./gradlew is reachable.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+# SDKMAN ships java/gradle/etc. under $SDKMAN_DIR/candidates/<tool>/current/bin
+# but only after sdkman-init.sh is sourced. Source it if we can find it.
+SDKMAN_DIR="${SDKMAN_DIR:-${HOME}/.sdkman}"
+if [ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]; then
+  # sdkman-init.sh references unset vars; relax `set -u` while sourcing.
+  set +u
+  # shellcheck disable=SC1091
+  source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+  set -u
+fi
+# -----------------------------------------------------------------------------
 
 SECRET_ID="${SECMAN_AWS_SECRET_ID:-secman/dev}"
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-central-1}}"
 
-command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See AWS.md."; exit 1; }
-command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See AWS.md.";       exit 1; }
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See docs/AWS.md."; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See docs/AWS.md.";       exit 1; }
 command -v openssl >/dev/null 2>&1 || { echo "ERROR: openssl is required.";          exit 1; }
+command -v java >/dev/null 2>&1 || {
+  echo "ERROR: java not found. Install via SDKMAN ('sdk install java 21-amzn') or set SDKMAN_DIR."
+  exit 1
+}
 
 echo "Fetching secret '${SECRET_ID}' from AWS Secrets Manager (region ${REGION})..."
 SECRET_JSON=$(aws secretsmanager get-secret-value \

--- a/scripts/startfrontenddevaws.sh
+++ b/scripts/startfrontenddevaws.sh
@@ -1,26 +1,65 @@
 #!/bin/bash
 # Frontend dev start using AWS Secrets Manager (alternative to startfrontenddev.sh + pass-cli).
 #
+# Cron-safe: bootstraps PATH and sources SDKMAN/nvm if installed, so node/npm and any
+# SDKMAN-managed tools are visible even under cron's minimal environment.
+#
 # Configuration (env vars):
 #   SECMAN_AWS_SECRET_ID  Secrets Manager secret name or ARN  (default: secman/dev)
 #   AWS_REGION            AWS region for the secret           (default: eu-central-1)
 #   AWS_PROFILE           Optional named profile from ~/.aws/credentials
+#   SDKMAN_DIR            Override SDKMAN install location    (default: $HOME/.sdkman)
+#   NVM_DIR               Override nvm install location       (default: $HOME/.nvm)
 #
-# Required tools: aws CLI v2, jq, node/npm. See AWS.md.
+# Required tools: aws CLI v2, jq, node/npm. See docs/AWS.md.
 
 set -euo pipefail
+
+# --- Cron-safe environment bootstrap -----------------------------------------
+: "${HOME:=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)}"
+export HOME
+
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# SDKMAN — usually for java/gradle/etc., but harmless to source here in case
+# anyone manages node via sdkman as well.
+SDKMAN_DIR="${SDKMAN_DIR:-${HOME}/.sdkman}"
+if [ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]; then
+  set +u
+  # shellcheck disable=SC1091
+  source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+  set -u
+fi
+
+# nvm — common way to install Node on EC2. Sourcing it makes `node`/`npm` visible.
+NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  set +u
+  # shellcheck disable=SC1091
+  source "${NVM_DIR}/nvm.sh" --no-use
+  # If a default alias exists, activate it; otherwise leave whatever PATH-resolved
+  # node is in place.
+  if [ -s "${NVM_DIR}/alias/default" ]; then
+    nvm use default >/dev/null 2>&1 || true
+  fi
+  set -u
+fi
+# -----------------------------------------------------------------------------
 
 SECRET_ID="${SECMAN_AWS_SECRET_ID:-secman/dev}"
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-central-1}}"
 
-command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See AWS.md."; exit 1; }
-command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See AWS.md.";       exit 1; }
-command -v npm >/dev/null 2>&1 || { echo "ERROR: npm is required.";                   exit 1; }
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See docs/AWS.md."; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See docs/AWS.md.";       exit 1; }
+command -v npm >/dev/null 2>&1 || {
+  echo "ERROR: npm not found. Install Node.js (e.g. via nvm) or set NVM_DIR."
+  exit 1
+}
 
-# Resolve the project's frontend directory relative to this script so it works from
-# anywhere on the filesystem.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "${SCRIPT_DIR}/../src/frontend"
+cd "${PROJECT_ROOT}/src/frontend"
 
 echo "Fetching secret '${SECRET_ID}' from AWS Secrets Manager (region ${REGION})..."
 SECRET_JSON=$(aws secretsmanager get-secret-value \

--- a/scripts/startfrontenddevaws.sh
+++ b/scripts/startfrontenddevaws.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Frontend dev start using AWS Secrets Manager (alternative to startfrontenddev.sh + pass-cli).
+#
+# Configuration (env vars):
+#   SECMAN_AWS_SECRET_ID  Secrets Manager secret name or ARN  (default: secman/dev)
+#   AWS_REGION            AWS region for the secret           (default: eu-central-1)
+#   AWS_PROFILE           Optional named profile from ~/.aws/credentials
+#
+# Required tools: aws CLI v2, jq, node/npm. See AWS.md.
+
+set -euo pipefail
+
+SECRET_ID="${SECMAN_AWS_SECRET_ID:-secman/dev}"
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-eu-central-1}}"
+
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See AWS.md."; exit 1; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See AWS.md.";       exit 1; }
+command -v npm >/dev/null 2>&1 || { echo "ERROR: npm is required.";                   exit 1; }
+
+# Resolve the project's frontend directory relative to this script so it works from
+# anywhere on the filesystem.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src/frontend"
+
+echo "Fetching secret '${SECRET_ID}' from AWS Secrets Manager (region ${REGION})..."
+SECRET_JSON=$(aws secretsmanager get-secret-value \
+  --secret-id "${SECRET_ID}" \
+  --region "${REGION}" \
+  --query SecretString \
+  --output text)
+
+if [ -z "${SECRET_JSON}" ] || [ "${SECRET_JSON}" = "None" ]; then
+  echo "ERROR: empty SecretString for ${SECRET_ID}"; exit 1
+fi
+
+extract() { printf '%s' "${SECRET_JSON}" | jq -r --arg k "$1" '.[$k] // empty'; }
+
+maybe_export() {
+  local var="$1" key="$2" val
+  val="$(extract "$key")"
+  if [ -n "$val" ]; then export "$var=$val"; fi
+}
+
+maybe_export SECMAN_DOMAIN  SECMAN_BACKEND_BASE_URL
+maybe_export SECMAN_HOST    SECMAN_HOST
+
+exec npm run dev

--- a/scripts/test/provision-test-useraws.sh
+++ b/scripts/test/provision-test-useraws.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# provision-test-useraws.sh — AWS Secrets Manager counterpart to
+# scripts/test/provision-test-user.sh.
+#
+# Provisions the e2ejs `secmanuser` test account by calling /api/users on the
+# admin-authenticated backend. Idempotent: exits 0 if the user already exists.
+#
+# Loads SECMAN_HOST / SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS / SECMAN_USER_NAME /
+# SECMAN_USER_PASS from AWS Secrets Manager. Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=../lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+: "${SECMAN_HOST:?SECMAN_HOST not present in secret}"
+: "${SECMAN_ADMIN_NAME:?SECMAN_ADMIN_NAME not present in secret}"
+: "${SECMAN_ADMIN_PASS:?SECMAN_ADMIN_PASS not present in secret}"
+: "${SECMAN_USER_NAME:?SECMAN_USER_NAME not present in secret}"
+: "${SECMAN_USER_PASS:?SECMAN_USER_PASS not present in secret}"
+
+# SECMAN_HOST in the vault is typically the bare hostname. Build a full base
+# URL — assume https unless SECMAN_HOST already has a scheme.
+if [[ "$SECMAN_HOST" == http://* || "$SECMAN_HOST" == https://* ]]; then
+  base_url="${SECMAN_HOST%/}"
+else
+  base_url="https://${SECMAN_HOST%/}"
+fi
+
+cookie_jar="$(mktemp)"
+trap 'rm -f "$cookie_jar"' EXIT
+
+echo "→ Logging in as ${SECMAN_ADMIN_NAME} at ${base_url} …"
+login_status=$(curl -sS -k -o /dev/null -w '%{http_code}' \
+  -c "$cookie_jar" \
+  -H 'Content-Type: application/json' \
+  -X POST "${base_url}/api/auth/login" \
+  --data "$(printf '{"username":"%s","password":"%s"}' \
+             "$SECMAN_ADMIN_NAME" "$SECMAN_ADMIN_PASS")")
+if [[ "$login_status" != "200" ]]; then
+  echo "✗ Admin login failed (HTTP $login_status)" >&2
+  exit 1
+fi
+
+echo "→ Checking if user '${SECMAN_USER_NAME}' already exists …"
+exists_payload=$(curl -sS -k -b "$cookie_jar" "${base_url}/api/users")
+if echo "$exists_payload" | grep -q "\"username\":\"${SECMAN_USER_NAME}\""; then
+  echo "✓ User '${SECMAN_USER_NAME}' already exists. Nothing to do."
+  exit 0
+fi
+
+echo "→ Creating user '${SECMAN_USER_NAME}' (role USER) …"
+create_body=$(mktemp)
+create_status=$(curl -sS -k -o "$create_body" -w '%{http_code}' \
+  -b "$cookie_jar" \
+  -H 'Content-Type: application/json' \
+  -X POST "${base_url}/api/users" \
+  --data "$(printf '{"username":"%s","email":"%s@e2e.local","password":"%s","roles":["USER"]}' \
+             "$SECMAN_USER_NAME" "$SECMAN_USER_NAME" "$SECMAN_USER_PASS")")
+if [[ "$create_status" != "200" && "$create_status" != "201" ]]; then
+  echo "✗ Create user failed (HTTP $create_status):" >&2
+  cat "$create_body" >&2
+  rm -f "$create_body"
+  exit 1
+fi
+rm -f "$create_body"
+
+echo "✓ User '${SECMAN_USER_NAME}' provisioned."

--- a/scripts/test/test-e2e-exception-workflowaws.sh
+++ b/scripts/test/test-e2e-exception-workflowaws.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# test-e2e-exception-workflowaws.sh — AWS Secrets Manager counterpart to
+# scripts/test/test-e2e-exception-workflow.sh.
+#
+# Loads the secret block, then delegates to the same support script the
+# pass-cli wrapper does.
+#
+# Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=../lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+exec ./scripts/test/test-e2e-exception-workflowsupport.sh "$@"

--- a/scripts/test/test-e2e-vuln-exception-fullaws.sh
+++ b/scripts/test/test-e2e-vuln-exception-fullaws.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# test-e2e-vuln-exception-fullaws.sh — AWS Secrets Manager counterpart to
+# scripts/test/test-e2e-vuln-exception-full.sh.
+#
+# The original test script reads SECMAN_MCP_KEY / SECMAN_ADMIN_EMAIL /
+# SECMAN_ADMIN_NAME / SECMAN_ADMIN_PASS from the environment and aborts if any
+# are missing. This wrapper resolves them from Secrets Manager and re-execs
+# the original with the env populated, so the original's pre-flight check
+# passes without pass-cli.
+#
+# Cron-safe.
+
+set -euo pipefail
+
+# shellcheck source=../lib/aws-secrets.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/aws-secrets.sh"
+
+secman_aws_export_envfile
+
+cd "${PROJECT_ROOT}"
+
+exec ./scripts/test/test-e2e-vuln-exception-full.sh "$@"


### PR DESCRIPTION
scripts/startbackenddevaws.sh and scripts/startfrontenddevaws.sh mirror the
existing pass-cli launchers but resolve credentials from a single JSON-shaped
secret in AWS Secrets Manager (default name: secman/dev). Useful on EC2
(Amazon Linux) where pass-cli is unavailable but an instance role can read
Secrets Manager.

Application-side AWS credentials are exported only when present in the secret,
so an EC2 instance role passes through cleanly when those keys are omitted.

AWS.md documents installation prerequisites for Amazon Linux 2 / 2023, IAM
permissions, secret schema, a one-time pass-cli to Secrets Manager migration,
configuration env vars, and troubleshooting.

https://claude.ai/code/session_01LJCGppVUZ6q4bNudyaq4wp