### PR TITLE
fix(workgroups): filter visible workgroups for non-admin users

### DIFF
--- a/src/frontend/src/components/WorkgroupManagement.tsx
+++ b/src/frontend/src/components/WorkgroupManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { authenticatedGet, authenticatedPost, authenticatedPut, authenticatedDelete } from '../utils/auth';
+import { authenticatedGet, authenticatedPost, authenticatedPut, authenticatedDelete, getUser } from '../utils/auth';
 import WorkgroupAccountsModal from './WorkgroupAccountsModal';
 
 // Extract a useful error message from a non-OK Response. Handles the three
@@ -64,6 +64,30 @@ interface AssignedAsset {
   owner: string | null;
 }
 
+
+interface UserProfileResponse {
+  workgroups?: Array<{ id?: number }>;
+}
+
+function canSeeAllWorkgroups(): boolean {
+  const roles = getUser()?.roles ?? [];
+  return roles.includes('ADMIN') || roles.includes('SECCHAMPION');
+}
+
+async function getCurrentUserWorkgroupIds(): Promise<Set<number>> {
+  const response = await authenticatedGet('/api/users/profile');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch current user profile: ${response.status}`);
+  }
+
+  const profile = await response.json() as UserProfileResponse;
+  const ids = (profile.workgroups ?? [])
+    .map(wg => wg.id)
+    .filter((id): id is number => typeof id === 'number');
+
+  return new Set(ids);
+}
+
 const WorkgroupManagement: React.FC = () => {
   const [workgroups, setWorkgroups] = useState<Workgroup[]>([]);
   const [users, setUsers] = useState<User[]>([]);
@@ -108,8 +132,14 @@ const WorkgroupManagement: React.FC = () => {
     try {
       const response = await authenticatedGet('/api/workgroups');
       if (response.ok) {
-        const data = await response.json();
-        setWorkgroups(data);
+        const data = await response.json() as Workgroup[];
+
+        if (canSeeAllWorkgroups()) {
+          setWorkgroups(data);
+        } else {
+          const currentUserWorkgroupIds = await getCurrentUserWorkgroupIds();
+          setWorkgroups(data.filter(workgroup => currentUserWorkgroupIds.has(workgroup.id)));
+        }
       } else {
         setError(`Failed to fetch workgroups: ${response.status}`);
       }

--- a/src/frontend/src/components/WorkgroupTree.tsx
+++ b/src/frontend/src/components/WorkgroupTree.tsx
@@ -1,6 +1,32 @@
 import React, { useState, useEffect } from 'react';
 import type { WorkgroupResponse } from '../services/workgroupApi';
 import { getWorkgroupChildren, getRootWorkgroups } from '../services/workgroupApi';
+import { authenticatedGet, getUser } from '../utils/auth';
+
+
+
+interface UserProfileResponse {
+  workgroups?: Array<{ id?: number }>;
+}
+
+function canSeeAllWorkgroups(): boolean {
+  const roles = getUser()?.roles ?? [];
+  return roles.includes('ADMIN') || roles.includes('SECCHAMPION');
+}
+
+async function getCurrentUserWorkgroupIds(): Promise<Set<number>> {
+  const response = await authenticatedGet('/api/users/profile');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch current user profile: ${response.status}`);
+  }
+
+  const profile = await response.json() as UserProfileResponse;
+  const ids = (profile.workgroups ?? [])
+    .map(wg => wg.id)
+    .filter((id): id is number => typeof id === 'number');
+
+  return new Set(ids);
+}
 
 /**
  * Workgroup Tree Component
@@ -184,7 +210,12 @@ const WorkgroupTree: React.FC<WorkgroupTreeProps> = ({
     setError(null);
     try {
       const roots = await getRootWorkgroups();
-      setRootWorkgroups(roots);
+      if (canSeeAllWorkgroups()) {
+        setRootWorkgroups(roots);
+      } else {
+        const currentUserWorkgroupIds = await getCurrentUserWorkgroupIds();
+        setRootWorkgroups(roots.filter(workgroup => currentUserWorkgroupIds.has(workgroup.id)));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load workgroups');
       console.error('Failed to load root workgroups:', err);


### PR DESCRIPTION
### Motivation
- Non-ADMIN and non-SECCHAMPION users should only see the workgroups they belong to in the workgroup management UIs instead of all workgroups returned by the list endpoints. This reduces information leakage and aligns the UI with backend RBAC intent.

### Description
- Added `canSeeAllWorkgroups()` and `getCurrentUserWorkgroupIds()` helpers that use `getUser()` and `GET /api/users/profile` to determine membership and roles. 
- Applied client-side filtering in `WorkgroupManagement` so that if the current user is not `ADMIN` or `SECCHAMPION`, the `/api/workgroups` response is filtered to only include workgroups whose IDs appear in the user's profile. 
- Applied the same visibility filtering to `WorkgroupTree` when loading root workgroups so tree roots are restricted for non-privileged users. 
- Updated imports to use `getUser` and `authenticatedGet` where needed. Files changed: `src/frontend/src/components/WorkgroupManagement.tsx` and `src/frontend/src/components/WorkgroupTree.tsx`.

### Testing
- Built the frontend with `cd src/frontend && npm run build` which completed successfully.
- Ran lint with `cd src/frontend && npm run lint` which failed in this environment due to an ESLint configuration mismatch (ESLint v9 expecting `eslint.config.*`), not due to the code changes.
- No backend/schema changes were made, and the update is limited to frontend UI filtering behavior only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd209f020832384f0494087fcc28c)