### PR TITLE
docs(e2e): enforce strict URL env policy in vuln exception flow

### DIFF
--- a/.agents/skills/e2evulnexception/SKILL.md
+++ b/.agents/skills/e2evulnexception/SKILL.md
@@ -95,7 +95,7 @@ full restart for this skill.)
 This skill is **pinned to Proton Pass** — start services via the wrapper
 scripts that source secrets via `pass-cli`. Never hardcode `localhost:8080`
 or `localhost:4321` in tests; the driver and Playwright config already
-respect `BASE_URL` / `FRONTEND_URL` / `SECMAN_BASE_URL`.
+respect `BASE_URL` / `SECMAN_BACKEND_URL` / `FRONTEND_URL` / `SECMAN_BASE_URL`.
 
 | Setting                  | Default                           |
 | ------------------------ | --------------------------------- |
@@ -131,6 +131,9 @@ respect `BASE_URL` / `FRONTEND_URL` / `SECMAN_BASE_URL`.
    `npx playwright install chrome msedge` per `AGENTS.md`.)
 
 ### Phase 2 — Run Tests
+
+- Driver pre-flight now logs the **resolved** `BASE_URL` and `FRONTEND_URL`; include that line when triaging reachability failures so backend/frontend target ambiguity is eliminated.
+
 
 Run the driver with Proton Pass injection:
 
@@ -316,8 +319,7 @@ in the cleanup logic and fix `cleanup()` in
 - **Secrets via Proton Pass** — both `scripts/startbackenddev.sh`,
   `scripts/startfrontenddev.sh`, and the test driver use `pass-cli run`.
   Never hardcode credentials.
-- **No `localhost` literals in tests** — use `BASE_URL` / `FRONTEND_URL` /
-  `SECMAN_BASE_URL`. Liveness checks use port binding, not HTTP probes.
+- **No `localhost` literals in tests** — strict policy: set backend/frontend URLs from pass-cli env (`BASE_URL` or `SECMAN_BACKEND_URL`, plus `FRONTEND_URL`) and fail fast when missing. Use `SECMAN_BASE_URL` for Playwright. Liveness checks use port binding, not HTTP probes.
 - **Logs**: backend → `.e2e-logs/backend.log`; frontend → `.e2e-logs/frontend.log`;
   driver → `.e2e-logs/e2e-vuln-exception-run-<N>.log`. The directory is gitignored.
 - **MariaDB**: cleanup uses `mariadb -h 127.0.0.1 -u secman -pCHANGEME secman`.

--- a/scripts/test/test-e2e-vuln-exception-full.sh
+++ b/scripts/test/test-e2e-vuln-exception-full.sh
@@ -18,9 +18,9 @@
 #   SECMAN_ADMIN_EMAIL
 #   SECMAN_ADMIN_NAME
 #   SECMAN_ADMIN_PASS
-# Optional:
-#   BASE_URL (default http://localhost:8080)
-#   FRONTEND_URL (default http://localhost:4321)
+# Additional env:
+#   BASE_URL or SECMAN_BACKEND_URL (required backend URL, pass-cli sourced)
+#   FRONTEND_URL (required frontend URL, pass-cli sourced)
 #   SKIP_UI=true to skip Playwright phase
 #   VERBOSE=true for debug logging
 #
@@ -35,8 +35,8 @@ set -euo pipefail
 # Configuration
 # =============================================================================
 
-BASE_URL="${BASE_URL:-${SECMAN_BACKEND_URL:-http://localhost:8080}}"
-FRONTEND_URL="${FRONTEND_URL:-http://localhost:4321}"
+BASE_URL="${BASE_URL:-${SECMAN_BACKEND_URL:-}}"
+FRONTEND_URL="${FRONTEND_URL:-}"
 # Strip trailing whitespace/newlines from secrets — pass-cli can append a trailing
 # newline depending on how the source field is stored, which would corrupt headers
 # (e.g. "X-MCP-API-Key: <key>\n\n" terminates the header block early, producing 400).
@@ -146,8 +146,9 @@ Usage:
     $0 [--verbose|-v] [--skip-ui] [--help|-h]
 
 Environment:
-    BASE_URL              Backend URL (default http://localhost:8080)
-    FRONTEND_URL          Frontend URL (default http://localhost:4321)
+    BASE_URL              Backend URL (required unless SECMAN_BACKEND_URL is set)
+    SECMAN_BACKEND_URL    Backend URL fallback when BASE_URL is not set
+    FRONTEND_URL          Frontend URL (required)
     SECMAN_MCP_KEY        MCP API key (required)
     SECMAN_ADMIN_EMAIL    Admin email for delegation (required)
     SECMAN_ADMIN_NAME     Admin username (required for UI phase)
@@ -177,6 +178,10 @@ done
 
 [[ -z "$SECMAN_MCP_KEY"   ]] && fail "SECMAN_MCP_KEY is required (use pass-cli run)"
 [[ -z "$ADMIN_USER_EMAIL" ]] && fail "SECMAN_ADMIN_EMAIL is required (use pass-cli run)"
+[[ -z "$BASE_URL" ]] && fail "Backend URL is required: set BASE_URL or SECMAN_BACKEND_URL via pass-cli env"
+[[ -z "$FRONTEND_URL" ]] && fail "Frontend URL is required: set FRONTEND_URL via pass-cli env"
+
+log "Resolved pre-flight URLs: BASE_URL=$BASE_URL FRONTEND_URL=$FRONTEND_URL"
 
 if ! curl -sf -o /dev/null --connect-timeout 5 "$BASE_URL" 2>/dev/null; then
     # Some backends don't serve / so also try /api/mcp/capabilities (returns 401 but reachable)


### PR DESCRIPTION
### Motivation

- The driver script and skill docs were inconsistent: the script fell back to `localhost` while docs mandated pass-cli-provided URLs, causing ambiguity during triage.  
- Make the vuln-exception full E2E flow deterministic and aligned with the repo policy that host URLs come from `pass-cli`/env, failing fast when missing.  
- Improve pre-flight diagnostics so reachability failures include the exact resolved target URLs.  

### Description

- Updated `.agents/skills/e2evulnexception/SKILL.md` to document the strict URL policy and to reference `BASE_URL` / `SECMAN_BACKEND_URL` / `FRONTEND_URL` and the new pre-flight resolved-URL log line.  
- Modified `scripts/test/test-e2e-vuln-exception-full.sh` to remove `http://localhost:*` defaults, to require `BASE_URL` (or `SECMAN_BACKEND_URL`) and `FRONTEND_URL` from the environment, and to `fail` early when they are not set.  
- Added an explicit pre-flight `log` line that prints `BASE_URL` and `FRONTEND_URL` before connectivity probes to remove ambiguity during triage.  
- Updated usage/help text and inline comments to reflect the new required env variables and policy.  

### Testing

- Ran `bash -n scripts/test/test-e2e-vuln-exception-full.sh` for a syntax check, which succeeded.  
- Verified the diff with `git diff -- .agents/skills/e2evulnexception/SKILL.md scripts/test/test-e2e-vuln-exception-full.sh` and committed the change, and the commit/PR metadata was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bef6fbab48323aad9cce44b853a7b)