### PR TITLE
fix(mcp): stop /api/mcp 401 on foreign RS256 bearer tokens

### DIFF
--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -125,6 +125,23 @@ micronaut:
       - pattern: /mcp/**
         access:
           - isAnonymous()
+      # MCP REST endpoints under /api/mcp use X-MCP-API-Key (not JWT) for auth.
+      # Without these explicit rules, the /api/** catch-all forces JWT validation
+      # on every request — and a foreign-issued RS256 token (e.g. from a Postman
+      # OAuth helper) fails the HS256 secret verifier with "Unsupported JWS
+      # algorithm RS256", returning 401 before the controller-level
+      # @Secured(IS_ANONYMOUS) is ever consulted.
+      # Admin paths stay authenticated so @Secured("ADMIN") on McpAdminController
+      # still gates them.
+      - pattern: /api/mcp/admin/**
+        access:
+          - isAuthenticated()
+      - pattern: /api/mcp
+        access:
+          - isAnonymous()
+      - pattern: /api/mcp/**
+        access:
+          - isAnonymous()
       - pattern: /api/auth/status
         access:
           - isAuthenticated()


### PR DESCRIPTION
The /api/mcp/** REST endpoints authenticate via the X-MCP-API-Key
header and are annotated @Secured(IS_ANONYMOUS) in code. They were
nonetheless rejected with 401 whenever a client (e.g. Postman with
an OAuth helper) included a foreign Authorization: Bearer header,
because the /api/** catch-all rule forced Micronaut Security to
validate the JWT with the only configured verifier (HS256 secret).
RS256 tokens then trip MACProvider with "Unsupported JWS algorithm
RS256", short-circuiting the controller-level anonymous rule.

Mirror the existing /mcp and /mcp/** anonymous entries for the
/api/mcp REST tree. Keep /api/mcp/admin/** isAuthenticated() first
so @Secured("ADMIN") on McpAdminController continues to gate it.