### PR TITLE
Scope user vulnerability notifications by user role and expose notification scope in API/CLI

### DIFF
--- a/scripts/notifyuser.sh
+++ b/scripts/notifyuser.sh
@@ -8,7 +8,7 @@ Usage:
   scripts/notifyuser.sh --notification-user USER_EMAIL --dry-run
 
 Options:
-  --notification-user, --user EMAIL  Notify only this user. A positional email is also accepted.
+  --notification-user, --user EMAIL  Notify only this user. If target user has ADMIN role, scope is all AWS overdue vulns; otherwise only the user's mapped AWS accounts.
   --dry-run                          Preview notifications without sending email.
   --days DAYS                        Vulnerability age threshold in days. Default: 30.
   --help, -h                         Show this help.

--- a/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
@@ -379,6 +379,7 @@ class CliController(
     @Serdeable
     data class UserVulnNotificationResultDto(
         val status: String,
+        val notificationScope: String,
         val awsAccountsAffected: Int,
         val usersNotified: Int,
         val emailsSent: Int,
@@ -415,6 +416,7 @@ class CliController(
 
             HttpResponse.ok(UserVulnNotificationResultDto(
                 status = result.status.name,
+                notificationScope = result.notificationScope.name,
                 awsAccountsAffected = result.awsAccountsAffected,
                 usersNotified = result.usersNotified,
                 emailsSent = result.emailsSent,

--- a/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
@@ -2,8 +2,10 @@ package com.secman.service
 
 import com.secman.config.AppConfig
 import com.secman.domain.ExecutionStatus
+import com.secman.domain.User
 import com.secman.repository.ExceptionMatchSql
 import com.secman.repository.UserMappingRepository
+import com.secman.repository.UserRepository
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.inject.Singleton
 import jakarta.persistence.EntityManager
@@ -23,6 +25,7 @@ import java.time.LocalDateTime
 open class UserVulnerabilityNotificationService(
     private val entityManager: EntityManager,
     private val userMappingRepository: UserMappingRepository,
+    private val userRepository: UserRepository,
     private val emailService: EmailService,
     private val appConfig: AppConfig
 ) {
@@ -67,6 +70,7 @@ open class UserVulnerabilityNotificationService(
     @Serdeable
     data class UserNotificationResult(
         val status: ExecutionStatus,
+        val notificationScope: NotificationScope = NotificationScope.GLOBAL_AWS_OVERDUE,
         val awsAccountsAffected: Int,
         val usersNotified: Int,
         val emailsSent: Int,
@@ -77,6 +81,11 @@ open class UserVulnerabilityNotificationService(
         val thresholdDays: Int,
         val accountDetails: List<AwsAccountNotificationDetail> = emptyList()
     )
+
+    enum class NotificationScope {
+        GLOBAL_AWS_OVERDUE,
+        USER_SCOPED_AWS_OVERDUE
+    }
 
     /**
      * Find AWS accounts with overdue vulnerabilities and send notification emails to mapped users.
@@ -89,14 +98,19 @@ open class UserVulnerabilityNotificationService(
         notificationUser: String? = null
     ): UserNotificationResult {
         val thresholdDate = LocalDateTime.now().minusDays(thresholdDays.toLong())
+        val scope = resolveScope(notificationUser)
 
         // Step 1: Find all AWS accounts with overdue vulnerabilities
-        val accountSummaries = findAffectedAwsAccounts(thresholdDate)
+        val accountSummaries = when (scope) {
+            NotificationScope.GLOBAL_AWS_OVERDUE -> findAffectedAwsAccounts(thresholdDate)
+            NotificationScope.USER_SCOPED_AWS_OVERDUE -> findAffectedAwsAccountsForUser(thresholdDate, notificationUser!!)
+        }
 
         if (accountSummaries.isEmpty()) {
             logger.info("No AWS accounts found with vulnerabilities older than {} days", thresholdDays)
             return UserNotificationResult(
                 status = if (dryRun) ExecutionStatus.DRY_RUN else ExecutionStatus.SUCCESS,
+                notificationScope = scope,
                 awsAccountsAffected = 0,
                 usersNotified = 0,
                 emailsSent = 0,
@@ -109,7 +123,10 @@ open class UserVulnerabilityNotificationService(
             )
         }
 
-        val accountDetails = findAffectedAwsAccountDetails(thresholdDate)
+        val accountDetails = when (scope) {
+            NotificationScope.GLOBAL_AWS_OVERDUE -> findAffectedAwsAccountDetails(thresholdDate)
+            NotificationScope.USER_SCOPED_AWS_OVERDUE -> findAffectedAwsAccountDetailsForUser(thresholdDate, notificationUser!!)
+        }
 
         logger.info("Found {} AWS accounts with overdue vulnerabilities", accountSummaries.size)
 
@@ -136,6 +153,7 @@ open class UserVulnerabilityNotificationService(
             logger.warn("No users mapped to any affected AWS accounts")
             return UserNotificationResult(
                 status = if (dryRun) ExecutionStatus.DRY_RUN else ExecutionStatus.FAILURE,
+                notificationScope = scope,
                 awsAccountsAffected = accountSummaries.size,
                 usersNotified = 0,
                 emailsSent = 0,
@@ -153,7 +171,11 @@ open class UserVulnerabilityNotificationService(
         // Step 2b: Filter to specific user if --notification-user was provided
         if (notificationUser != null) {
             val targetEmail = notificationUser.lowercase()
-            val targetAccounts = userAccountMap[targetEmail]
+            val targetAccounts = userAccountMap[targetEmail] ?: if (scope == NotificationScope.USER_SCOPED_AWS_OVERDUE) {
+                accountSummaries
+            } else {
+                null
+            }
             userAccountMap.clear()
             if (targetAccounts != null) {
                 userAccountMap[targetEmail] = targetAccounts
@@ -162,6 +184,7 @@ open class UserVulnerabilityNotificationService(
                 logger.info("Notification user {} has no affected AWS accounts — skipping all notifications", targetEmail)
                 return UserNotificationResult(
                     status = if (dryRun) ExecutionStatus.DRY_RUN else ExecutionStatus.SUCCESS,
+                    notificationScope = scope,
                     awsAccountsAffected = accountSummaries.size,
                     usersNotified = 0,
                     emailsSent = 0,
@@ -180,6 +203,7 @@ open class UserVulnerabilityNotificationService(
             logger.info("Dry run mode - would send to {} recipients", userAccountMap.size)
             return UserNotificationResult(
                 status = ExecutionStatus.DRY_RUN,
+                notificationScope = scope,
                 awsAccountsAffected = accountSummaries.size,
                 usersNotified = userAccountMap.size,
                 emailsSent = 0,
@@ -238,6 +262,7 @@ open class UserVulnerabilityNotificationService(
 
         return UserNotificationResult(
             status = status,
+            notificationScope = scope,
             awsAccountsAffected = accountSummaries.size,
             usersNotified = sentRecipients.size,
             emailsSent = sentRecipients.size,
@@ -248,6 +273,15 @@ open class UserVulnerabilityNotificationService(
             thresholdDays = thresholdDays,
             accountDetails = accountDetails
         )
+    }
+
+    private fun resolveScope(notificationUser: String?): NotificationScope {
+        if (notificationUser.isNullOrBlank()) {
+            return NotificationScope.GLOBAL_AWS_OVERDUE
+        }
+        val user = userRepository.findByEmail(notificationUser.lowercase()).orElse(null)
+        val isAdmin = user?.roles?.contains(User.Role.ADMIN) == true
+        return if (isAdmin) NotificationScope.GLOBAL_AWS_OVERDUE else NotificationScope.USER_SCOPED_AWS_OVERDUE
     }
 
     /**
@@ -291,6 +325,15 @@ open class UserVulnerabilityNotificationService(
                 oldestVulnDays = (row[7] as Number).toLong()
             )
         }
+    }
+
+    private fun findAffectedAwsAccountsForUser(thresholdDate: LocalDateTime, userEmail: String): List<AwsAccountVulnSummary> {
+        val mappedAccounts = userMappingRepository.findByEmail(userEmail.lowercase())
+            .mapNotNull { it.awsAccountId?.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+        if (mappedAccounts.isEmpty()) return emptyList()
+        return findAffectedAwsAccounts(thresholdDate).filter { it.awsAccountId in mappedAccounts }
     }
 
     /**
@@ -348,6 +391,15 @@ open class UserVulnerabilityNotificationService(
                     }
                 AwsAccountNotificationDetail(accountId, assets)
             }
+    }
+
+    private fun findAffectedAwsAccountDetailsForUser(thresholdDate: LocalDateTime, userEmail: String): List<AwsAccountNotificationDetail> {
+        val mappedAccounts = userMappingRepository.findByEmail(userEmail.lowercase())
+            .mapNotNull { it.awsAccountId?.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+        if (mappedAccounts.isEmpty()) return emptyList()
+        return findAffectedAwsAccountDetails(thresholdDate).filter { it.awsAccountId in mappedAccounts }
     }
 
     /**

--- a/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
@@ -1,9 +1,11 @@
 package com.secman.service
 
 import com.secman.config.AppConfig
+import com.secman.domain.User
 import com.secman.domain.UserMapping
 import com.secman.repository.ExceptionMatchSql
 import com.secman.repository.UserMappingRepository
+import com.secman.repository.UserRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -11,15 +13,18 @@ import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.Optional
 
 class UserVulnerabilityNotificationServiceTest {
 
     private val entityManager = mockk<EntityManager>()
     private val userMappingRepository = mockk<UserMappingRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
     private val emailService = mockk<EmailService>(relaxed = true)
     private val service = UserVulnerabilityNotificationService(
         entityManager = entityManager,
         userMappingRepository = userMappingRepository,
+        userRepository = userRepository,
         emailService = emailService,
         appConfig = AppConfig()
     )
@@ -69,5 +74,54 @@ class UserVulnerabilityNotificationServiceTest {
         assertThat(result.accountDetails[0].assets[0].vulnerabilities)
             .extracting<String> { it.vulnerabilityId }
             .containsExactly("CVE-2026-0001", "CVE-2026-0002")
+    }
+
+    @Test
+    fun `notification user with ADMIN role keeps global scope`() {
+        val accountQuery = mockk<Query>()
+        val detailQuery = mockk<Query>()
+        every { userRepository.findByEmail("admin@example.com") } returns Optional.of(
+            User(id = 1, email = "admin@example.com", passwordHash = "x", roles = mutableSetOf(User.Role.ADMIN))
+        )
+        every { entityManager.createNativeQuery(match { it.contains("GROUP BY a.cloud_account_id") }) } returns accountQuery
+        every { entityManager.createNativeQuery(match { it.contains("ORDER BY a.cloud_account_id, a.name") }) } returns detailQuery
+        every { accountQuery.setParameter("thresholdDate", any()) } returns accountQuery
+        every { detailQuery.setParameter("thresholdDate", any()) } returns detailQuery
+        every { accountQuery.resultList } returns listOf(arrayOf<Any?>("123456789012", 1, 1, 1, 0, 0, 0, 45))
+        every { detailQuery.resultList } returns emptyList<Array<Any?>>()
+        every { userMappingRepository.findByAwsAccountId("123456789012") } returns listOf(UserMapping("admin@example.com", "123456789012", null))
+
+        val result = service.sendUserVulnerabilityNotifications(dryRun = true, notificationUser = "admin@example.com")
+
+        assertThat(result.notificationScope.name).isEqualTo("GLOBAL_AWS_OVERDUE")
+    }
+
+    @Test
+    fun `notification user without ADMIN role gets user scoped accounts only`() {
+        val accountQuery = mockk<Query>()
+        val detailQuery = mockk<Query>()
+        every { userRepository.findByEmail("user@example.com") } returns Optional.of(
+            User(id = 2, email = "user@example.com", passwordHash = "x", roles = mutableSetOf(User.Role.USER))
+        )
+        every { entityManager.createNativeQuery(match { it.contains("GROUP BY a.cloud_account_id") }) } returns accountQuery
+        every { entityManager.createNativeQuery(match { it.contains("ORDER BY a.cloud_account_id, a.name") }) } returns detailQuery
+        every { accountQuery.setParameter("thresholdDate", any()) } returns accountQuery
+        every { detailQuery.setParameter("thresholdDate", any()) } returns detailQuery
+        every { accountQuery.resultList } returns listOf(
+            arrayOf<Any?>("111111111111", 1, 1, 1, 0, 0, 0, 45),
+            arrayOf<Any?>("222222222222", 1, 1, 1, 0, 0, 0, 45)
+        )
+        every { detailQuery.resultList } returns listOf(
+            arrayOf<Any?>("111111111111", 11L, "a1", "10.0.0.1", 101L, "CVE-1", "Critical", "45 days", 45, "openssl"),
+            arrayOf<Any?>("222222222222", 22L, "a2", "10.0.0.2", 102L, "CVE-2", "Critical", "45 days", 45, "openssl")
+        )
+        every { userMappingRepository.findByEmail("user@example.com") } returns listOf(UserMapping("user@example.com", "111111111111", null))
+        every { userMappingRepository.findByAwsAccountId("111111111111") } returns listOf(UserMapping("user@example.com", "111111111111", null))
+
+        val result = service.sendUserVulnerabilityNotifications(dryRun = true, notificationUser = "user@example.com")
+
+        assertThat(result.notificationScope.name).isEqualTo("USER_SCOPED_AWS_OVERDUE")
+        assertThat(result.accountDetails).hasSize(1)
+        assertThat(result.accountDetails[0].awsAccountId).isEqualTo("111111111111")
     }
 }

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendNotificationUsersCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendNotificationUsersCommand.kt
@@ -87,6 +87,7 @@ class SendNotificationUsersCommand : Runnable {
             ) ?: throw RuntimeException("Failed to send user vulnerability notifications - no response from server")
 
             val status = result["status"]?.toString() ?: "UNKNOWN"
+            val notificationScope = result["notificationScope"]?.toString() ?: "GLOBAL_AWS_OVERDUE"
             val awsAccountsAffected = (result["awsAccountsAffected"] as? Number)?.toInt() ?: 0
             val usersNotified = (result["usersNotified"] as? Number)?.toInt() ?: 0
             val emailsSent = (result["emailsSent"] as? Number)?.toInt() ?: 0
@@ -100,6 +101,7 @@ class SendNotificationUsersCommand : Runnable {
             val accountDetails = (result["accountDetails"] as? List<*>) ?: emptyList<Any>()
 
             println("AWS accounts with overdue vulnerabilities: $awsAccountsAffected")
+            println("Notification scope: $notificationScope")
             println()
 
             if (dryRun) {


### PR DESCRIPTION
### Motivation
- Make `--notification-user` semantics explicit so that targeting a non-admin user limits the search to that user's mapped AWS accounts while admins keep the global overdue-AWS scope.
- Surface the chosen scope to callers so operators can verify whether notifications were global or user-scoped.

### Description
- Added `NotificationScope` enum and `notificationScope` field to the service `UserNotificationResult` and to the controller DTO to return the scope in the API response.
- Implemented `resolveScope(notificationUser)` which checks `UserRepository.findByEmail(...)` and treats users with `User.Role.ADMIN` as global-scoped and others as user-scoped, and wired `UserRepository` into the service.
- Added user-scoped queries by filtering results via `findAffectedAwsAccountsForUser(...)` and `findAffectedAwsAccountDetailsForUser(...)` and adjusted mapping/filtering logic so `--notification-user` returns either all global accounts (for admins) or only mapped accounts (for non-admins).
- Updated CLI to display `notificationScope`, updated `scripts/notifyuser.sh` usage text to document the new behavior, and added/updated unit tests in `UserVulnerabilityNotificationServiceTest` to assert admin vs non-admin scoping.

### Testing
- Ran unit tests in `UserVulnerabilityNotificationServiceTest`, including the new tests `notification user with ADMIN role keeps global scope` and `notification user without ADMIN role gets user scoped accounts only`, and they passed.
- Ran existing dry-run tests that verify SQL queries and account/account-detail shaping (`affected AWS account query excludes matching active vulnerability exceptions` and `dry run result includes affected accounts assets and vulnerabilities`), and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdab0847c8323b3506c75d4dc8119)