### PR TITLE
feat(mcp): expose application register operations

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -113,7 +113,7 @@ curl -XPOST http://localhost:8080/mcp \
 | `REQUIREMENTS_READ` | `get_requirements`, `export_requirements`, `list_releases`, `get_release`, `compare_releases`, `create_release`*, `delete_release`*, `set_release_status`* |
 | `REQUIREMENTS_WRITE` | `add_requirement` |
 | `REQUIREMENTS_DELETE` | `delete_all_requirements` (ADMIN) |
-| `ASSETS_READ` | `get_assets`, `get_all_assets_detail`, `get_asset_profile`, `get_asset_complete_profile`, `create_asset`, `update_asset` |
+| `ASSETS_READ` | `get_assets`, `get_all_assets_detail`, `get_asset_profile`, `get_asset_complete_profile`, `create_asset`, `update_asset`, `application_register` |
 | `VULNERABILITIES_READ` | `get_vulnerabilities`, `get_all_vulnerabilities_detail`, `get_asset_most_vulnerabilities`, `get_overdue_assets`, `*_exception_request*`, `get_vulnerability_heatmap`, `refresh_vulnerability_heatmap` |
 | `SCANS_READ` | `get_scans`, `get_asset_scan_results`, `search_products` |
 | `USER_ACTIVITY` | `list_users`, `add_user`, `delete_user`, `import_user_mappings`, `list_user_mappings`, `*_aws_account_sharing` |
@@ -136,6 +136,14 @@ curl -XPOST http://localhost:8080/mcp \
 - **`update_asset`** — `assetId`* + any of `name`, `type`, `owner`, `ip`, `description`, `criticality`, `adDomain`. Partial update; row-level access enforced. Workgroup reassignment is via `assign_assets_to_workgroup`.
 - **`delete_asset`** — `assetId`*, `forceTimeout` (ADMIN). Cascade-deletes vulnerabilities, scan results, exception requests; returns counts and audit-log id.
 - **`delete_all_assets`** — `confirm: true` (ADMIN).
+
+- **`application_register`** — unified Application Register tool via `action`:
+  - `list` (`search` optional)
+  - `get` (`id`*)
+  - `create` (`application`* object; ADMIN/SECCHAMPION, delegation required)
+  - `update` (`id`*, `application`*; ADMIN/SECCHAMPION)
+  - `delete` (`id`*; ADMIN/SECCHAMPION)
+  - `replace_assets` (`id`*, `assetIds[]`; ADMIN/SECCHAMPION)
 
 ### Vulnerabilities
 - **`get_vulnerabilities`** — `page`, `pageSize`, `cveId`, `severity[]` (`Critical|High|Medium|Low|Info`), `assetId`.

--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -95,7 +95,8 @@ class McpToolRegistry(
     @Inject private val addWorkgroupAwsAccountTool: AddWorkgroupAwsAccountTool,
     @Inject private val removeWorkgroupAwsAccountTool: RemoveWorkgroupAwsAccountTool,
     // CrowdStrike import status
-    @Inject private val getCrowdStrikeLastImportTool: GetCrowdStrikeLastImportTool
+    @Inject private val getCrowdStrikeLastImportTool: GetCrowdStrikeLastImportTool,
+    @Inject private val applicationRegisterTool: ApplicationRegisterTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -187,7 +188,8 @@ class McpToolRegistry(
             addWorkgroupAwsAccountTool,
             removeWorkgroupAwsAccountTool,
             // CrowdStrike import status
-            getCrowdStrikeLastImportTool
+            getCrowdStrikeLastImportTool,
+            applicationRegisterTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/ApplicationRegisterTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/ApplicationRegisterTool.kt
@@ -1,0 +1,121 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.ApplicationRegisterRequest
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.ApplicationRegisterService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.LocalDate
+
+@Singleton
+class ApplicationRegisterTool(
+    @Inject private val applicationRegisterService: ApplicationRegisterService
+) : McpTool {
+
+    override val name = "application_register"
+    override val description = "List/get/create/update/delete application-register entries and replace related assets"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "action" to mapOf(
+                "type" to "string",
+                "enum" to listOf("list", "get", "create", "update", "delete", "replace_assets")
+            ),
+            "id" to mapOf("type" to "number"),
+            "search" to mapOf("type" to "string"),
+            "assetIds" to mapOf("type" to "array", "items" to mapOf("type" to "number")),
+            "application" to mapOf("type" to "object")
+        ),
+        "required" to listOf("action")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled")
+
+        val action = (arguments["action"] as? String)?.trim()?.lowercase()
+            ?: return McpToolResult.error("VALIDATION_ERROR", "action is required")
+
+        return try {
+            when (action) {
+                "list" -> McpToolResult.success(applicationRegisterService.list(arguments["search"] as? String))
+                "get" -> {
+                    val id = (arguments["id"] as? Number)?.toLong()
+                        ?: return McpToolResult.error("VALIDATION_ERROR", "id is required for get")
+                    McpToolResult.success(applicationRegisterService.get(id))
+                }
+                "create" -> {
+                    ensureWriteRole(context)
+                    val req = parseRequest(arguments["application"])
+                    McpToolResult.success(applicationRegisterService.create(req, context.delegatedUsername ?: "mcp"))
+                }
+                "update" -> {
+                    ensureWriteRole(context)
+                    val id = (arguments["id"] as? Number)?.toLong()
+                        ?: return McpToolResult.error("VALIDATION_ERROR", "id is required for update")
+                    val req = parseRequest(arguments["application"])
+                    McpToolResult.success(applicationRegisterService.update(id, req, context.delegatedUsername ?: "mcp"))
+                }
+                "delete" -> {
+                    ensureWriteRole(context)
+                    val id = (arguments["id"] as? Number)?.toLong()
+                        ?: return McpToolResult.error("VALIDATION_ERROR", "id is required for delete")
+                    applicationRegisterService.delete(id)
+                    McpToolResult.success(mapOf("deleted" to true, "id" to id))
+                }
+                "replace_assets" -> {
+                    ensureWriteRole(context)
+                    val id = (arguments["id"] as? Number)?.toLong()
+                        ?: return McpToolResult.error("VALIDATION_ERROR", "id is required for replace_assets")
+                    val assetIds = (arguments["assetIds"] as? List<*>)?.mapNotNull { (it as? Number)?.toLong() }
+                        ?: emptyList()
+                    McpToolResult.success(applicationRegisterService.replaceAssets(id, assetIds, context.delegatedUsername ?: "mcp"))
+                }
+                else -> McpToolResult.error("VALIDATION_ERROR", "Unknown action '$action'")
+            }
+        } catch (e: NoSuchElementException) {
+            McpToolResult.error("NOT_FOUND", e.message ?: "Application not found")
+        } catch (e: IllegalArgumentException) {
+            McpToolResult.error("VALIDATION_ERROR", e.message ?: "Invalid input")
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to execute application_register action '$action': ${e.message}")
+        }
+    }
+
+    private fun ensureWriteRole(context: McpExecutionContext) {
+        val roles = context.delegatedUserRoles ?: emptySet()
+        if (!(context.isAdmin || roles.contains("SECCHAMPION"))) {
+            throw IllegalArgumentException("ADMIN or SECCHAMPION role required for write actions")
+        }
+    }
+
+    private fun parseRequest(raw: Any?): ApplicationRegisterRequest {
+        val map = raw as? Map<*, *> ?: throw IllegalArgumentException("application object is required")
+        fun str(key: String): String? = (map[key] as? String)
+        fun date(key: String): LocalDate? = (map[key] as? String)?.let { LocalDate.parse(it) }
+        return ApplicationRegisterRequest(
+            carId = str("carId"),
+            name = str("name") ?: throw IllegalArgumentException("application.name is required"),
+            criticality = str("criticality"),
+            operationalStatus = str("operationalStatus"),
+            businessOwner = str("businessOwner") ?: throw IllegalArgumentException("application.businessOwner is required"),
+            applicationManager = str("applicationManager") ?: throw IllegalArgumentException("application.applicationManager is required"),
+            applicationTechnology = str("applicationTechnology"),
+            applicationArchitecture = str("applicationArchitecture"),
+            lastQualityCheck = date("lastQualityCheck"),
+            informationClassification = str("informationClassification"),
+            processingOfPersonalData = str("processingOfPersonalData"),
+            icsRelevant = str("icsRelevant"),
+            applicationExportControlRelevant = str("applicationExportControlRelevant"),
+            operationModel = str("operationModel"),
+            productionOperatingHours = str("productionOperatingHours"),
+            serviceOperatingHours = str("serviceOperatingHours"),
+            backupRecoveryUrl = str("backupRecoveryUrl"),
+            incidentAssignmentGroup = str("incidentAssignmentGroup"),
+            notes = str("notes"),
+            cmdbWorkspaceUrl = str("cmdbWorkspaceUrl")
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the Application Register functionality available via MCP so automated agents can list/get/create/update/delete application-register entries and manage their linked assets.
- Keep MCP behavior aligned with the REST API by enforcing User Delegation and the same RBAC (ADMIN/SECCHAMPION for writes) to ensure consistent audit and access control.

### Description
- Added a new MCP tool `application_register` implemented in `src/backendng/src/main/kotlin/com/secman/mcp/tools/ApplicationRegisterTool.kt` that supports `action` values: `list`, `get`, `create`, `update`, `delete`, and `replace_assets`.
- Registered the new tool in `McpToolRegistry` so it is discoverable by MCP clients and included in the `tools` map returned by the registry.
- Mapped `application_register` into the `ASSETS_READ` permission family for discovery and enforced delegation plus write-role checks (`ADMIN` or `SECCHAMPION`) inside the tool using `McpExecutionContext`.
- Updated `docs/MCP.md` to document the new `application_register` tool, its `action` semantics and required parameters.

### Testing
- Attempted to compile the backend with `./gradlew :backendng:compileKotlin` which failed in this environment due to a missing Java 21 toolchain, so no successful compilation run was performed here.
- No new unit or integration tests were added in this change; tests covering MCP tools and delegated access should be added or run in CI where a Java 21 toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc3c6e8088323a364d57de4427f0d)