### PR TITLE
Use ID-based asset access helpers and optimize callers for performance

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/AccessibleAssetIdsCache.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AccessibleAssetIdsCache.kt
@@ -46,9 +46,7 @@ open class AccessibleAssetIdsCache(
         if (cachedSnapshot != null && cachedForUserId == currentUserId) {
             return cachedSnapshot
         }
-        val ids = assetFilterService.getAccessibleAssets(authentication)
-            .mapNotNull { it.id }
-            .toSet()
+        val ids = assetFilterService.getAccessibleAssetIds(authentication)
         cached = ids
         cachedForUserId = currentUserId
         return ids

--- a/src/backendng/src/main/kotlin/com/secman/service/AssetFilterService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AssetFilterService.kt
@@ -88,6 +88,19 @@ open class AssetFilterService(
     }
 
     /**
+     * Get asset IDs accessible to the authenticated user.
+     *
+     * This helper avoids repeatedly materializing full Asset entities for call sites
+     * that only need membership checks or `IN (:assetIds)` filtering.
+     */
+    fun getAccessibleAssetIds(authentication: Authentication): Set<Long> {
+        if (hasRole(authentication, "ADMIN") || hasRole(authentication, "SECCHAMPION")) {
+            return assetRepository.findAll().mapNotNull { it.id }.toSet()
+        }
+        return getAccessibleAssets(authentication).mapNotNull { it.id }.toSet()
+    }
+
+    /**
      * Get accessible assets using unified single-query approach
      * Feature 073: Combines all access criteria in one database round trip.
      *
@@ -188,13 +201,12 @@ open class AssetFilterService(
             return vulnerabilityRepository.findAll()
         }
 
-        // Regular users and VULN: filter by asset accessibility
-        val userId = getUserId(authentication)
-        return vulnerabilityRepository.findByAssetWorkgroupsUsersIdOrAssetManualCreatorIdOrAssetScanUploaderIdOrderByScanTimestampDesc(
-            userId = userId,
-            manualCreatorId = userId,
-            scanUploaderId = userId
-        )
+        // Regular users and VULN: filter by unified asset accessibility rules.
+        val accessibleAssetIds = getAccessibleAssetIds(authentication)
+        if (accessibleAssetIds.isEmpty()) {
+            return emptyList()
+        }
+        return vulnerabilityRepository.findLatestVulnerabilitiesForAssetIds(accessibleAssetIds)
     }
 
     /**
@@ -261,8 +273,7 @@ open class AssetFilterService(
         }
 
         // Check if asset is in user's accessible assets
-        val accessibleAssets = getAccessibleAssets(authentication)
-        return accessibleAssets.any { it.id == assetId }
+        return getAccessibleAssetIds(authentication).contains(assetId)
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Reduce memory and allocation overhead by avoiding repeated materialization of full `Asset` entities when only IDs are needed. 
- Centralize asset-ID retrieval logic to support more efficient DB filtering (e.g. `IN (:assetIds)`) and simpler access checks.
- Improve performance of vulnerability and access-check paths by short-circuiting empty results.

### Description

- Added `getAccessibleAssetIds(authentication): Set<Long>` to `AssetFilterService` to return accessible asset IDs and handle admin/SECCHAMPION cases directly. 
- Updated `AccessibleAssetIdsCache.get` to use `assetFilterService.getAccessibleAssetIds(authentication)` instead of mapping full `Asset` objects to IDs. 
- Switched `getAccessibleVulnerabilities` to compute `accessibleAssetIds` and call `vulnerabilityRepository.findLatestVulnerabilitiesForAssetIds(accessibleAssetIds)`, with an early return when the ID set is empty. 
- Changed `canAccessAsset` to check membership using `getAccessibleAssetIds(authentication).contains(assetId)` instead of scanning full `Asset` lists.

### Testing

- Ran the test suite with `./gradlew test` and all tests completed successfully. 
- Performed a full build with `./gradlew build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de48cbef88323b4fb66003545cb6b)