### PR TITLE
perf(vulnerabilities): skip redundant COUNT() on custom-sort paths when frontend provides known total

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -548,7 +548,8 @@ open class VulnerabilityService(
                 normalizedDomainFilter, normalizedCloudAccountIdFilter,
                 normalizedExceptionStatus, activeExceptions,
                 sort, sortDir, page, size,
-                accessibleAssetIds = if (isAdmin) null else accessibleAssetIds
+                accessibleAssetIds = if (isAdmin) null else accessibleAssetIds,
+                knownTotal = knownTotal
             )
         }
 
@@ -656,7 +657,8 @@ open class VulnerabilityService(
                 sort = sort,
                 sortDir = sortDir,
                 page = page,
-                size = size
+                size = size,
+                knownTotal = knownTotal
             )
             val effectiveTotal = knownTotal ?: totalCount
             val totalPages = if (effectiveTotal > 0) kotlin.math.ceil(effectiveTotal.toDouble() / size).toInt() else 0
@@ -783,7 +785,8 @@ open class VulnerabilityService(
                 sort = sort,
                 sortDir = sortDir,
                 page = page,
-                size = size
+                size = size,
+                knownTotal = knownTotal
             )
             val effectiveTotal = knownTotal ?: totalCount
             val totalPages = if (effectiveTotal > 0) kotlin.math.ceil(effectiveTotal.toDouble() / size).toInt() else 0
@@ -938,7 +941,8 @@ open class VulnerabilityService(
         sortDir: String?,
         page: Int,
         size: Int,
-        accessibleAssetIds: Set<Long>? = null
+        accessibleAssetIds: Set<Long>? = null,
+        knownTotal: Long? = null
     ): com.secman.dto.PaginatedVulnerabilitiesResponse {
         // SECURITY: Lock the access-control invariant. The non-admin path of
         // getCurrentVulnerabilitiesOptimized short-circuits empty asset sets before reaching
@@ -1011,10 +1015,13 @@ open class VulnerabilityService(
 
         jpqlBase.append(" ORDER BY $sortColumn $direction")
 
-        // Execute count query
-        val countQuery = entityManager.createQuery(countBase.toString(), Long::class.javaObjectType)
-        params.forEach { (k, v) -> countQuery.setParameter(k, v) }
-        val totalCount = countQuery.singleResult
+        // Execute count query only when caller did not provide a known total
+        // (e.g., page/sort navigation with unchanged filters).
+        val totalCount = knownTotal ?: run {
+            val countQuery = entityManager.createQuery(countBase.toString(), Long::class.javaObjectType)
+            params.forEach { (k, v) -> countQuery.setParameter(k, v) }
+            countQuery.singleResult
+        }
 
         // Execute data query with pagination
         val dataQuery = entityManager.createQuery(jpqlBase.toString(), Vulnerability::class.java)
@@ -1065,7 +1072,8 @@ open class VulnerabilityService(
         sort: String,
         sortDir: String?,
         page: Int,
-        size: Int
+        size: Int,
+        knownTotal: Long? = null
     ): Pair<List<Vulnerability>, Long> {
         // SECURITY: Lock the access-control invariant — see getCurrentVulnerabilitiesWithCustomSort
         // for rationale. Empty asset sets are the responsibility of the dispatcher to short-circuit;
@@ -1131,7 +1139,6 @@ open class VulnerabilityService(
             statusType, accessibleAssetIds?.size ?: "ALL", sortColumn, direction, dataSql.length)
 
         val dataQuery = entityManager.createNativeQuery(dataSql, Vulnerability::class.java)
-        val countQuery = entityManager.createNativeQuery(countSql)
 
         fun bindParams(q: jakarta.persistence.Query) {
             if (accessibleAssetIds != null) q.setParameter("accessibleAssetIds", accessibleAssetIds)
@@ -1147,11 +1154,13 @@ open class VulnerabilityService(
         dataQuery.setParameter("pageSize", size)
         dataQuery.setParameter("pageOffset", page * size)
 
-        bindParams(countQuery)
-
         @Suppress("UNCHECKED_CAST")
         val vulns = dataQuery.resultList as List<Vulnerability>
-        val totalCount = (countQuery.singleResult as Number).toLong()
+        val totalCount = knownTotal ?: run {
+            val countQuery = entityManager.createNativeQuery(countSql)
+            bindParams(countQuery)
+            (countQuery.singleResult as Number).toLong()
+        }
 
         log.info("Status-filtered custom sort returned {} vulns (total: {}, status: {}, sort: {} {})",
             vulns.size, totalCount, statusType, sortColumn, direction)


### PR DESCRIPTION
### Motivation
- The vulnerability overview endpoint was incurring expensive `COUNT(*)` queries on large datasets (observed ~12s for ~1M rows) even when the frontend already supplied a stable total during page/sort-only navigation.
- The frontend passes a `knownTotal` to avoid re-running the costly global count on unchanged filters, but the backend custom-sort paths still executed their own count queries, adding latency.

### Description
- Threaded the optional `knownTotal: Long?` through the custom-sort execution paths so callers can supply a pre-known total to avoid redundant counting. 
- Updated the JPQL dynamic-sort helper (`getCurrentVulnerabilitiesWithCustomSort`) to skip the `COUNT` query when `knownTotal` is provided and use it as the page total instead. 
- Updated the native-SQL status-filtered helper (`executeStatusFilteredCustomSortQuery`) to similarly avoid executing the native `SELECT COUNT(*)` when `knownTotal` is supplied, binding params and running the count only on demand. 
- Adjusted call sites in `getCurrentVulnerabilitiesOptimized` to pass `knownTotal` into the new helper signatures so page/sort navigation can short-circuit expensive counts.

### Testing
- Attempted an automated backend compile with `./gradlew :backendng:compileKotlin`, which failed in this environment because the Java 21 toolchain is not installed/configured, so no compile/test suite could be executed here. 
- No unit/integration tests were run locally due to the compile/toolchain failure; intended behavior is covered by the existing pagination and caching tests and should be verified with `./gradlew build` and the repository E2E gates (`/e2ejs`, `/e2evulnexception`) in CI or a dev environment that has Java 21 configured."}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171e2865c4832396336472400f177a)