### PR TITLE
fix(vulns): scope SECCHAMPION vulnerability overview to accessible assets

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
@@ -136,8 +136,8 @@ open class VulnerabilityManagementController(
             log.debug("Getting current vulnerabilities for user: {} - severity: {}, system: {}, exceptionStatus: {} (effective: {}), product: {}, adDomain: {}, cloudAccountId: {}, page: {}, size: {}",
                 authentication.name, severity, system, exceptionStatus, effectiveExceptionStatus, product, adDomain, cloudAccountId, pageNumber, pageSize)
 
-            // Check if user has universal access (ADMIN or SECCHAMPION)
-            val isAdmin = authentication.roles.contains("ADMIN") || authentication.roles.contains("SECCHAMPION")
+            // Only ADMIN has universal access; SECCHAMPION must still be scoped to accessible assets
+            val isAdmin = authentication.roles.contains("ADMIN")
 
             // Get accessible asset IDs (only needed for non-ADMIN users)
             // PERFORMANCE: For ADMIN users, we skip this query entirely.

--- a/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
@@ -140,7 +140,8 @@ open class ExportJobService(
 
         // Start async processing using ExecutorService
         // We need to capture the authentication info since Authentication may not be available in background thread
-        val isAdmin = authentication.roles.contains("ADMIN") || authentication.roles.contains("SECCHAMPION")
+        // Only ADMIN can bypass asset scoping in vulnerability exports.
+        val isAdmin = authentication.roles.contains("ADMIN")
         val accessibleAssetIds = if (isAdmin) {
             emptySet()
         } else {

--- a/src/backendng/src/test/kotlin/com/secman/integration/VulnerabilityIntegrationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/integration/VulnerabilityIntegrationTest.kt
@@ -50,6 +50,7 @@ class VulnerabilityIntegrationTest : BaseIntegrationTest() {
     private lateinit var adminUser: User
     private lateinit var vulnUser: User
     private lateinit var regularUser: User
+    private lateinit var secChampionUser: User
 
     @BeforeEach
     fun setupTestUsers() {
@@ -65,6 +66,10 @@ class VulnerabilityIntegrationTest : BaseIntegrationTest() {
         regularUser = userRepository.save(TestDataFactory.createRegularUser(
             username = "integ-user-${System.nanoTime()}",
             email = "integ-user-${System.nanoTime()}@test.com"
+        ))
+        secChampionUser = userRepository.save(TestDataFactory.createSecChampionUser(
+            username = "integ-secchamp-${System.nanoTime()}",
+            email = "integ-secchamp-${System.nanoTime()}@test.com"
         ))
     }
 
@@ -252,6 +257,40 @@ class VulnerabilityIntegrationTest : BaseIntegrationTest() {
             )
 
             assertThat(response.status).isEqualTo(HttpStatus.OK)
+        }
+
+
+        @Test
+        @DisplayName("VI-007: SECCHAMPION cannot see unrelated vulnerabilities")
+        fun `rbac_secChampionCannotSeeUnrelatedVulns`() {
+            // Given: Admin creates a vulnerability on an asset not accessible to SECCHAMPION
+            val adminToken = TestAuthHelper.getAuthToken(client, adminUser.username)
+            val secChampionToken = TestAuthHelper.getAuthToken(client, secChampionUser.username)
+            val hostname = "admin-only-${System.nanoTime()}"
+            val cve = "CVE-2024-ADMIN-ONLY-${System.nanoTime()}"
+
+            val request = AddVulnerabilityRequestDto(
+                hostname = hostname,
+                cve = cve,
+                criticality = "HIGH",
+                daysOpen = 10
+            )
+
+            client.toBlocking().exchange(
+                HttpRequest.POST("/api/vulnerabilities/cli-add", request).bearerAuth(adminToken),
+                AddVulnerabilityResponseDto::class.java
+            )
+
+            // When: SECCHAMPION queries vulnerability overview
+            val response = client.toBlocking().exchange(
+                HttpRequest.GET<Any>("/api/vulnerabilities/current").bearerAuth(secChampionToken),
+                String::class.java
+            )
+
+            // Then: Vulnerability is not visible because SECCHAMPION is asset-scoped
+            assertThat(response.status).isEqualTo(HttpStatus.OK)
+            assertThat(response.body()!!).doesNotContain(cve)
+            assertThat(response.body()!!).doesNotContain(hostname)
         }
 
         @Test

--- a/src/backendng/src/test/kotlin/com/secman/testutil/TestDataFactory.kt
+++ b/src/backendng/src/test/kotlin/com/secman/testutil/TestDataFactory.kt
@@ -55,6 +55,22 @@ object TestDataFactory {
         )
     }
 
+
+    /**
+     * Create a user with SECCHAMPION role.
+     */
+    fun createSecChampionUser(
+        username: String = "testsecchampion",
+        email: String = "testsecchampion@secman.test"
+    ): User {
+        return User(
+            username = username,
+            email = email,
+            passwordHash = defaultPasswordHash,
+            roles = mutableSetOf(Role.USER, Role.SECCHAMPION)
+        )
+    }
+
     /**
      * Create a regular user with only USER role
      */


### PR DESCRIPTION
### Motivation
- SECCHAMPION users were effectively treated as global viewers for the vulnerability overview and exports, allowing them to see vulnerabilities outside their accessible assets; the intention is to restrict SECCHAMPIONs to the same asset-scoped view as other non-admin users.

### Description
- Restrict universal access to `ADMIN` only by changing the `isAdmin` check in `VulnerabilityManagementController.getCurrentVulnerabilities` so `SECCHAMPION` no longer bypasses asset scoping.
- Apply the same rule in `ExportJobService.startExport` so background vulnerability exports use accessible asset IDs for `SECCHAMPION` users instead of full system-wide exports.
- Add `TestDataFactory.createSecChampionUser()` to support tests that exercise SECCHAMPION behavior.
- Add an integration test `rbac_secChampionCannotSeeUnrelatedVulns` in `VulnerabilityIntegrationTest` to assert that a SECCHAMPION cannot see vulnerabilities on assets they do not have access to.

### Testing
- Ran the integration test target `./gradlew :backendng:test --tests "*VulnerabilityIntegrationTest*"`, which failed in this environment due to a missing Java 21 toolchain and so could not complete (toolchain error).
- No other automated test suites were executed here because the environment could not compile the backend without Java 21; local/CI verification should include `./gradlew build` and the two mandatory E2E gates described in repo guidelines after installing the proper JDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1719d054c4832382bd565d1b71a2d6)