### PR TITLE
feat(app-settings): make AI risk model configurable via admin UI

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/AppSettingsController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AppSettingsController.kt
@@ -42,7 +42,9 @@ open class AppSettingsController(
         @field:NotBlank(message = "Base URL is required")
         val baseUrl: String,
         val globalCveApprovalAdminOnly: Boolean = false,
-        val aiRiskAssessmentEnabled: Boolean = false
+        val aiRiskAssessmentEnabled: Boolean = false,
+        @field:NotBlank(message = "AI risk-assessment model is required")
+        val aiRiskAssessmentModel: String = "anthropic/claude-sonnet-4.6:online"
     )
 
     /**
@@ -104,7 +106,8 @@ open class AppSettingsController(
                 baseUrl = request.baseUrl,
                 updatedBy = username,
                 globalCveApprovalAdminOnly = request.globalCveApprovalAdminOnly,
-                aiRiskAssessmentEnabled = request.aiRiskAssessmentEnabled
+                aiRiskAssessmentEnabled = request.aiRiskAssessmentEnabled,
+                aiRiskAssessmentModel = request.aiRiskAssessmentModel
             )
 
             logger.info("Application settings updated successfully by user '{}'", username)

--- a/src/backendng/src/main/kotlin/com/secman/domain/AppSettings.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/AppSettings.kt
@@ -46,6 +46,13 @@ data class AppSettings(
     var aiRiskAssessmentEnabled: Boolean = false,
 
     /**
+     * OpenRouter model id used for AI-assisted risk-assessment answers.
+     * Example: anthropic/claude-sonnet-4.6:online
+     */
+    @Column(nullable = false, length = 255, name = "ai_risk_assessment_model")
+    var aiRiskAssessmentModel: String = "anthropic/claude-sonnet-4.6:online",
+
+    /**
      * Username of ADMIN who last updated these settings
      */
     @Column(nullable = true, length = 100, name = "updated_by")

--- a/src/backendng/src/main/kotlin/com/secman/service/AppSettingsService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AppSettingsService.kt
@@ -2,6 +2,7 @@ package com.secman.service
 
 import com.secman.domain.AppSettings
 import com.secman.repository.AppSettingsRepository
+import com.secman.config.AiRiskAssessmentConfig
 import io.micronaut.context.annotation.Value
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.inject.Singleton
@@ -14,7 +15,8 @@ import org.slf4j.LoggerFactory
  */
 @Singleton
 open class AppSettingsService(
-    private val appSettingsRepository: AppSettingsRepository
+    private val appSettingsRepository: AppSettingsRepository,
+    private val aiRiskAssessmentConfig: AiRiskAssessmentConfig
 ) {
     private val logger = LoggerFactory.getLogger(AppSettingsService::class.java)
 
@@ -34,6 +36,7 @@ open class AppSettingsService(
         val baseUrl: String,
         val globalCveApprovalAdminOnly: Boolean,
         val aiRiskAssessmentEnabled: Boolean,
+        val aiRiskAssessmentModel: String,
         val updatedBy: String?,
         val updatedAt: String?
     )
@@ -49,6 +52,7 @@ open class AppSettingsService(
             baseUrl = settings.getNormalizedBaseUrl(),
             globalCveApprovalAdminOnly = settings.globalCveApprovalAdminOnly,
             aiRiskAssessmentEnabled = settings.aiRiskAssessmentEnabled,
+            aiRiskAssessmentModel = settings.aiRiskAssessmentModel,
             updatedBy = settings.updatedBy,
             updatedAt = settings.updatedAt?.toString()
         )
@@ -62,6 +66,11 @@ open class AppSettingsService(
     @Transactional
     open fun isAiRiskAssessmentEnabled(): Boolean {
         return getOrCreateSettings().aiRiskAssessmentEnabled
+    }
+
+    @Transactional
+    open fun getAiRiskAssessmentModel(): String {
+        return getOrCreateSettings().aiRiskAssessmentModel
     }
 
     /**
@@ -96,7 +105,8 @@ open class AppSettingsService(
         baseUrl: String,
         updatedBy: String,
         globalCveApprovalAdminOnly: Boolean = false,
-        aiRiskAssessmentEnabled: Boolean = false
+        aiRiskAssessmentEnabled: Boolean = false,
+        aiRiskAssessmentModel: String = aiRiskAssessmentConfig.model
     ): AppSettingsDto {
         val settings = getOrCreateSettings()
 
@@ -104,7 +114,12 @@ open class AppSettingsService(
         settings.baseUrl = baseUrl.trimEnd('/')
         settings.globalCveApprovalAdminOnly = globalCveApprovalAdminOnly
         settings.aiRiskAssessmentEnabled = aiRiskAssessmentEnabled
+        settings.aiRiskAssessmentModel = aiRiskAssessmentModel.trim()
         settings.updatedBy = updatedBy
+
+        if (settings.aiRiskAssessmentModel.isBlank()) {
+            throw IllegalArgumentException("AI risk-assessment model cannot be empty")
+        }
 
         // Validate
         val errors = settings.validateBaseUrl()
@@ -122,6 +137,7 @@ open class AppSettingsService(
             baseUrl = updated.getNormalizedBaseUrl(),
             globalCveApprovalAdminOnly = updated.globalCveApprovalAdminOnly,
             aiRiskAssessmentEnabled = updated.aiRiskAssessmentEnabled,
+            aiRiskAssessmentModel = updated.aiRiskAssessmentModel,
             updatedBy = updated.updatedBy,
             updatedAt = updated.updatedAt?.toString()
         )
@@ -140,6 +156,7 @@ open class AppSettingsService(
             val default = AppSettings(
                 baseUrl = defaultBaseUrl,
                 aiRiskAssessmentEnabled = aiRiskAssessmentDefault,
+                aiRiskAssessmentModel = aiRiskAssessmentConfig.model,
                 updatedBy = "system"
             )
             appSettingsRepository.save(default)

--- a/src/backendng/src/main/kotlin/com/secman/service/ComplianceAssistantService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ComplianceAssistantService.kt
@@ -122,7 +122,7 @@ open class ComplianceAssistantService(
      * before any HTTP call.
      */
     fun estimateCostUsd(requirementCount: Int): BigDecimal {
-        val pricing = config.pricingPer1kTokens[config.model]
+        val pricing = config.pricingPer1kTokens[currentModel]
         val inPer1k = pricing?.input ?: 0.005   // conservative default
         val outPer1k = pricing?.output ?: 0.020 // conservative default
         val perReq = (config.tokenEstimate.inputPerRequirement * inPer1k +
@@ -131,7 +131,7 @@ open class ComplianceAssistantService(
     }
 
     val currentPromptVersion: String get() = promptVersion
-    val currentModel: String get() = config.model
+    val currentModel: String get() = appSettingsService.getAiRiskAssessmentModel()
 
     /**
      * Produce a suggestion for the given requirement, asynchronously on the
@@ -149,7 +149,7 @@ open class ComplianceAssistantService(
         }
 
         val userPrompt = promptBuilder.build(requirement, context)
-        val cacheKey = hashKey(systemPrompt, userPrompt, config.model)
+        val cacheKey = hashKey(systemPrompt, userPrompt, currentModel)
         cache.getIfPresent(cacheKey)?.let {
             log.debug("Cache hit for requirement={} key={}", requirement.id, cacheKey.take(12))
             return CompletableFuture.completedFuture(it.copy(cacheHit = true))
@@ -181,7 +181,7 @@ open class ComplianceAssistantService(
 
     private fun doSuggestBlocking(userPrompt: String): SuggestionResult {
         val body = ChatRequest(
-            model = config.model,
+            model = currentModel,
             messages = listOf(
                 mapOf("role" to "system", "content" to systemPrompt),
                 mapOf("role" to "user", "content" to userPrompt)
@@ -266,7 +266,7 @@ open class ComplianceAssistantService(
             rawConfidence = raw,
             confidenceBand = band,
             citations = cleaned,
-            model = root.path("model").asText(config.model).ifBlank { config.model },
+            model = root.path("model").asText(currentModel).ifBlank { currentModel },
             promptVersion = promptVersion,
             inputTokens = inputTokens,
             outputTokens = outputTokens,
@@ -290,7 +290,7 @@ open class ComplianceAssistantService(
     }
 
     private fun computeCost(inputTokens: Int?, outputTokens: Int?): BigDecimal? {
-        val pricing = config.pricingPer1kTokens[config.model] ?: return null
+        val pricing = config.pricingPer1kTokens[currentModel] ?: return null
         val inCost = (inputTokens ?: 0) * pricing.input / 1000.0
         val outCost = (outputTokens ?: 0) * pricing.output / 1000.0
         return BigDecimal.valueOf(inCost + outCost).setScale(6, RoundingMode.HALF_UP)

--- a/src/backendng/src/main/resources/db/migration/V227__app_settings_ai_risk_assessment_model.sql
+++ b/src/backendng/src/main/resources/db/migration/V227__app_settings_ai_risk_assessment_model.sql
@@ -1,0 +1,4 @@
+-- Feature 088 follow-up: make AI risk-assessment model runtime-configurable
+-- from Admin UI by persisting the OpenRouter model id in app_settings.
+ALTER TABLE app_settings
+    ADD COLUMN ai_risk_assessment_model VARCHAR(255) NOT NULL DEFAULT 'anthropic/claude-sonnet-4.6:online';

--- a/src/backendng/src/test/kotlin/com/secman/service/AppSettingsServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AppSettingsServiceTest.kt
@@ -1,0 +1,67 @@
+package com.secman.service
+
+import com.secman.config.AiRiskAssessmentConfig
+import com.secman.domain.AppSettings
+import com.secman.repository.AppSettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class AppSettingsServiceTest {
+    private val repository: AppSettingsRepository = mockk()
+    private val config = AiRiskAssessmentConfig(model = "openai/gpt-4.1")
+    private val service = AppSettingsService(repository, config)
+
+    @Test
+    fun `get settings returns persisted ai model`() {
+        every { repository.findAll() } returns listOf(
+            AppSettings(
+                id = 1L,
+                baseUrl = "https://secman.example.com",
+                aiRiskAssessmentEnabled = true,
+                aiRiskAssessmentModel = "anthropic/claude-sonnet-4.6:online",
+                updatedBy = "admin"
+            )
+        )
+
+        val dto = service.getSettings()
+
+        assertEquals("anthropic/claude-sonnet-4.6:online", dto.aiRiskAssessmentModel)
+    }
+
+    @Test
+    fun `update settings persists ai model`() {
+        val existing = AppSettings(id = 1L, baseUrl = "https://secman.example.com", updatedBy = "system")
+        every { repository.findAll() } returns listOf(existing)
+        val captured = slot<AppSettings>()
+        every { repository.update(capture(captured)) } answers { captured.captured }
+
+        val updated = service.updateSettings(
+            baseUrl = "https://secman.example.com",
+            updatedBy = "admin",
+            aiRiskAssessmentEnabled = true,
+            aiRiskAssessmentModel = "openai/gpt-4.1"
+        )
+
+        assertEquals("openai/gpt-4.1", updated.aiRiskAssessmentModel)
+        assertEquals("openai/gpt-4.1", captured.captured.aiRiskAssessmentModel)
+        verify(exactly = 1) { repository.update(any()) }
+    }
+
+    @Test
+    fun `update settings rejects blank ai model`() {
+        every { repository.findAll() } returns listOf(AppSettings(id = 1L, baseUrl = "https://secman.example.com"))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            service.updateSettings(
+                baseUrl = "https://secman.example.com",
+                updatedBy = "admin",
+                aiRiskAssessmentModel = "   "
+            )
+        }
+    }
+}

--- a/src/frontend/src/components/AppSettingsAdmin.tsx
+++ b/src/frontend/src/components/AppSettingsAdmin.tsx
@@ -23,6 +23,7 @@ const AppSettingsAdmin: React.FC = () => {
   const [baseUrl, setBaseUrl] = useState('');
   const [globalCveApprovalAdminOnly, setGlobalCveApprovalAdminOnly] = useState(false);
   const [aiRiskAssessmentEnabled, setAiRiskAssessmentEnabled] = useState(false);
+  const [aiRiskAssessmentModel, setAiRiskAssessmentModel] = useState('');
 
   // Load settings on component mount
   useEffect(() => {
@@ -42,6 +43,7 @@ const AppSettingsAdmin: React.FC = () => {
       setBaseUrl(data.baseUrl);
       setGlobalCveApprovalAdminOnly(data.globalCveApprovalAdminOnly);
       setAiRiskAssessmentEnabled(data.aiRiskAssessmentEnabled);
+      setAiRiskAssessmentModel(data.aiRiskAssessmentModel);
     } catch (err) {
       console.error('[AppSettingsAdmin] Failed to load settings:', err);
       const errorMessage = err instanceof Error ? err.message : 'Failed to load application settings';
@@ -78,13 +80,15 @@ const AppSettingsAdmin: React.FC = () => {
       const updatedSettings = await updateAppSettings(
         baseUrl.replace(/\/$/, ''),
         globalCveApprovalAdminOnly,
-        aiRiskAssessmentEnabled
+        aiRiskAssessmentEnabled,
+        aiRiskAssessmentModel.trim()
       );
 
       console.log('[AppSettingsAdmin] Settings saved successfully:', updatedSettings);
       setSettings(updatedSettings);
       setBaseUrl(updatedSettings.baseUrl);
       setAiRiskAssessmentEnabled(updatedSettings.aiRiskAssessmentEnabled);
+      setAiRiskAssessmentModel(updatedSettings.aiRiskAssessmentModel);
       setSuccessMessage('Settings saved successfully!');
 
       // Clear success message after 3 seconds
@@ -188,6 +192,25 @@ const AppSettingsAdmin: React.FC = () => {
             <small className="form-text text-muted">
               The base URL of your SecMan installation. This is used for generating links in email
               notifications. Example: <code>https://secman.example.com</code>
+            </small>
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="aiRiskAssessmentModel" className="form-label">
+              <strong>OpenRouter Model for AI Risk Assessment</strong>
+            </label>
+            <input
+              type="text"
+              className="form-control"
+              id="aiRiskAssessmentModel"
+              value={aiRiskAssessmentModel}
+              onChange={(e) => setAiRiskAssessmentModel(e.target.value)}
+              disabled={saving}
+              placeholder="anthropic/claude-sonnet-4.6:online"
+              required
+            />
+            <small className="form-text text-muted">
+              OpenRouter model id used by the AI pre-fill feature. Example: <code>anthropic/claude-sonnet-4.6:online</code>
             </small>
           </div>
 

--- a/src/frontend/src/services/appSettingsService.ts
+++ b/src/frontend/src/services/appSettingsService.ts
@@ -21,6 +21,7 @@ export interface AppSettingsDto {
   /** Feature 088: AI-assisted risk-assessment master switch. When false the
    *  "AI Pre-fill" button is hidden and all /ai-suggestions endpoints 403. */
   aiRiskAssessmentEnabled: boolean;
+  aiRiskAssessmentModel: string;
 
   /** Username of admin who last updated settings */
   updatedBy: string | null;
@@ -82,12 +83,13 @@ export async function getAppSettings(): Promise<AppSettingsDto> {
 export async function updateAppSettings(
   baseUrl: string,
   globalCveApprovalAdminOnly: boolean,
-  aiRiskAssessmentEnabled: boolean
+  aiRiskAssessmentEnabled: boolean,
+  aiRiskAssessmentModel: string
 ): Promise<AppSettingsDto> {
-  console.log('[appSettingsService] updateAppSettings called with:', { baseUrl, globalCveApprovalAdminOnly, aiRiskAssessmentEnabled });
+  console.log('[appSettingsService] updateAppSettings called with:', { baseUrl, globalCveApprovalAdminOnly, aiRiskAssessmentEnabled, aiRiskAssessmentModel });
   console.log('[appSettingsService] Making authenticated PUT to /api/settings/app');
 
-  const response = await authenticatedPut('/api/settings/app', { baseUrl, globalCveApprovalAdminOnly, aiRiskAssessmentEnabled });
+  const response = await authenticatedPut('/api/settings/app', { baseUrl, globalCveApprovalAdminOnly, aiRiskAssessmentEnabled, aiRiskAssessmentModel });
 
   console.log('[appSettingsService] Response received:', {
     ok: response.ok,


### PR DESCRIPTION
### Motivation
- Admins needed the ability to choose which OpenRouter model is used for AI-assisted risk-assessment pre-fill without a code change or redeploy.  
- Persisting the model in `app_settings` lets operators change models at runtime via the existing App Settings UI while preserving the feature toggle and API-key gating semantics.

### Description
- Added `ai_risk_assessment_model` to the `app_settings` entity with a Flyway migration `V227__app_settings_ai_risk_assessment_model.sql` and default `'anthropic/claude-sonnet-4.6:online'`.  
- Extended `AppSettings` and `AppSettingsService` to persist, validate (non-blank), return, and initialize the OpenRouter model, and added `getAiRiskAssessmentModel()`.  
- Wired `ComplianceAssistantService` to use the DB-backed model for the OpenRouter request payload, cache key, pricing lookup, and cost estimation (via `AppSettingsService.getAiRiskAssessmentModel()`).  
- Updated the Admin UI (`AppSettingsAdmin.tsx`) and frontend service (`appSettingsService.ts`) to display and save the new `aiRiskAssessmentModel` field in `/api/settings/app`.  
- Added unit tests (`AppSettingsServiceTest`) covering persistence and validation of the new model field.

### Testing
- Ran the backend unit tests for the changed service with `./gradlew :backendng:test --tests "*AppSettingsServiceTest*"`, which completed successfully (`BUILD SUCCESSFUL`).  
- Executed the frontend linter with `cd src/frontend && npm run lint`, which failed in this environment due to ESLint v10 requiring `eslint.config.*` (this is unrelated to the functional change and reflects the local lint config mismatch).  
- The change includes a Flyway migration (`V227`) so existing deployments will receive the default model automatically and can override it from the Admin UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e8804ca88323b9be2d5d65cc80a8)