### PR TITLE
[codex] Add application register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ env/
 htmlcov/
 
 # Project specific
+.worktrees/
 .claude/settings.local.json
 ./codex/
 .serena/

--- a/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
@@ -1,0 +1,97 @@
+package com.secman.controller
+
+import com.secman.dto.ApplicationRegisterAssetUpdateRequest
+import com.secman.dto.ApplicationRegisterDetail
+import com.secman.dto.ApplicationRegisterRequest
+import com.secman.dto.ApplicationRegisterSummary
+import com.secman.service.ApplicationRegisterService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.rules.SecurityRule
+
+@Controller("/api/applications")
+open class ApplicationRegisterController(
+    private val service: ApplicationRegisterService
+) {
+
+    @Get
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    open fun list(@QueryValue(defaultValue = "") search: String?): HttpResponse<List<ApplicationRegisterSummary>> {
+        return HttpResponse.ok(service.list(search))
+    }
+
+    @Get("/{id}")
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    open fun get(@PathVariable id: Long): HttpResponse<ApplicationRegisterDetail> {
+        return try {
+            HttpResponse.ok(service.get(id))
+        } catch (e: NoSuchElementException) {
+            HttpResponse.notFound()
+        }
+    }
+
+    @Post
+    @Secured("ADMIN", "SECCHAMPION")
+    open fun create(
+        @Body request: ApplicationRegisterRequest,
+        authentication: Authentication
+    ): HttpResponse<Any> {
+        return try {
+            HttpResponse.created(service.create(request, authentication.name))
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.badRequest(mapOf("error" to e.message))
+        }
+    }
+
+    @Put("/{id}")
+    @Secured("ADMIN", "SECCHAMPION")
+    open fun update(
+        @PathVariable id: Long,
+        @Body request: ApplicationRegisterRequest,
+        authentication: Authentication
+    ): HttpResponse<Any> {
+        return try {
+            HttpResponse.ok(service.update(id, request, authentication.name))
+        } catch (e: NoSuchElementException) {
+            HttpResponse.notFound()
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.badRequest(mapOf("error" to e.message))
+        }
+    }
+
+    @Delete("/{id}")
+    @Secured("ADMIN", "SECCHAMPION")
+    open fun delete(@PathVariable id: Long): HttpResponse<Void> {
+        return try {
+            service.delete(id)
+            HttpResponse.noContent()
+        } catch (e: NoSuchElementException) {
+            HttpResponse.notFound()
+        }
+    }
+
+    @Put("/{id}/assets")
+    @Secured("ADMIN", "SECCHAMPION")
+    open fun replaceAssets(
+        @PathVariable id: Long,
+        @Body request: ApplicationRegisterAssetUpdateRequest,
+        authentication: Authentication
+    ): HttpResponse<Any> {
+        return try {
+            HttpResponse.ok(service.replaceAssets(id, request.assetIds, authentication.name))
+        } catch (e: NoSuchElementException) {
+            HttpResponse.notFound()
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.badRequest(mapOf("error" to e.message))
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/ApplicationRegister.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/ApplicationRegister.kt
@@ -1,0 +1,216 @@
+package com.secman.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "application_register",
+    indexes = [
+        Index(name = "idx_application_register_car_id", columnList = "car_id", unique = true),
+        Index(name = "idx_application_register_name", columnList = "name"),
+        Index(name = "idx_application_register_owner", columnList = "business_owner"),
+        Index(name = "idx_application_register_manager", columnList = "application_manager"),
+        Index(name = "idx_application_register_status", columnList = "operational_status"),
+        Index(name = "idx_application_register_criticality", columnList = "criticality")
+    ]
+)
+@Serdeable
+data class ApplicationRegister(
+    @Id
+    @GeneratedValue
+    var id: Long? = null,
+
+    @Column(name = "car_id", nullable = false, unique = true, length = 100)
+    @NotBlank
+    var carId: String,
+
+    @Column(nullable = false, length = 255)
+    @NotBlank
+    var name: String,
+
+    @Column(name = "process_cluster", columnDefinition = "TEXT")
+    var processCluster: String? = null,
+
+    @Column(name = "process_area", columnDefinition = "TEXT")
+    var processArea: String? = null,
+
+    @Column(length = 100)
+    var criticality: String? = null,
+
+    @Column(name = "operational_status", length = 100)
+    var operationalStatus: String? = null,
+
+    @Column(name = "business_owner", nullable = false, length = 255)
+    @NotBlank
+    var businessOwner: String,
+
+    @Column(name = "application_champion", columnDefinition = "TEXT")
+    var applicationChampion: String? = null,
+
+    @Column(name = "application_manager", nullable = false, length = 255)
+    @NotBlank
+    var applicationManager: String,
+
+    @Column(name = "application_technology", columnDefinition = "TEXT")
+    var applicationTechnology: String? = null,
+
+    @Column(name = "application_architecture", columnDefinition = "TEXT")
+    var applicationArchitecture: String? = null,
+
+    @Column(name = "last_quality_check")
+    var lastQualityCheck: LocalDate? = null,
+
+    @Column(name = "information_classification", columnDefinition = "TEXT")
+    var informationClassification: String? = null,
+
+    @Column(name = "processing_of_personal_data", columnDefinition = "TEXT")
+    var processingOfPersonalData: String? = null,
+
+    @Column(name = "ics_relevant", columnDefinition = "TEXT")
+    var icsRelevant: String? = null,
+
+    @Column(name = "legal_regulatory", columnDefinition = "TEXT")
+    var legalRegulatory: String? = null,
+
+    @Column(name = "legal_regulatory_rationale_impact", columnDefinition = "TEXT")
+    var legalRegulatoryRationaleImpact: String? = null,
+
+    @Column(name = "data_export_control_relevant", columnDefinition = "TEXT")
+    var dataExportControlRelevant: String? = null,
+
+    @Column(name = "application_export_control_relevant", columnDefinition = "TEXT")
+    var applicationExportControlRelevant: String? = null,
+
+    @Column(name = "operation_model", columnDefinition = "TEXT")
+    var operationModel: String? = null,
+
+    @Column(name = "production_operating_hours", columnDefinition = "TEXT")
+    var productionOperatingHours: String? = null,
+
+    @Column(name = "service_operating_hours", columnDefinition = "TEXT")
+    var serviceOperatingHours: String? = null,
+
+    @Column(name = "ssl_certificates_used", columnDefinition = "TEXT")
+    var sslCertificatesUsed: String? = null,
+
+    @Column(name = "all_machine_users", columnDefinition = "TEXT")
+    var allMachineUsers: String? = null,
+
+    @Column(name = "recovery_plan_url", columnDefinition = "TEXT")
+    var recoveryPlanUrl: String? = null,
+
+    @Column(name = "authorization_concept_url", columnDefinition = "TEXT")
+    var authorizationConceptUrl: String? = null,
+
+    @Column(name = "password_storage_tool", columnDefinition = "TEXT")
+    var passwordStorageTool: String? = null,
+
+    @Column(name = "availability_support_url", columnDefinition = "TEXT")
+    var availabilitySupportUrl: String? = null,
+
+    @Column(name = "recurring_tasks_responsibilities_url", columnDefinition = "TEXT")
+    var recurringTasksResponsibilitiesUrl: String? = null,
+
+    @Column(name = "backup_recovery_url", columnDefinition = "TEXT")
+    var backupRecoveryUrl: String? = null,
+
+    @Column(name = "monitoring_escalation_url", columnDefinition = "TEXT")
+    var monitoringEscalationUrl: String? = null,
+
+    @Column(name = "tools_used_for_monitoring_url", columnDefinition = "TEXT")
+    var toolsUsedForMonitoringUrl: String? = null,
+
+    @Column(name = "license_management_url", columnDefinition = "TEXT")
+    var licenseManagementUrl: String? = null,
+
+    @Column(name = "communication_channels_url", columnDefinition = "TEXT")
+    var communicationChannelsUrl: String? = null,
+
+    @Column(name = "incident_assignment_group", columnDefinition = "TEXT")
+    var incidentAssignmentGroup: String? = null,
+
+    @Column(name = "solver_group_c", columnDefinition = "TEXT")
+    var solverGroupC: String? = null,
+
+    @Column(name = "change_approval_group", columnDefinition = "TEXT")
+    var changeApprovalGroup: String? = null,
+
+    @Column(name = "cab_approval_group", columnDefinition = "TEXT")
+    var cabApprovalGroup: String? = null,
+
+    @Column(name = "change_fulfillment_group", columnDefinition = "TEXT")
+    var changeFulfillmentGroup: String? = null,
+
+    @Column(name = "run_and_change", columnDefinition = "TEXT")
+    var runAndChange: String? = null,
+
+    @Column(name = "managed_service_run", columnDefinition = "TEXT")
+    var managedServiceRun: String? = null,
+
+    @Column(name = "managed_service_change", columnDefinition = "TEXT")
+    var managedServiceChange: String? = null,
+
+    @Column(name = "extended_workbench_change", columnDefinition = "TEXT")
+    var extendedWorkbenchChange: String? = null,
+
+    @Column(name = "extended_workbench_run", columnDefinition = "TEXT")
+    var extendedWorkbenchRun: String? = null,
+
+    @Column(name = "managed_internally", columnDefinition = "TEXT")
+    var managedInternally: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var notes: String? = null,
+
+    @Column(name = "cmdb_workspace_url", columnDefinition = "TEXT")
+    var cmdbWorkspaceUrl: String? = null,
+
+    @Column(name = "created_at", updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @Column(name = "updated_at")
+    var updatedAt: LocalDateTime? = null,
+
+    @Column(name = "created_by", length = 255)
+    var createdBy: String? = null,
+
+    @Column(name = "updated_by", length = 255)
+    var updatedBy: String? = null,
+
+    @JsonIgnore
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "application_register_asset",
+        joinColumns = [JoinColumn(name = "application_register_id")],
+        inverseJoinColumns = [JoinColumn(name = "asset_id")]
+    )
+    var assets: MutableSet<Asset> = mutableSetOf()
+) {
+    @PrePersist
+    fun onCreate() {
+        val now = LocalDateTime.now()
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/dto/ApplicationRegisterDtos.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/ApplicationRegisterDtos.kt
@@ -1,0 +1,228 @@
+package com.secman.dto
+
+import com.secman.domain.ApplicationRegister
+import com.secman.domain.Asset
+import io.micronaut.serde.annotation.Serdeable
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Serdeable
+data class ApplicationRegisterRequest(
+    val carId: String,
+    val name: String,
+    val processCluster: String? = null,
+    val processArea: String? = null,
+    val criticality: String? = null,
+    val operationalStatus: String? = null,
+    val businessOwner: String,
+    val applicationChampion: String? = null,
+    val applicationManager: String,
+    val applicationTechnology: String? = null,
+    val applicationArchitecture: String? = null,
+    val lastQualityCheck: LocalDate? = null,
+    val informationClassification: String? = null,
+    val processingOfPersonalData: String? = null,
+    val icsRelevant: String? = null,
+    val legalRegulatory: String? = null,
+    val legalRegulatoryRationaleImpact: String? = null,
+    val dataExportControlRelevant: String? = null,
+    val applicationExportControlRelevant: String? = null,
+    val operationModel: String? = null,
+    val productionOperatingHours: String? = null,
+    val serviceOperatingHours: String? = null,
+    val sslCertificatesUsed: String? = null,
+    val allMachineUsers: String? = null,
+    val recoveryPlanUrl: String? = null,
+    val authorizationConceptUrl: String? = null,
+    val passwordStorageTool: String? = null,
+    val availabilitySupportUrl: String? = null,
+    val recurringTasksResponsibilitiesUrl: String? = null,
+    val backupRecoveryUrl: String? = null,
+    val monitoringEscalationUrl: String? = null,
+    val toolsUsedForMonitoringUrl: String? = null,
+    val licenseManagementUrl: String? = null,
+    val communicationChannelsUrl: String? = null,
+    val incidentAssignmentGroup: String? = null,
+    val solverGroupC: String? = null,
+    val changeApprovalGroup: String? = null,
+    val cabApprovalGroup: String? = null,
+    val changeFulfillmentGroup: String? = null,
+    val runAndChange: String? = null,
+    val managedServiceRun: String? = null,
+    val managedServiceChange: String? = null,
+    val extendedWorkbenchChange: String? = null,
+    val extendedWorkbenchRun: String? = null,
+    val managedInternally: String? = null,
+    val notes: String? = null,
+    val cmdbWorkspaceUrl: String? = null
+)
+
+@Serdeable
+data class ApplicationRegisterSummary(
+    val id: Long,
+    val carId: String,
+    val name: String,
+    val criticality: String?,
+    val operationalStatus: String?,
+    val businessOwner: String,
+    val applicationManager: String,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(application: ApplicationRegister): ApplicationRegisterSummary {
+            return ApplicationRegisterSummary(
+                id = application.id ?: 0,
+                carId = application.carId,
+                name = application.name,
+                criticality = application.criticality,
+                operationalStatus = application.operationalStatus,
+                businessOwner = application.businessOwner,
+                applicationManager = application.applicationManager,
+                updatedAt = application.updatedAt
+            )
+        }
+    }
+}
+
+@Serdeable
+data class ApplicationRegisterAssetSummary(
+    val id: Long,
+    val name: String,
+    val type: String,
+    val owner: String,
+    val ip: String?
+) {
+    companion object {
+        fun from(asset: Asset): ApplicationRegisterAssetSummary {
+            return ApplicationRegisterAssetSummary(
+                id = asset.id ?: 0,
+                name = asset.name,
+                type = asset.type,
+                owner = asset.owner,
+                ip = asset.ip
+            )
+        }
+    }
+}
+
+@Serdeable
+data class ApplicationRegisterDetail(
+    val id: Long,
+    val carId: String,
+    val name: String,
+    val processCluster: String?,
+    val processArea: String?,
+    val criticality: String?,
+    val operationalStatus: String?,
+    val businessOwner: String,
+    val applicationChampion: String?,
+    val applicationManager: String,
+    val applicationTechnology: String?,
+    val applicationArchitecture: String?,
+    val lastQualityCheck: LocalDate?,
+    val informationClassification: String?,
+    val processingOfPersonalData: String?,
+    val icsRelevant: String?,
+    val legalRegulatory: String?,
+    val legalRegulatoryRationaleImpact: String?,
+    val dataExportControlRelevant: String?,
+    val applicationExportControlRelevant: String?,
+    val operationModel: String?,
+    val productionOperatingHours: String?,
+    val serviceOperatingHours: String?,
+    val sslCertificatesUsed: String?,
+    val allMachineUsers: String?,
+    val recoveryPlanUrl: String?,
+    val authorizationConceptUrl: String?,
+    val passwordStorageTool: String?,
+    val availabilitySupportUrl: String?,
+    val recurringTasksResponsibilitiesUrl: String?,
+    val backupRecoveryUrl: String?,
+    val monitoringEscalationUrl: String?,
+    val toolsUsedForMonitoringUrl: String?,
+    val licenseManagementUrl: String?,
+    val communicationChannelsUrl: String?,
+    val incidentAssignmentGroup: String?,
+    val solverGroupC: String?,
+    val changeApprovalGroup: String?,
+    val cabApprovalGroup: String?,
+    val changeFulfillmentGroup: String?,
+    val runAndChange: String?,
+    val managedServiceRun: String?,
+    val managedServiceChange: String?,
+    val extendedWorkbenchChange: String?,
+    val extendedWorkbenchRun: String?,
+    val managedInternally: String?,
+    val notes: String?,
+    val cmdbWorkspaceUrl: String?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+    val createdBy: String?,
+    val updatedBy: String?,
+    val assets: List<ApplicationRegisterAssetSummary>
+) {
+    companion object {
+        fun from(application: ApplicationRegister): ApplicationRegisterDetail {
+            return ApplicationRegisterDetail(
+                id = application.id ?: 0,
+                carId = application.carId,
+                name = application.name,
+                processCluster = application.processCluster,
+                processArea = application.processArea,
+                criticality = application.criticality,
+                operationalStatus = application.operationalStatus,
+                businessOwner = application.businessOwner,
+                applicationChampion = application.applicationChampion,
+                applicationManager = application.applicationManager,
+                applicationTechnology = application.applicationTechnology,
+                applicationArchitecture = application.applicationArchitecture,
+                lastQualityCheck = application.lastQualityCheck,
+                informationClassification = application.informationClassification,
+                processingOfPersonalData = application.processingOfPersonalData,
+                icsRelevant = application.icsRelevant,
+                legalRegulatory = application.legalRegulatory,
+                legalRegulatoryRationaleImpact = application.legalRegulatoryRationaleImpact,
+                dataExportControlRelevant = application.dataExportControlRelevant,
+                applicationExportControlRelevant = application.applicationExportControlRelevant,
+                operationModel = application.operationModel,
+                productionOperatingHours = application.productionOperatingHours,
+                serviceOperatingHours = application.serviceOperatingHours,
+                sslCertificatesUsed = application.sslCertificatesUsed,
+                allMachineUsers = application.allMachineUsers,
+                recoveryPlanUrl = application.recoveryPlanUrl,
+                authorizationConceptUrl = application.authorizationConceptUrl,
+                passwordStorageTool = application.passwordStorageTool,
+                availabilitySupportUrl = application.availabilitySupportUrl,
+                recurringTasksResponsibilitiesUrl = application.recurringTasksResponsibilitiesUrl,
+                backupRecoveryUrl = application.backupRecoveryUrl,
+                monitoringEscalationUrl = application.monitoringEscalationUrl,
+                toolsUsedForMonitoringUrl = application.toolsUsedForMonitoringUrl,
+                licenseManagementUrl = application.licenseManagementUrl,
+                communicationChannelsUrl = application.communicationChannelsUrl,
+                incidentAssignmentGroup = application.incidentAssignmentGroup,
+                solverGroupC = application.solverGroupC,
+                changeApprovalGroup = application.changeApprovalGroup,
+                cabApprovalGroup = application.cabApprovalGroup,
+                changeFulfillmentGroup = application.changeFulfillmentGroup,
+                runAndChange = application.runAndChange,
+                managedServiceRun = application.managedServiceRun,
+                managedServiceChange = application.managedServiceChange,
+                extendedWorkbenchChange = application.extendedWorkbenchChange,
+                extendedWorkbenchRun = application.extendedWorkbenchRun,
+                managedInternally = application.managedInternally,
+                notes = application.notes,
+                cmdbWorkspaceUrl = application.cmdbWorkspaceUrl,
+                createdAt = application.createdAt,
+                updatedAt = application.updatedAt,
+                createdBy = application.createdBy,
+                updatedBy = application.updatedBy,
+                assets = application.assets.sortedBy { it.name }.map { ApplicationRegisterAssetSummary.from(it) }
+            )
+        }
+    }
+}
+
+@Serdeable
+data class ApplicationRegisterAssetUpdateRequest(
+    val assetIds: List<Long> = emptyList()
+)

--- a/src/backendng/src/main/kotlin/com/secman/repository/ApplicationRegisterRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/ApplicationRegisterRepository.kt
@@ -1,0 +1,39 @@
+package com.secman.repository
+
+import com.secman.domain.ApplicationRegister
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+@Repository
+interface ApplicationRegisterRepository : JpaRepository<ApplicationRegister, Long> {
+
+    fun existsByCarIdIgnoreCase(carId: String): Boolean
+
+    fun findByCarIdIgnoreCase(carId: String): Optional<ApplicationRegister>
+
+    @Query(
+        """
+        SELECT a FROM ApplicationRegister a
+        WHERE (:search IS NULL OR :search = ''
+          OR LOWER(a.name) LIKE LOWER(CONCAT('%', :search, '%'))
+          OR LOWER(a.carId) LIKE LOWER(CONCAT('%', :search, '%'))
+          OR LOWER(a.businessOwner) LIKE LOWER(CONCAT('%', :search, '%'))
+          OR LOWER(a.applicationManager) LIKE LOWER(CONCAT('%', :search, '%'))
+          OR LOWER(COALESCE(a.operationalStatus, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+          OR LOWER(COALESCE(a.criticality, '')) LIKE LOWER(CONCAT('%', :search, '%')))
+        ORDER BY a.name ASC
+        """
+    )
+    fun search(search: String?): List<ApplicationRegister>
+
+    @Query(
+        """
+        SELECT a FROM ApplicationRegister a
+        LEFT JOIN FETCH a.assets
+        WHERE a.id = :id
+        """
+    )
+    fun findByIdWithAssets(id: Long): Optional<ApplicationRegister>
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterService.kt
@@ -1,0 +1,211 @@
+package com.secman.service
+
+import com.secman.domain.ApplicationRegister
+import com.secman.dto.ApplicationRegisterDetail
+import com.secman.dto.ApplicationRegisterRequest
+import com.secman.dto.ApplicationRegisterSummary
+import com.secman.repository.ApplicationRegisterRepository
+import com.secman.repository.AssetRepository
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+
+@Singleton
+open class ApplicationRegisterService(
+    private val repository: ApplicationRegisterRepository,
+    private val assetRepository: AssetRepository
+) {
+
+    @Transactional
+    open fun list(search: String?): List<ApplicationRegisterSummary> {
+        return repository.search(search?.trim()).map { ApplicationRegisterSummary.from(it) }
+    }
+
+    @Transactional
+    open fun get(id: Long): ApplicationRegisterDetail {
+        return ApplicationRegisterDetail.from(getWithAssets(id))
+    }
+
+    @Transactional
+    open fun create(request: ApplicationRegisterRequest, username: String): ApplicationRegisterDetail {
+        val cleaned = clean(request)
+        if (repository.existsByCarIdIgnoreCase(cleaned.carId)) {
+            throw IllegalArgumentException("carId already exists")
+        }
+
+        val application = ApplicationRegister(
+            carId = cleaned.carId,
+            name = cleaned.name,
+            businessOwner = cleaned.businessOwner,
+            applicationManager = cleaned.applicationManager
+        )
+        apply(application, cleaned)
+        application.createdBy = username
+        application.updatedBy = username
+
+        return ApplicationRegisterDetail.from(repository.save(application))
+    }
+
+    @Transactional
+    open fun update(id: Long, request: ApplicationRegisterRequest, username: String): ApplicationRegisterDetail {
+        val application = getWithAssets(id)
+        val cleaned = clean(request)
+        repository.findByCarIdIgnoreCase(cleaned.carId).ifPresent { existing ->
+            if (existing.id != id) {
+                throw IllegalArgumentException("carId already exists")
+            }
+        }
+
+        apply(application, cleaned)
+        application.updatedBy = username
+
+        return ApplicationRegisterDetail.from(repository.update(application))
+    }
+
+    @Transactional
+    open fun delete(id: Long) {
+        if (!repository.existsById(id)) {
+            throw NoSuchElementException("Application not found")
+        }
+        repository.deleteById(id)
+    }
+
+    @Transactional
+    open fun replaceAssets(id: Long, assetIds: List<Long>, username: String): ApplicationRegisterDetail {
+        val application = getWithAssets(id)
+        val distinctIds = assetIds.distinct()
+        val assets = if (distinctIds.isEmpty()) emptyList() else assetRepository.findByIdIn(distinctIds)
+        val foundIds = assets.mapNotNull { it.id }.toSet()
+        val missing = distinctIds.filterNot { foundIds.contains(it) }
+        if (missing.isNotEmpty()) {
+            throw IllegalArgumentException("Unknown asset ids: ${missing.joinToString(", ")}")
+        }
+
+        application.assets.clear()
+        application.assets.addAll(assets)
+        application.updatedBy = username
+
+        return ApplicationRegisterDetail.from(repository.update(application))
+    }
+
+    private fun getWithAssets(id: Long): ApplicationRegister {
+        return repository.findByIdWithAssets(id).orElseThrow {
+            NoSuchElementException("Application not found")
+        }
+    }
+
+    private fun clean(request: ApplicationRegisterRequest): ApplicationRegisterRequest {
+        val carId = request.carId.trim()
+        val name = request.name.trim()
+        val businessOwner = request.businessOwner.trim()
+        val applicationManager = request.applicationManager.trim()
+        val errors = mutableListOf<String>()
+        if (carId.isBlank()) errors.add("carId is required")
+        if (name.isBlank()) errors.add("name is required")
+        if (businessOwner.isBlank()) errors.add("businessOwner is required")
+        if (applicationManager.isBlank()) errors.add("applicationManager is required")
+        if (errors.isNotEmpty()) {
+            throw IllegalArgumentException(errors.joinToString("; "))
+        }
+
+        return request.copy(
+            carId = carId,
+            name = name,
+            businessOwner = businessOwner,
+            applicationManager = applicationManager,
+            processCluster = request.processCluster.clean(),
+            processArea = request.processArea.clean(),
+            criticality = request.criticality.clean(),
+            operationalStatus = request.operationalStatus.clean(),
+            applicationChampion = request.applicationChampion.clean(),
+            applicationTechnology = request.applicationTechnology.clean(),
+            applicationArchitecture = request.applicationArchitecture.clean(),
+            informationClassification = request.informationClassification.clean(),
+            processingOfPersonalData = request.processingOfPersonalData.clean(),
+            icsRelevant = request.icsRelevant.clean(),
+            legalRegulatory = request.legalRegulatory.clean(),
+            legalRegulatoryRationaleImpact = request.legalRegulatoryRationaleImpact.clean(),
+            dataExportControlRelevant = request.dataExportControlRelevant.clean(),
+            applicationExportControlRelevant = request.applicationExportControlRelevant.clean(),
+            operationModel = request.operationModel.clean(),
+            productionOperatingHours = request.productionOperatingHours.clean(),
+            serviceOperatingHours = request.serviceOperatingHours.clean(),
+            sslCertificatesUsed = request.sslCertificatesUsed.clean(),
+            allMachineUsers = request.allMachineUsers.clean(),
+            recoveryPlanUrl = request.recoveryPlanUrl.clean(),
+            authorizationConceptUrl = request.authorizationConceptUrl.clean(),
+            passwordStorageTool = request.passwordStorageTool.clean(),
+            availabilitySupportUrl = request.availabilitySupportUrl.clean(),
+            recurringTasksResponsibilitiesUrl = request.recurringTasksResponsibilitiesUrl.clean(),
+            backupRecoveryUrl = request.backupRecoveryUrl.clean(),
+            monitoringEscalationUrl = request.monitoringEscalationUrl.clean(),
+            toolsUsedForMonitoringUrl = request.toolsUsedForMonitoringUrl.clean(),
+            licenseManagementUrl = request.licenseManagementUrl.clean(),
+            communicationChannelsUrl = request.communicationChannelsUrl.clean(),
+            incidentAssignmentGroup = request.incidentAssignmentGroup.clean(),
+            solverGroupC = request.solverGroupC.clean(),
+            changeApprovalGroup = request.changeApprovalGroup.clean(),
+            cabApprovalGroup = request.cabApprovalGroup.clean(),
+            changeFulfillmentGroup = request.changeFulfillmentGroup.clean(),
+            runAndChange = request.runAndChange.clean(),
+            managedServiceRun = request.managedServiceRun.clean(),
+            managedServiceChange = request.managedServiceChange.clean(),
+            extendedWorkbenchChange = request.extendedWorkbenchChange.clean(),
+            extendedWorkbenchRun = request.extendedWorkbenchRun.clean(),
+            managedInternally = request.managedInternally.clean(),
+            notes = request.notes.clean(),
+            cmdbWorkspaceUrl = request.cmdbWorkspaceUrl.clean()
+        )
+    }
+
+    private fun apply(application: ApplicationRegister, request: ApplicationRegisterRequest) {
+        application.carId = request.carId
+        application.name = request.name
+        application.processCluster = request.processCluster
+        application.processArea = request.processArea
+        application.criticality = request.criticality
+        application.operationalStatus = request.operationalStatus
+        application.businessOwner = request.businessOwner
+        application.applicationChampion = request.applicationChampion
+        application.applicationManager = request.applicationManager
+        application.applicationTechnology = request.applicationTechnology
+        application.applicationArchitecture = request.applicationArchitecture
+        application.lastQualityCheck = request.lastQualityCheck
+        application.informationClassification = request.informationClassification
+        application.processingOfPersonalData = request.processingOfPersonalData
+        application.icsRelevant = request.icsRelevant
+        application.legalRegulatory = request.legalRegulatory
+        application.legalRegulatoryRationaleImpact = request.legalRegulatoryRationaleImpact
+        application.dataExportControlRelevant = request.dataExportControlRelevant
+        application.applicationExportControlRelevant = request.applicationExportControlRelevant
+        application.operationModel = request.operationModel
+        application.productionOperatingHours = request.productionOperatingHours
+        application.serviceOperatingHours = request.serviceOperatingHours
+        application.sslCertificatesUsed = request.sslCertificatesUsed
+        application.allMachineUsers = request.allMachineUsers
+        application.recoveryPlanUrl = request.recoveryPlanUrl
+        application.authorizationConceptUrl = request.authorizationConceptUrl
+        application.passwordStorageTool = request.passwordStorageTool
+        application.availabilitySupportUrl = request.availabilitySupportUrl
+        application.recurringTasksResponsibilitiesUrl = request.recurringTasksResponsibilitiesUrl
+        application.backupRecoveryUrl = request.backupRecoveryUrl
+        application.monitoringEscalationUrl = request.monitoringEscalationUrl
+        application.toolsUsedForMonitoringUrl = request.toolsUsedForMonitoringUrl
+        application.licenseManagementUrl = request.licenseManagementUrl
+        application.communicationChannelsUrl = request.communicationChannelsUrl
+        application.incidentAssignmentGroup = request.incidentAssignmentGroup
+        application.solverGroupC = request.solverGroupC
+        application.changeApprovalGroup = request.changeApprovalGroup
+        application.cabApprovalGroup = request.cabApprovalGroup
+        application.changeFulfillmentGroup = request.changeFulfillmentGroup
+        application.runAndChange = request.runAndChange
+        application.managedServiceRun = request.managedServiceRun
+        application.managedServiceChange = request.managedServiceChange
+        application.extendedWorkbenchChange = request.extendedWorkbenchChange
+        application.extendedWorkbenchRun = request.extendedWorkbenchRun
+        application.managedInternally = request.managedInternally
+        application.notes = request.notes
+        application.cmdbWorkspaceUrl = request.cmdbWorkspaceUrl
+    }
+
+    private fun String?.clean(): String? = this?.trim()?.ifBlank { null }
+}

--- a/src/backendng/src/main/resources/db/migration/V218__application_register.sql
+++ b/src/backendng/src/main/resources/db/migration/V218__application_register.sql
@@ -1,0 +1,76 @@
+CREATE TABLE application_register (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    car_id VARCHAR(100) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    process_cluster TEXT NULL,
+    process_area TEXT NULL,
+    criticality VARCHAR(100) NULL,
+    operational_status VARCHAR(100) NULL,
+    business_owner VARCHAR(255) NOT NULL,
+    application_champion TEXT NULL,
+    application_manager VARCHAR(255) NOT NULL,
+    application_technology TEXT NULL,
+    application_architecture TEXT NULL,
+    last_quality_check DATE NULL,
+    information_classification TEXT NULL,
+    processing_of_personal_data TEXT NULL,
+    ics_relevant TEXT NULL,
+    legal_regulatory TEXT NULL,
+    legal_regulatory_rationale_impact TEXT NULL,
+    data_export_control_relevant TEXT NULL,
+    application_export_control_relevant TEXT NULL,
+    operation_model TEXT NULL,
+    production_operating_hours TEXT NULL,
+    service_operating_hours TEXT NULL,
+    ssl_certificates_used TEXT NULL,
+    all_machine_users TEXT NULL,
+    recovery_plan_url TEXT NULL,
+    authorization_concept_url TEXT NULL,
+    password_storage_tool TEXT NULL,
+    availability_support_url TEXT NULL,
+    recurring_tasks_responsibilities_url TEXT NULL,
+    backup_recovery_url TEXT NULL,
+    monitoring_escalation_url TEXT NULL,
+    tools_used_for_monitoring_url TEXT NULL,
+    license_management_url TEXT NULL,
+    communication_channels_url TEXT NULL,
+    incident_assignment_group TEXT NULL,
+    solver_group_c TEXT NULL,
+    change_approval_group TEXT NULL,
+    cab_approval_group TEXT NULL,
+    change_fulfillment_group TEXT NULL,
+    run_and_change TEXT NULL,
+    managed_service_run TEXT NULL,
+    managed_service_change TEXT NULL,
+    extended_workbench_change TEXT NULL,
+    extended_workbench_run TEXT NULL,
+    managed_internally TEXT NULL,
+    notes TEXT NULL,
+    cmdb_workspace_url TEXT NULL,
+    created_at DATETIME NULL,
+    updated_at DATETIME NULL,
+    created_by VARCHAR(255) NULL,
+    updated_by VARCHAR(255) NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_application_register_car_id UNIQUE (car_id)
+);
+
+CREATE INDEX idx_application_register_name ON application_register (name);
+CREATE INDEX idx_application_register_owner ON application_register (business_owner);
+CREATE INDEX idx_application_register_manager ON application_register (application_manager);
+CREATE INDEX idx_application_register_status ON application_register (operational_status);
+CREATE INDEX idx_application_register_criticality ON application_register (criticality);
+
+CREATE TABLE application_register_asset (
+    application_register_id BIGINT NOT NULL,
+    asset_id BIGINT NOT NULL,
+    PRIMARY KEY (application_register_id, asset_id),
+    CONSTRAINT fk_application_register_asset_application
+        FOREIGN KEY (application_register_id) REFERENCES application_register (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_application_register_asset_asset
+        FOREIGN KEY (asset_id) REFERENCES asset (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_application_register_asset_asset ON application_register_asset (asset_id);

--- a/src/backendng/src/test/kotlin/com/secman/controller/ApplicationRegisterControllerIntegrationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/ApplicationRegisterControllerIntegrationTest.kt
@@ -1,0 +1,119 @@
+package com.secman.controller
+
+import com.secman.domain.ApplicationRegister
+import com.secman.domain.User
+import com.secman.dto.ApplicationRegisterDetail
+import com.secman.dto.ApplicationRegisterRequest
+import com.secman.dto.ApplicationRegisterSummary
+import com.secman.repository.ApplicationRegisterRepository
+import com.secman.repository.UserRepository
+import com.secman.testutil.BaseIntegrationTest
+import com.secman.testutil.TestAuthHelper
+import com.secman.testutil.TestDataFactory
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIf
+
+@EnabledIf("com.secman.testutil.DockerAvailable#isDockerAvailable")
+class ApplicationRegisterControllerIntegrationTest : BaseIntegrationTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var applicationRepository: ApplicationRegisterRepository
+
+    private lateinit var regularUser: User
+    private lateinit var adminUser: User
+
+    @BeforeEach
+    fun setUp() {
+        val suffix = System.nanoTime()
+        regularUser = userRepository.save(TestDataFactory.createRegularUser("app-user-$suffix", "app-user-$suffix@test.com"))
+        adminUser = userRepository.save(TestDataFactory.createAdminUser("app-admin-$suffix", "app-admin-$suffix@test.com"))
+    }
+
+    @Test
+    fun `authenticated user can list and get applications`() {
+        val application = applicationRepository.save(ApplicationRegister(
+            carId = "CAR-${System.nanoTime()}",
+            name = "Register Read Test",
+            businessOwner = "Business Owner",
+            applicationManager = "Application Manager"
+        ))
+        val token = TestAuthHelper.getAuthToken(client, regularUser.username)
+
+        val listResponse = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/applications?search=Read").bearerAuth(token),
+            Argument.listOf(ApplicationRegisterSummary::class.java)
+        )
+        val detailResponse = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/applications/${application.id}").bearerAuth(token),
+            ApplicationRegisterDetail::class.java
+        )
+
+        assertThat(listResponse.status).isEqualTo(HttpStatus.OK)
+        assertThat(listResponse.body().map { it.id }).contains(application.id)
+        assertThat(detailResponse.status).isEqualTo(HttpStatus.OK)
+        assertThat(detailResponse.body()!!.carId).isEqualTo(application.carId)
+    }
+
+    @Test
+    fun `regular user cannot create applications`() {
+        val token = TestAuthHelper.getAuthToken(client, regularUser.username)
+
+        val exception = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                TestAuthHelper.authenticatedRequest(
+                    HttpMethod.POST,
+                    "/api/applications",
+                    validRequest(),
+                    token
+                ),
+                ApplicationRegisterDetail::class.java
+            )
+        }
+
+        assertThat(exception.status).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `admin can create applications`() {
+        val token = TestAuthHelper.getAuthToken(client, adminUser.username)
+
+        val response = client.toBlocking().exchange(
+            TestAuthHelper.authenticatedRequest(
+                HttpMethod.POST,
+                "/api/applications",
+                validRequest(carId = "CAR-${System.nanoTime()}"),
+                token
+            ),
+            ApplicationRegisterDetail::class.java
+        )
+
+        assertThat(response.status).isEqualTo(HttpStatus.CREATED)
+        assertThat(response.body()!!.createdBy).isEqualTo(adminUser.username)
+    }
+
+    private fun validRequest(carId: String = "CAR-${System.nanoTime()}"): ApplicationRegisterRequest {
+        return ApplicationRegisterRequest(
+            carId = carId,
+            name = "Application",
+            businessOwner = "Owner",
+            applicationManager = "Manager"
+        )
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/ApplicationRegisterServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/ApplicationRegisterServiceTest.kt
@@ -1,0 +1,111 @@
+package com.secman.service
+
+import com.secman.domain.ApplicationRegister
+import com.secman.domain.Asset
+import com.secman.dto.ApplicationRegisterRequest
+import com.secman.repository.ApplicationRegisterRepository
+import com.secman.repository.AssetRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class ApplicationRegisterServiceTest {
+
+    private val repository: ApplicationRegisterRepository = mockk()
+    private val assetRepository: AssetRepository = mockk()
+    private val service = ApplicationRegisterService(repository, assetRepository)
+
+    @Test
+    fun `create trims required strings before saving`() {
+        val savedSlot = slot<ApplicationRegister>()
+        every { repository.existsByCarIdIgnoreCase("CAR-123") } returns false
+        every { repository.save(capture(savedSlot)) } answers { savedSlot.captured.apply { id = 10L } }
+
+        val response = service.create(
+            validRequest(
+                carId = "  CAR-123  ",
+                name = "  Application Name  ",
+                businessOwner = "  Business Owner  ",
+                applicationManager = "  Manager  "
+            ),
+            "creator"
+        )
+
+        assertEquals("CAR-123", response.carId)
+        assertEquals("Application Name", response.name)
+        assertEquals("Business Owner", response.businessOwner)
+        assertEquals("Manager", response.applicationManager)
+        assertEquals("creator", savedSlot.captured.createdBy)
+        assertEquals("creator", savedSlot.captured.updatedBy)
+    }
+
+    @Test
+    fun `create rejects blank required fields`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            service.create(validRequest(carId = " ", businessOwner = ""), "creator")
+        }
+
+        assertEquals("carId is required; businessOwner is required", exception.message)
+    }
+
+    @Test
+    fun `replaceAssets rejects unknown asset ids`() {
+        val application = ApplicationRegister(
+            carId = "CAR-123",
+            name = "Application",
+            businessOwner = "Owner",
+            applicationManager = "Manager"
+        ).apply { id = 10L }
+        val asset = Asset(name = "Asset One", type = "SERVER", owner = "Owner").apply { id = 1L }
+
+        every { repository.findByIdWithAssets(10L) } returns Optional.of(application)
+        every { assetRepository.findByIdIn(listOf(1L, 2L)) } returns listOf(asset)
+
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            service.replaceAssets(10L, listOf(1L, 2L), "updater")
+        }
+
+        assertEquals("Unknown asset ids: 2", exception.message)
+    }
+
+    @Test
+    fun `replaceAssets returns linked asset summaries`() {
+        val application = ApplicationRegister(
+            carId = "CAR-123",
+            name = "Application",
+            businessOwner = "Owner",
+            applicationManager = "Manager"
+        ).apply { id = 10L }
+        val asset = Asset(name = "Asset One", type = "SERVER", owner = "Owner").apply { id = 1L }
+        val savedSlot = slot<ApplicationRegister>()
+
+        every { repository.findByIdWithAssets(10L) } returns Optional.of(application)
+        every { assetRepository.findByIdIn(listOf(1L)) } returns listOf(asset)
+        every { repository.update(capture(savedSlot)) } answers { savedSlot.captured }
+
+        val response = service.replaceAssets(10L, listOf(1L), "updater")
+
+        assertEquals(listOf(1L), response.assets.map { it.id })
+        assertEquals("updater", savedSlot.captured.updatedBy)
+        verify { repository.update(any<ApplicationRegister>()) }
+    }
+
+    private fun validRequest(
+        carId: String = "CAR-123",
+        name: String = "Application",
+        businessOwner: String = "Owner",
+        applicationManager: String = "Manager"
+    ): ApplicationRegisterRequest {
+        return ApplicationRegisterRequest(
+            carId = carId,
+            name = name,
+            businessOwner = businessOwner,
+            applicationManager = applicationManager
+        )
+    }
+}

--- a/src/frontend/src/components/ApplicationRegister.tsx
+++ b/src/frontend/src/components/ApplicationRegister.tsx
@@ -1,0 +1,494 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { getUser } from '../utils/auth';
+import { isAdmin, isSecChampion } from '../utils/permissions';
+import {
+  createApplication,
+  deleteApplication,
+  getApplication,
+  listApplications,
+  replaceApplicationAssets,
+  updateApplication,
+  type ApplicationAssetSummary,
+  type ApplicationRegisterDetail,
+  type ApplicationRegisterRequest,
+  type ApplicationRegisterSummary,
+} from '../services/applicationRegisterService';
+import { authenticatedGet } from '../utils/auth';
+
+type TabKey = 'operation' | 'technical' | 'organization' | 'relations' | 'compliance' | 'dates' | 'reporting';
+
+interface AssetOption {
+  id: number;
+  name: string;
+  type: string;
+  owner: string;
+  ip?: string | null;
+}
+
+const emptyForm: ApplicationRegisterRequest = {
+  carId: '',
+  name: '',
+  processCluster: '',
+  processArea: '',
+  criticality: '',
+  operationalStatus: '',
+  businessOwner: '',
+  applicationChampion: '',
+  applicationManager: '',
+  applicationTechnology: '',
+  applicationArchitecture: '',
+  lastQualityCheck: '',
+  informationClassification: '',
+  processingOfPersonalData: '',
+  icsRelevant: '',
+  legalRegulatory: '',
+  legalRegulatoryRationaleImpact: '',
+  dataExportControlRelevant: '',
+  applicationExportControlRelevant: '',
+  operationModel: '',
+  productionOperatingHours: '',
+  serviceOperatingHours: '',
+  sslCertificatesUsed: '',
+  allMachineUsers: '',
+  recoveryPlanUrl: '',
+  authorizationConceptUrl: '',
+  passwordStorageTool: '',
+  availabilitySupportUrl: '',
+  recurringTasksResponsibilitiesUrl: '',
+  backupRecoveryUrl: '',
+  monitoringEscalationUrl: '',
+  toolsUsedForMonitoringUrl: '',
+  licenseManagementUrl: '',
+  communicationChannelsUrl: '',
+  incidentAssignmentGroup: '',
+  solverGroupC: '',
+  changeApprovalGroup: '',
+  cabApprovalGroup: '',
+  changeFulfillmentGroup: '',
+  runAndChange: '',
+  managedServiceRun: '',
+  managedServiceChange: '',
+  extendedWorkbenchChange: '',
+  extendedWorkbenchRun: '',
+  managedInternally: '',
+  notes: '',
+  cmdbWorkspaceUrl: '',
+};
+
+const tabs: Array<{ key: TabKey; label: string; icon: string }> = [
+  { key: 'operation', label: 'Operation', icon: 'bi-clock-history' },
+  { key: 'technical', label: 'Technical Details', icon: 'bi-cpu' },
+  { key: 'organization', label: 'Organization', icon: 'bi-diagram-3' },
+  { key: 'relations', label: 'Relations', icon: 'bi-link-45deg' },
+  { key: 'compliance', label: 'Compliance', icon: 'bi-shield-check' },
+  { key: 'dates', label: 'Dates', icon: 'bi-calendar3' },
+  { key: 'reporting', label: 'Reporting', icon: 'bi-file-text' },
+];
+
+const fieldGroups: Record<Exclude<TabKey, 'relations'>, Array<{ name: keyof ApplicationRegisterRequest; label: string; type?: string; textarea?: boolean }>> = {
+  operation: [
+    { name: 'operationModel', label: 'Operation model' },
+    { name: 'productionOperatingHours', label: 'Production operating hours' },
+    { name: 'serviceOperatingHours', label: 'Service operating hours' },
+    { name: 'sslCertificatesUsed', label: 'SSL certificates used' },
+    { name: 'allMachineUsers', label: 'All machine users' },
+    { name: 'passwordStorageTool', label: 'Password storage tool' },
+  ],
+  technical: [
+    { name: 'applicationTechnology', label: 'Application technology' },
+    { name: 'applicationArchitecture', label: 'Application architecture' },
+    { name: 'recoveryPlanUrl', label: 'Recovery plan URL' },
+    { name: 'authorizationConceptUrl', label: 'Authorization concept URL' },
+    { name: 'availabilitySupportUrl', label: 'Availability support URL' },
+    { name: 'backupRecoveryUrl', label: 'Backup and recovery URL' },
+    { name: 'monitoringEscalationUrl', label: 'Monitoring escalation URL' },
+    { name: 'toolsUsedForMonitoringUrl', label: 'Tools used for monitoring URL' },
+    { name: 'licenseManagementUrl', label: 'License management URL' },
+    { name: 'communicationChannelsUrl', label: 'Communication channels URL' },
+    { name: 'recurringTasksResponsibilitiesUrl', label: 'Recurring tasks URL' },
+  ],
+  organization: [
+    { name: 'incidentAssignmentGroup', label: 'Incident assignment group' },
+    { name: 'solverGroupC', label: 'Solver group C' },
+    { name: 'changeApprovalGroup', label: 'Change approval group' },
+    { name: 'cabApprovalGroup', label: 'CAB approval group' },
+    { name: 'changeFulfillmentGroup', label: 'Change fulfillment group' },
+    { name: 'runAndChange', label: 'Run and change' },
+    { name: 'managedServiceRun', label: 'Managed service run' },
+    { name: 'managedServiceChange', label: 'Managed service change' },
+    { name: 'extendedWorkbenchChange', label: 'Extended workbench change' },
+    { name: 'extendedWorkbenchRun', label: 'Extended workbench run' },
+    { name: 'managedInternally', label: 'Managed internally' },
+  ],
+  compliance: [
+    { name: 'informationClassification', label: 'Information classification' },
+    { name: 'processingOfPersonalData', label: 'Processing of personal data' },
+    { name: 'icsRelevant', label: 'ICS relevant' },
+    { name: 'legalRegulatory', label: 'Legal regulatory' },
+    { name: 'legalRegulatoryRationaleImpact', label: 'Legal regulatory rationale impact', textarea: true },
+    { name: 'dataExportControlRelevant', label: 'Data export control relevant' },
+    { name: 'applicationExportControlRelevant', label: 'Application export control relevant' },
+  ],
+  dates: [
+    { name: 'lastQualityCheck', label: 'Last quality check', type: 'date' },
+  ],
+  reporting: [
+    { name: 'notes', label: 'Notes', textarea: true },
+    { name: 'cmdbWorkspaceUrl', label: 'CMDB workspace URL' },
+  ],
+};
+
+const toForm = (application: ApplicationRegisterDetail): ApplicationRegisterRequest => {
+  const form = { ...emptyForm };
+  Object.keys(form).forEach((key) => {
+    const typedKey = key as keyof ApplicationRegisterRequest;
+    form[typedKey] = (application[typedKey] ?? '') as never;
+  });
+  return form;
+};
+
+const ApplicationRegister: React.FC = () => {
+  const [applications, setApplications] = useState<ApplicationRegisterSummary[]>([]);
+  const [selected, setSelected] = useState<ApplicationRegisterDetail | null>(null);
+  const [formData, setFormData] = useState<ApplicationRegisterRequest>(emptyForm);
+  const [assetOptions, setAssetOptions] = useState<AssetOption[]>([]);
+  const [selectedAssetIds, setSelectedAssetIds] = useState<number[]>([]);
+  const [search, setSearch] = useState('');
+  const [assetSearch, setAssetSearch] = useState('');
+  const [activeTab, setActiveTab] = useState<TabKey>('operation');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const user = getUser();
+  const canMutate = isAdmin(user?.roles) || isSecChampion(user?.roles);
+
+  useEffect(() => {
+    void loadApplications();
+    void loadAssets();
+  }, []);
+
+  const filteredApplications = useMemo(() => applications, [applications]);
+  const filteredAssets = useMemo(() => {
+    const query = assetSearch.trim().toLowerCase();
+    if (!query) return assetOptions.slice(0, 80);
+    return assetOptions.filter((asset) =>
+      [asset.name, asset.type, asset.owner, asset.ip || ''].some((value) => value.toLowerCase().includes(query))
+    ).slice(0, 80);
+  }, [assetOptions, assetSearch]);
+
+  const loadApplications = async (nextSearch = search) => {
+    setLoading(true);
+    try {
+      const data = await listApplications(nextSearch);
+      setApplications(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load applications');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadAssets = async () => {
+    try {
+      const response = await authenticatedGet('/api/assets');
+      if (response.ok) {
+        setAssetOptions(await response.json());
+      }
+    } catch (err) {
+      console.error('Failed to load assets for application relations', err);
+    }
+  };
+
+  const selectApplication = async (id: number) => {
+    try {
+      const detail = await getApplication(id);
+      setSelected(detail);
+      setFormData(toForm(detail));
+      setSelectedAssetIds(detail.assets.map((asset) => asset.id));
+      setActiveTab('operation');
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load application');
+    }
+  };
+
+  const startNew = () => {
+    setSelected(null);
+    setFormData({ ...emptyForm });
+    setSelectedAssetIds([]);
+    setActiveTab('operation');
+    setError(null);
+  };
+
+  const updateField = (name: keyof ApplicationRegisterRequest, value: string) => {
+    setFormData((current) => ({ ...current, [name]: value }));
+  };
+
+  const save = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canMutate) return;
+    setSaving(true);
+    try {
+      const saved = selected
+        ? await updateApplication(selected.id, formData)
+        : await createApplication(formData);
+      const withAssets = await replaceApplicationAssets(saved.id, selectedAssetIds);
+      setSelected(withAssets);
+      setFormData(toForm(withAssets));
+      await loadApplications();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save application');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!selected || !canMutate || !window.confirm(`Delete ${selected.name}?`)) return;
+    try {
+      await deleteApplication(selected.id);
+      startNew();
+      await loadApplications();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete application');
+    }
+  };
+
+  const toggleAsset = (assetId: number) => {
+    setSelectedAssetIds((current) =>
+      current.includes(assetId) ? current.filter((id) => id !== assetId) : [...current, assetId]
+    );
+  };
+
+  const renderField = (field: { name: keyof ApplicationRegisterRequest; label: string; type?: string; textarea?: boolean }) => (
+    <div className="col-md-6" key={field.name}>
+      <label className="form-label small fw-semibold text-secondary">{field.label}</label>
+      {field.textarea ? (
+        <textarea
+          className="form-control form-control-sm"
+          rows={field.name === 'notes' ? 5 : 3}
+          value={(formData[field.name] as string) || ''}
+          disabled={!canMutate}
+          onChange={(event) => updateField(field.name, event.target.value)}
+        />
+      ) : (
+        <input
+          className="form-control form-control-sm"
+          type={field.type || 'text'}
+          value={(formData[field.name] as string) || ''}
+          disabled={!canMutate}
+          onChange={(event) => updateField(field.name, event.target.value)}
+        />
+      )}
+    </div>
+  );
+
+  const selectedAssets: ApplicationAssetSummary[] = assetOptions
+    .filter((asset) => selectedAssetIds.includes(asset.id))
+    .map((asset) => ({ id: asset.id, name: asset.name, type: asset.type, owner: asset.owner, ip: asset.ip }));
+
+  return (
+    <div className="container-fluid py-3 application-register">
+      <div className="d-flex align-items-center justify-content-between mb-3">
+        <div>
+          <h1 className="h3 mb-1">Application Register</h1>
+          <div className="text-secondary small">Governance records linked to SecMan assets</div>
+        </div>
+        {canMutate && (
+          <button className="btn btn-primary btn-sm" onClick={startNew}>
+            <i className="bi bi-plus-lg me-1"></i>
+            New Application
+          </button>
+        )}
+      </div>
+
+      {error && <div className="alert alert-danger py-2">{error}</div>}
+
+      <div className="row g-3">
+        <div className="col-xl-4">
+          <div className="border rounded bg-white">
+            <div className="p-3 border-bottom">
+              <label className="form-label small fw-semibold text-secondary">Search register</label>
+              <div className="input-group input-group-sm">
+                <span className="input-group-text"><i className="bi bi-search"></i></span>
+                <input
+                  className="form-control"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') void loadApplications();
+                  }}
+                  placeholder="Name, CAR ID, owner, manager, status"
+                />
+                <button className="btn btn-outline-secondary" onClick={() => void loadApplications()}>
+                  Filter
+                </button>
+              </div>
+            </div>
+            <div className="table-responsive application-register-list">
+              <table className="table table-sm table-hover align-middle mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th>CAR ID</th>
+                    <th>Name</th>
+                    <th>Status</th>
+                    <th>Criticality</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr><td colSpan={4} className="text-secondary p-3">Loading...</td></tr>
+                  ) : filteredApplications.length === 0 ? (
+                    <tr><td colSpan={4} className="text-secondary p-3">No application records found.</td></tr>
+                  ) : filteredApplications.map((application) => (
+                    <tr
+                      key={application.id}
+                      className={selected?.id === application.id ? 'table-primary' : ''}
+                      onClick={() => void selectApplication(application.id)}
+                      role="button"
+                    >
+                      <td className="fw-semibold">{application.carId}</td>
+                      <td>
+                        <div>{application.name}</div>
+                        <div className="text-secondary small">{application.businessOwner} / {application.applicationManager}</div>
+                      </td>
+                      <td>{application.operationalStatus || '-'}</td>
+                      <td>{application.criticality || '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-xl-8">
+          <form className="border rounded bg-white" onSubmit={save}>
+            <div className="p-3 border-bottom">
+              <div className="row g-2">
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">CAR ID</label>
+                  <input className="form-control form-control-sm" value={formData.carId} required disabled={!canMutate} onChange={(event) => updateField('carId', event.target.value)} />
+                </div>
+                <div className="col-md-5">
+                  <label className="form-label small fw-semibold text-secondary">Application name</label>
+                  <input className="form-control form-control-sm" value={formData.name} required disabled={!canMutate} onChange={(event) => updateField('name', event.target.value)} />
+                </div>
+                <div className="col-md-2">
+                  <label className="form-label small fw-semibold text-secondary">Status</label>
+                  <input className="form-control form-control-sm" value={formData.operationalStatus || ''} disabled={!canMutate} onChange={(event) => updateField('operationalStatus', event.target.value)} />
+                </div>
+                <div className="col-md-2">
+                  <label className="form-label small fw-semibold text-secondary">Criticality</label>
+                  <input className="form-control form-control-sm" value={formData.criticality || ''} disabled={!canMutate} onChange={(event) => updateField('criticality', event.target.value)} />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">Business owner</label>
+                  <input className="form-control form-control-sm" value={formData.businessOwner} required disabled={!canMutate} onChange={(event) => updateField('businessOwner', event.target.value)} />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">Application manager</label>
+                  <input className="form-control form-control-sm" value={formData.applicationManager} required disabled={!canMutate} onChange={(event) => updateField('applicationManager', event.target.value)} />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">Application champion</label>
+                  <input className="form-control form-control-sm" value={formData.applicationChampion || ''} disabled={!canMutate} onChange={(event) => updateField('applicationChampion', event.target.value)} />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">Process area</label>
+                  <input className="form-control form-control-sm" value={formData.processArea || ''} disabled={!canMutate} onChange={(event) => updateField('processArea', event.target.value)} />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label small fw-semibold text-secondary">Process cluster</label>
+                  <input className="form-control form-control-sm" value={formData.processCluster || ''} disabled={!canMutate} onChange={(event) => updateField('processCluster', event.target.value)} />
+                </div>
+              </div>
+            </div>
+
+            <ul className="nav nav-tabs px-3 pt-2">
+              {tabs.map((tab) => (
+                <li className="nav-item" key={tab.key}>
+                  <button type="button" className={`nav-link small ${activeTab === tab.key ? 'active' : ''}`} onClick={() => setActiveTab(tab.key)}>
+                    <i className={`bi ${tab.icon} me-1`}></i>
+                    {tab.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            <div className="p-3">
+              {activeTab === 'relations' ? (
+                <div className="row g-3">
+                  <div className="col-md-5">
+                    <label className="form-label small fw-semibold text-secondary">Find SecMan assets</label>
+                    <input className="form-control form-control-sm mb-2" value={assetSearch} onChange={(event) => setAssetSearch(event.target.value)} placeholder="Asset name, type, owner, IP" />
+                    <div className="application-register-assets border rounded">
+                      {filteredAssets.map((asset) => (
+                        <label className="d-flex gap-2 align-items-start p-2 border-bottom small" key={asset.id}>
+                          <input type="checkbox" className="form-check-input mt-1" disabled={!canMutate} checked={selectedAssetIds.includes(asset.id)} onChange={() => toggleAsset(asset.id)} />
+                          <span>
+                            <span className="fw-semibold">{asset.name}</span>
+                            <span className="text-secondary d-block">{asset.type} / {asset.owner}{asset.ip ? ` / ${asset.ip}` : ''}</span>
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="col-md-7">
+                    <div className="small fw-semibold text-secondary mb-2">Linked assets</div>
+                    <table className="table table-sm align-middle">
+                      <thead className="table-light">
+                        <tr><th>Name</th><th>Type</th><th>Owner</th><th>IP</th></tr>
+                      </thead>
+                      <tbody>
+                        {selectedAssets.length === 0 ? (
+                          <tr><td colSpan={4} className="text-secondary">No assets linked.</td></tr>
+                        ) : selectedAssets.map((asset) => (
+                          <tr key={asset.id}>
+                            <td>{asset.name}</td>
+                            <td>{asset.type}</td>
+                            <td>{asset.owner}</td>
+                            <td>{asset.ip || '-'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              ) : (
+                <div className="row g-3">
+                  {fieldGroups[activeTab].map(renderField)}
+                </div>
+              )}
+            </div>
+
+            <div className="d-flex justify-content-between align-items-center border-top p-3">
+              <div className="text-secondary small">
+                {selected ? `Created by ${selected.createdBy || '-'} / Updated by ${selected.updatedBy || '-'}` : 'New register record'}
+              </div>
+              {canMutate && (
+                <div className="d-flex gap-2">
+                  {selected && (
+                    <button type="button" className="btn btn-outline-danger btn-sm" onClick={remove}>
+                      <i className="bi bi-trash me-1"></i>
+                      Delete
+                    </button>
+                  )}
+                  <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>
+                    <i className="bi bi-save me-1"></i>
+                    {saving ? 'Saving...' : 'Save'}
+                  </button>
+                </div>
+              )}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplicationRegister;

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -138,6 +138,11 @@ const Sidebar = () => {
                         <i className="bi bi-server me-2"></i> Assets Overview
                     </a>
                 </li>
+                <li>
+                    <a href="/applications" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
+                        <i className="bi bi-window-stack me-2"></i> Application Register
+                    </a>
+                </li>
 
 
                 {/* REQUIREMENTS Section - ADMIN, REQ, or SECCHAMPION only (Feature: 025-role-based-access-control) */}

--- a/src/frontend/src/pages/applications.astro
+++ b/src/frontend/src/pages/applications.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ApplicationRegister from '../components/ApplicationRegister';
+---
+
+<Layout title="Application Register">
+    <ApplicationRegister client:load />
+</Layout>

--- a/src/frontend/src/services/applicationRegisterService.ts
+++ b/src/frontend/src/services/applicationRegisterService.ts
@@ -1,0 +1,112 @@
+import { authenticatedDelete, authenticatedGet, authenticatedPost, authenticatedPut } from '../utils/auth';
+
+export interface ApplicationAssetSummary {
+  id: number;
+  name: string;
+  type: string;
+  owner: string;
+  ip?: string | null;
+}
+
+export interface ApplicationRegisterSummary {
+  id: number;
+  carId: string;
+  name: string;
+  criticality?: string | null;
+  operationalStatus?: string | null;
+  businessOwner: string;
+  applicationManager: string;
+  updatedAt?: string | null;
+}
+
+export interface ApplicationRegisterDetail extends ApplicationRegisterSummary {
+  processCluster?: string | null;
+  processArea?: string | null;
+  applicationChampion?: string | null;
+  applicationTechnology?: string | null;
+  applicationArchitecture?: string | null;
+  lastQualityCheck?: string | null;
+  informationClassification?: string | null;
+  processingOfPersonalData?: string | null;
+  icsRelevant?: string | null;
+  legalRegulatory?: string | null;
+  legalRegulatoryRationaleImpact?: string | null;
+  dataExportControlRelevant?: string | null;
+  applicationExportControlRelevant?: string | null;
+  operationModel?: string | null;
+  productionOperatingHours?: string | null;
+  serviceOperatingHours?: string | null;
+  sslCertificatesUsed?: string | null;
+  allMachineUsers?: string | null;
+  recoveryPlanUrl?: string | null;
+  authorizationConceptUrl?: string | null;
+  passwordStorageTool?: string | null;
+  availabilitySupportUrl?: string | null;
+  recurringTasksResponsibilitiesUrl?: string | null;
+  backupRecoveryUrl?: string | null;
+  monitoringEscalationUrl?: string | null;
+  toolsUsedForMonitoringUrl?: string | null;
+  licenseManagementUrl?: string | null;
+  communicationChannelsUrl?: string | null;
+  incidentAssignmentGroup?: string | null;
+  solverGroupC?: string | null;
+  changeApprovalGroup?: string | null;
+  cabApprovalGroup?: string | null;
+  changeFulfillmentGroup?: string | null;
+  runAndChange?: string | null;
+  managedServiceRun?: string | null;
+  managedServiceChange?: string | null;
+  extendedWorkbenchChange?: string | null;
+  extendedWorkbenchRun?: string | null;
+  managedInternally?: string | null;
+  notes?: string | null;
+  cmdbWorkspaceUrl?: string | null;
+  createdAt?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  assets: ApplicationAssetSummary[];
+}
+
+export type ApplicationRegisterRequest = Omit<ApplicationRegisterDetail, 'id' | 'assets' | 'createdAt' | 'updatedAt' | 'createdBy' | 'updatedBy'>;
+
+async function parseOrThrow<T>(response: Response, fallback: string): Promise<T> {
+  if (response.ok) {
+    return await response.json();
+  }
+  const body = await response.json().catch(() => ({}));
+  throw new Error(body.error || body.message || `${fallback}: ${response.status}`);
+}
+
+export async function listApplications(search = ''): Promise<ApplicationRegisterSummary[]> {
+  const params = new URLSearchParams();
+  if (search.trim()) params.set('search', search.trim());
+  const suffix = params.toString() ? `?${params.toString()}` : '';
+  return parseOrThrow(await authenticatedGet(`/api/applications${suffix}`), 'Failed to load applications');
+}
+
+export async function getApplication(id: number): Promise<ApplicationRegisterDetail> {
+  return parseOrThrow(await authenticatedGet(`/api/applications/${id}`), 'Failed to load application');
+}
+
+export async function createApplication(request: ApplicationRegisterRequest): Promise<ApplicationRegisterDetail> {
+  return parseOrThrow(await authenticatedPost('/api/applications', request), 'Failed to create application');
+}
+
+export async function updateApplication(id: number, request: ApplicationRegisterRequest): Promise<ApplicationRegisterDetail> {
+  return parseOrThrow(await authenticatedPut(`/api/applications/${id}`, request), 'Failed to update application');
+}
+
+export async function deleteApplication(id: number): Promise<void> {
+  const response = await authenticatedDelete(`/api/applications/${id}`);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || body.message || `Failed to delete application: ${response.status}`);
+  }
+}
+
+export async function replaceApplicationAssets(id: number, assetIds: number[]): Promise<ApplicationRegisterDetail> {
+  return parseOrThrow(
+    await authenticatedPut(`/api/applications/${id}/assets`, { assetIds }),
+    'Failed to update linked assets'
+  );
+}

--- a/src/frontend/src/styles/bootstrap-overrides.css
+++ b/src/frontend/src/styles/bootstrap-overrides.css
@@ -509,3 +509,31 @@ thead.table-dark {
 .bg-dark {
   background-color: var(--scand-bg-header) !important;
 }
+
+/* ========================
+   APPLICATION REGISTER
+   ======================== */
+
+.application-register .table td,
+.application-register .table th {
+  white-space: nowrap;
+}
+
+.application-register-list {
+  max-height: 66vh;
+  overflow: auto;
+}
+
+.application-register-assets {
+  max-height: 360px;
+  overflow: auto;
+}
+
+.application-register .nav-tabs .nav-link {
+  color: var(--scand-text-secondary);
+}
+
+.application-register .nav-tabs .nav-link.active {
+  color: var(--scand-text-primary);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Adds a backend Application Register governance model with Flyway migration, CRUD API under `/api/applications`, and SecMan asset relations through a join table.
- Adds service/controller tests for validation, RBAC, searchable reads, and linked asset handling.
- Adds the `/applications` Astro/React UI with searchable register list, tabbed detail/edit form, asset linking, and sidebar navigation.

## Validation
- `./gradlew :backendng:test --tests "com.secman.service.ApplicationRegisterServiceTest"`
- `./gradlew :backendng:test --tests "com.secman.controller.ApplicationRegisterControllerIntegrationTest"`
- `npm run build` from `src/frontend`
- `./gradlew build`
- `./scripts/startbackenddev.sh` started successfully and applied V218; stopped with `./scripts/stopbackenddev.sh`

## Notes
- `npm run lint` is blocked by the existing ESLint 9 setup because no `eslint.config.*` file exists.
- `/e2ejs` was started but interrupted before completion, so it is not claimed as passed.
- `/e2evulnexception` was not run after the interruption.