### PR TITLE
fix(frontend): remove duplicate CVE prefix in exception scope badge

### DIFF
--- a/src/frontend/src/components/ExceptionRequestModal.tsx
+++ b/src/frontend/src/components/ExceptionRequestModal.tsx
@@ -318,7 +318,7 @@ const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
                                     </div>
                                     <div className="d-flex align-items-center flex-wrap gap-2 mb-2">
                                         <span className="fs-6 fw-light">Except</span>
-                                        <span className="badge bg-info text-dark">CVE {vulnerabilityCveId ?? ''}</span>
+                                        <span className="badge bg-info text-dark">{vulnerabilityCveId ?? ''}</span>
                                         <select
                                             className="form-select form-select-sm"
                                             style={{ width: 'auto' }}


### PR DESCRIPTION
### Motivation
- The exception scope badge rendered `CVE CVE-...` when creating a CVE-scoped exception because the UI prepended a `CVE ` prefix even though the full identifier already contained it.

### Description
- Stop adding the extra prefix by updating `ExceptionRequestModal.tsx` to render only `vulnerabilityCveId` in the scope badge (one-line change to remove the hardcoded `CVE `).

### Testing
- Ran frontend lint with `cd src/frontend && npm run lint`; the command failed due to many pre-existing lint errors across the frontend unrelated to this one-line UI change, and the edit introduces no new lint issues in the touched line.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1719f9f2788323a9a5b175eee001b1)