### PR TITLE
feat(frontend): allow manual AWS account ID filter entry

### DIFF
--- a/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
+++ b/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
@@ -916,6 +916,16 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
               </option>
             ))}
           </select>
+          <input
+            type="text"
+            className="form-control mt-2"
+            placeholder="Or enter account ID manually..."
+            value={cloudAccountIdFilter}
+            onChange={(e) => {
+              setCloudAccountIdFilter(e.target.value.trim());
+              handleFilterChange();
+            }}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Allow users to type or paste an AWS Account ID into the Current Vulnerabilities filters when the desired account is not present in the dropdown list.

### Description
- Added a manual text input below the existing AWS Account ID `select` in `src/frontend/src/components/CurrentVulnerabilitiesTable.tsx` that is bound to the same `cloudAccountIdFilter` state and invokes the existing `handleFilterChange()` so both the listbox and manual entry drive the same backend filter.

### Testing
- Ran `cd src/frontend && npm run lint`, which fails due to many pre-existing frontend lint errors unrelated to this change, and no new lint errors were introduced by the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e93d2fa08323882c8e2df13c246e)