### PR TITLE
fix(workgroups): restrict edits/deletes to ADMIN or SECCHAMPION

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
@@ -60,6 +60,9 @@ open class WorkgroupController(
     private fun isAdmin(authentication: Authentication): Boolean =
         authentication.roles.contains("ADMIN")
 
+    private fun canManageWorkgroup(authentication: Authentication): Boolean =
+        isAdmin(authentication) || authentication.roles.contains("SECCHAMPION")
+
     /**
      * Resolve the calling User from the Authentication principal.
      * @throws IllegalStateException if no matching user row exists (should not happen for an authenticated request).
@@ -252,8 +255,8 @@ open class WorkgroupController(
         authentication: Authentication
     ): HttpResponse<*> {
         return try {
-            val existing = workgroupService.getWorkgroupById(id)
-            if (!isMemberOrAdmin(existing, authentication)) {
+            workgroupService.getWorkgroupById(id)
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status<Any>(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             val workgroup = workgroupService.updateWorkgroup(
@@ -290,22 +293,13 @@ open class WorkgroupController(
         authentication: Authentication
     ): HttpResponse<Void> {
         return try {
-            val workgroup = workgroupService.getWorkgroupById(id)
-            if (isAdmin(authentication)) {
-                // Admin retains the legacy "promote children to grandparent" semantics
-                // so hierarchy continuity is preserved across organizational re-shuffles.
-                workgroupService.deleteWorkgroupWithPromotion(id)
-                return HttpResponse.noContent()
-            }
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            workgroupService.getWorkgroupById(id)
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
-            // Non-admin members may not delete a parent workgroup — promoting children
-            // could re-parent them under a workgroup the deleter cannot see.
-            if (workgroup.children.isNotEmpty()) {
-                return HttpResponse.badRequest()
-            }
-            workgroupService.deleteWorkgroup(id)
+            // Privileged users retain the legacy "promote children to grandparent" semantics
+            // so hierarchy continuity is preserved across organizational re-shuffles.
+            workgroupService.deleteWorkgroupWithPromotion(id)
             HttpResponse.noContent()
         } catch (e: IllegalArgumentException) {
             HttpResponse.notFound()
@@ -340,8 +334,8 @@ open class WorkgroupController(
             // would already be committed and orphaned.
             val workgroup = workgroupRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound<Any>()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
-                return HttpResponse.status<Any>(io.micronaut.http.HttpStatus.FORBIDDEN)
+            if (!canManageWorkgroup(authentication)) {
+                return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
 
             // Domain restriction: non-admin callers can only lazy-create new pending users
@@ -450,7 +444,7 @@ open class WorkgroupController(
         return try {
             val workgroup = workgroupRepository.findById(workgroupId).orElse(null)
                 ?: return HttpResponse.notFound()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             workgroupService.removeUserFromWorkgroup(workgroupId, userId)
@@ -487,7 +481,7 @@ open class WorkgroupController(
             }
             val workgroup = workgroupRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             val removedCount = workgroupService.removeUsersFromWorkgroup(id, request.userIds)
@@ -524,7 +518,7 @@ open class WorkgroupController(
         return try {
             val workgroup = workgroupRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             workgroupService.assignAssetsToWorkgroup(id, request.assetIds)
@@ -598,7 +592,7 @@ open class WorkgroupController(
             }
             val workgroup = workgroupRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             val removedCount = workgroupService.removeAssetsFromWorkgroup(id, request.assetIds)
@@ -634,7 +628,7 @@ open class WorkgroupController(
         return try {
             val workgroup = workgroupRepository.findById(workgroupId).orElse(null)
                 ?: return HttpResponse.notFound()
-            if (!isMemberOrAdmin(workgroup, authentication)) {
+            if (!canManageWorkgroup(authentication)) {
                 return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
             }
             workgroupService.removeAssetFromWorkgroup(workgroupId, assetId)


### PR DESCRIPTION
### Motivation
- Prevent non-privileged workgroup members from mutating workgroup data (edits, deletes, user/asset assignments) by limiting those operations to privileged roles.

### Description
- Added a new authorization helper `canManageWorkgroup(authentication)` that returns true for `ADMIN` or `SECCHAMPION` in `WorkgroupController` (`src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt`).
- Replaced member-driven guards with `canManageWorkgroup(...)` on mutation endpoints so only privileged roles can perform `PUT /api/workgroups/{id}`, `DELETE /api/workgroups/{id}`, and the user/asset assignment and removal endpoints under `/api/workgroups/{id}/users` and `/api/workgroups/{id}/assets`.
- Retained existing member-visible behavior for read endpoints (`GET` detail/list/users/assets) so visibility is unchanged.
- No schema or dependency changes.

### Testing
- Attempted an automated compile with `./gradlew :backendng:compileKotlin`, which could not run to completion in this environment because the Java 21 toolchain is not available, so no unit/integration tests were executed.
- No other automated test runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fdd96902083239812b246aaefe19f)