### PR TITLE
fix(application-register): rename CAR ID to AppID in UI

### DIFF
--- a/src/frontend/src/components/ApplicationRegister.tsx
+++ b/src/frontend/src/components/ApplicationRegister.tsx
@@ -560,7 +560,7 @@ const ApplicationRegister: React.FC = () => {
             <form onSubmit={save}>
               <div className="row g-3">
                 <div className="col-md-3">
-                  <label className="form-label">CAR ID</label>
+                  <label className="form-label">AppID</label>
                   <input className="form-control" value={selected?.carId || 'Allocated on save'} disabled />
                 </div>
                 <div className="col-md-5">
@@ -735,7 +735,7 @@ const ApplicationRegister: React.FC = () => {
                   className="form-control"
                   value={search}
                   onChange={(event) => setSearch(event.target.value)}
-                  placeholder="Name, CAR ID, owner, manager, status"
+                  placeholder="Name, AppID, owner, manager, status"
                 />
                 <button className="btn btn-outline-secondary" onClick={() => setSearch('')} disabled={!search}>
                   Clear
@@ -780,7 +780,7 @@ const ApplicationRegister: React.FC = () => {
             <table className="table table-striped table-hover align-middle">
               <thead>
                 <tr>
-                  <th>CAR ID</th>
+                  <th>AppID</th>
                   <th>Name</th>
                   <th>Ownership</th>
                   <th>Status</th>


### PR DESCRIPTION
### Motivation
- Update user-facing wording in the Application Register to use the requested identifier name `AppID` instead of `CAR ID` for consistency and clarity.

### Description
- Replaced `CAR ID` with `AppID` in the Application Register UI in `src/frontend/src/components/ApplicationRegister.tsx` (form label, search placeholder, and table header); no backend or DB schema changes were made.

### Testing
- Ran frontend lint: `cd src/frontend && npm run lint`, which failed due to the repository ESLint v9 configuration error (missing `eslint.config.*`), an existing config issue unrelated to this text-only change; no other automated tests were run for this trivial UI text update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f379952d48323af703615c300fcd2)