### PR TITLE
docs(e2evulnexception): add read-only QA static review mode

### DIFF
--- a/.agents/skills/e2evulnexception/SKILL.md
+++ b/.agents/skills/e2evulnexception/SKILL.md
@@ -64,6 +64,24 @@ The driver script is
 The shell driver calls MCP via `curl`/`jq` and shells out to `npx playwright`
 for Phase 8, passing the captured IDs/credentials through env vars.
 
+## Read-Only / QA Scope Mode
+
+If the requested task scope is explicitly read-only or QA-only, run a **static
+review only**:
+
+- Do **not** start backend/frontend services.
+- Do **not** run the shell driver or Playwright.
+- Do **not** modify repository code or test assets.
+- Produce a concise **completeness + optimization report** with actionable
+  findings.
+
+Static-review checklist (inspect artifacts only):
+- Skill doc: `.agents/skills/e2evulnexception/SKILL.md`
+- Shell driver: `scripts/test/test-e2e-vuln-exception-full.sh`
+- Playwright spec: `tests/e2e/vuln-exception-full.spec.ts`
+- Cleanup semantics: pre/post cleanup behavior, idempotency, trap handling
+- Env assumptions: required vars, `pass-cli` usage, host/base-url assumptions
+
 ## High-Level Loop
 
 ```


### PR DESCRIPTION
### Motivation
- Prevent accidental execution or repo mutation when a task is explicitly read-only/QA-only by clarifying that the `e2evulnexception` skill should perform only static review in that scope and by standardizing the expected deliverable.

### Description
- Add a `Read-Only / QA Scope Mode` section to `.agents/skills/e2evulnexception/SKILL.md` that forbids starting services, running the shell driver or Playwright, and modifying code or test assets, and that requires a concise completeness + optimization report; also add a compact static-review checklist referencing the `SKILL.md`, `scripts/test/test-e2e-vuln-exception-full.sh`, `tests/e2e/vuln-exception-full.spec.ts`, cleanup semantics, and environment assumptions.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bef796c9083239fbc90364cc649cb)