### PR TITLE
feat(frontend): professional home statistics dashboard on start page

### DIFF
--- a/src/frontend/src/components/HomeStatisticsDashboard.tsx
+++ b/src/frontend/src/components/HomeStatisticsDashboard.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { authenticatedGet, getUser, hasRole } from '../utils/auth';
+
+type StatItem = {
+  label: string;
+  value: string;
+  subtitle: string;
+  icon: string;
+};
+
+type DashboardState = {
+  assets: number | null;
+  users: number | null;
+  runningAssessments: number | null;
+  releases: number | null;
+  lastCrowdStrikeCheckin: string | null;
+};
+
+const initialState: DashboardState = {
+  assets: null,
+  users: null,
+  runningAssessments: null,
+  releases: null,
+  lastCrowdStrikeCheckin: null
+};
+
+const formatDateTime = (isoOrNever: string): string => {
+  if (isoOrNever === 'never') return 'Never imported';
+  const parsed = new Date(isoOrNever);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown';
+  return parsed.toLocaleString();
+};
+
+const formatCount = (value: number | null): string => {
+  if (value == null) return '—';
+  return new Intl.NumberFormat().format(value);
+};
+
+const HomeStatisticsDashboard: React.FC = () => {
+  const [stats, setStats] = useState<DashboardState>(initialState);
+
+  useEffect(() => {
+    const load = async () => {
+      const next: DashboardState = { ...initialState };
+
+      try {
+        const assetsResp = await authenticatedGet('/api/assets');
+        if (assetsResp.ok) {
+          const assets = await assetsResp.json();
+          next.assets = Array.isArray(assets) ? assets.length : null;
+        }
+      } catch (error) {
+        console.error('Failed to load asset statistics:', error);
+      }
+
+      try {
+        const assessmentsResp = await authenticatedGet('/api/risk-assessments');
+        if (assessmentsResp.ok) {
+          const assessments = await assessmentsResp.json();
+          if (Array.isArray(assessments)) {
+            next.runningAssessments = assessments.filter(a => a?.status === 'IN_PROGRESS').length;
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load risk assessment statistics:', error);
+      }
+
+      try {
+        const releasesResp = await authenticatedGet('/api/releases');
+        if (releasesResp.ok) {
+          const releases = await releasesResp.json();
+          next.releases = Array.isArray(releases) ? releases.length : null;
+        }
+      } catch (error) {
+        console.error('Failed to load release statistics:', error);
+      }
+
+      try {
+        const csResp = await authenticatedGet('/api/crowdstrike/last-checkin');
+        if (csResp.ok) {
+          next.lastCrowdStrikeCheckin = formatDateTime((await csResp.text()).trim());
+        }
+      } catch (error) {
+        console.error('Failed to load CrowdStrike check-in statistics:', error);
+      }
+
+      if (hasRole('ADMIN')) {
+        try {
+          const usersResp = await authenticatedGet('/api/users');
+          if (usersResp.ok) {
+            const users = await usersResp.json();
+            next.users = Array.isArray(users) ? users.length : null;
+          }
+        } catch (error) {
+          console.error('Failed to load user statistics:', error);
+        }
+      }
+
+      setStats(next);
+    };
+
+    void load();
+  }, []);
+
+  const isAdmin = useMemo(() => hasRole('ADMIN'), []);
+  const userName = getUser()?.username ?? 'there';
+
+  const cards: StatItem[] = [
+    { label: 'Systems in Asset Inventory', value: formatCount(stats.assets), subtitle: 'Visible to your role', icon: 'bi-hdd-network' },
+    { label: 'Active Standard Releases', value: formatCount(stats.releases), subtitle: 'All release records', icon: 'bi-journals' },
+    { label: 'Running Risk Assessments', value: formatCount(stats.runningAssessments), subtitle: 'Status: IN_PROGRESS', icon: 'bi-clipboard2-pulse' },
+    { label: 'Last CrowdStrike Import', value: stats.lastCrowdStrikeCheckin ?? '—', subtitle: 'Most recent server check-in', icon: 'bi-shield-check' }
+  ];
+
+  if (isAdmin) {
+    cards.splice(1, 0, {
+      label: 'Users',
+      value: formatCount(stats.users),
+      subtitle: 'Registered user accounts',
+      icon: 'bi-people'
+    });
+  }
+
+  return (
+    <section className="container-fluid py-4 px-4 px-lg-5">
+      <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-end mb-4 gap-2">
+        <div>
+          <h1 className="display-6 fw-semibold mb-1">Welcome back, {userName}</h1>
+          <p className="text-muted mb-0">Security posture at a glance</p>
+        </div>
+      </div>
+
+      <div className="row g-4">
+        {cards.map((card) => (
+          <div className="col-12 col-md-6 col-xl-4" key={card.label}>
+            <article className="card border-0 shadow-sm h-100">
+              <div className="card-body p-4">
+                <div className="d-flex justify-content-between align-items-start mb-3">
+                  <h2 className="h6 text-muted text-uppercase mb-0" style={{ letterSpacing: '0.04em' }}>{card.label}</h2>
+                  <i className={`bi ${card.icon} fs-4 text-primary`} aria-hidden="true"></i>
+                </div>
+                <p className="display-6 fw-bold mb-2">{card.value}</p>
+                <p className="text-muted mb-0">{card.subtitle}</p>
+              </div>
+            </article>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default HomeStatisticsDashboard;

--- a/src/frontend/src/components/Welcome.astro
+++ b/src/frontend/src/components/Welcome.astro
@@ -1,16 +1,4 @@
 ---
+import HomeStatisticsDashboard from './HomeStatisticsDashboard';
 ---
-<div class="container-fluid p-5">
-    <div class="row justify-content-center">
-        <div class="col-md-8 text-center">
-            <div class="mb-4">
-                <img src="/SecManLogo.png" alt="SecMan" height="120" class="mb-3" />
-                <h1 class="display-4">Welcome to SecMan</h1>
-            </div>
-            <p class="lead mb-4">
-                Security Management System for your organization.
-                Use the sidebar navigation to access different features.
-            </p>
-        </div>
-    </div>
-</div>
+<HomeStatisticsDashboard client:load />


### PR DESCRIPTION
### Motivation
- The existing post-login start page was a static welcome banner and lacked an at-a-glance operational view. 
- Users need a professional-looking KPI summary (assets, users, running risk assessments, releases, CrowdStrike import time) immediately after login.

### Description
- Added a React dashboard component `src/frontend/src/components/HomeStatisticsDashboard.tsx` that queries existing APIs and renders polished KPI cards. 
- Replaced the static start markup by mounting the new dashboard from `src/frontend/src/components/Welcome.astro` using a client island (`client:load`).
- Dashboard loads counts from `/api/assets`, `/api/risk-assessments` (counts `IN_PROGRESS`), `/api/releases`, `/api/crowdstrike/last-checkin`, and shows `/api/users` only for `ADMIN` users to preserve RBAC expectations. 
- UX details include graceful fallbacks (`—`, `Never imported`, `Unknown`), number formatting, Bootstrap card/grid layout and icons, and defensive error logging (no backend/schema changes). 

### Testing
- Frontend build succeeded: ran `cd src/frontend && npm run build` and the build completed successfully. 
- Lint step failed in this environment: `cd src/frontend && npm run lint` errors out due to the repository ESLint v9 flat-config expectation (`eslint.config.*` not present) and needs repo-wide lint config alignment. 
- Mandatory post-change E2E gates (`/e2ejs` and `/e2evulnexception`) have not been executed in this rollout and must be run and pass (0 failures) before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f393223c08323925ee9f60f4ec849)