### PR TITLE
fix(workgroup): return clear forbidden message for user assignment

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupController.kt
@@ -349,7 +349,8 @@ open class WorkgroupController(
             val workgroup = workgroupRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound<Any>()
             if (!canManageWorkgroup(authentication)) {
-                return HttpResponse.status<Any>(io.micronaut.http.HttpStatus.FORBIDDEN)
+                return HttpResponse.status<Map<String, String>>(io.micronaut.http.HttpStatus.FORBIDDEN)
+                    .body(mapOf("error" to "Missing rights"))
             }
 
             // Domain restriction: non-admin callers can only lazy-create new pending users

--- a/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAuthorizationTest.kt
@@ -72,6 +72,7 @@ class WorkgroupAuthorizationTest {
         )
 
         assertEquals(HttpStatus.FORBIDDEN, response.status)
+        assertEquals(mapOf("error" to "Missing rights"), response.body())
         verify(exactly = 0) { workgroupService.assignUsersToWorkgroup(any(), any()) }
     }
 


### PR DESCRIPTION
### Motivation
- Non-privileged users received a bare 403 when attempting to add users to a workgroup, which made the UI error unclear and unhelpful.

### Description
- Return HTTP 403 with a structured JSON body (`{ "error": "Missing rights" }`) from `POST /api/workgroups/{id}/users` when the caller fails `canManageWorkgroup`, and update `WorkgroupAuthorizationTest` to assert the new response body.

### Testing
- Executed `./gradlew :backendng:test --tests "*WorkgroupAuthorizationTest"` in this environment but the run failed due to a missing Java 21 toolchain; the test asserting the new payload is included and will run successfully in a properly provisioned CI/developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171a6f90988323a3d78c37459909cb)