### PR TITLE
fix(backendng): guard exception preview against missing assets

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -1314,9 +1314,17 @@ open class VulnerabilityService(
         val activeExceptions = getActiveExceptions()
 
         // Convert sample to DTOs with exception info
-        val affectedDtos = sampleVulns.map { vuln ->
+        val affectedDtos = sampleVulns.mapNotNull { vuln ->
+            val asset = vuln.asset
+            if (asset == null || asset.id == null) {
+                log.warn(
+                    "Skipping vulnerability {} in preview because it has no resolvable asset (scope={}, subject={})",
+                    vuln.id, scope, subject
+                )
+                return@mapNotNull null
+            }
             // Calculate overdue status - pass pre-loaded exceptions to avoid N+1 queries
-            val overdueInfo = calculateOverdueStatus(vuln, vuln.asset, activeExceptions)
+            val overdueInfo = calculateOverdueStatus(vuln, asset, activeExceptions)
 
             // Check if any active exception matches this vulnerability
             val matchingException = activeExceptions.firstOrNull { exception ->
@@ -1328,11 +1336,11 @@ open class VulnerabilityService(
 
             VulnerabilityWithExceptionDto(
                 id = vuln.id,
-                asset = vuln.asset,
-                assetId = vuln.asset.id!!,
-                assetName = vuln.asset.name,
-                assetIp = vuln.asset.ip,
-                cloudInstanceId = vuln.asset.cloudInstanceId,
+                asset = asset,
+                assetId = asset.id,
+                assetName = asset.name,
+                assetIp = asset.ip,
+                cloudInstanceId = asset.cloudInstanceId,
                 vulnerabilityId = vuln.vulnerabilityId,
                 cvssSeverity = vuln.cvssSeverity,
                 vulnerableProductVersions = vuln.vulnerableProductVersions,


### PR DESCRIPTION
### Motivation
- Previewing an `ALL_VULNS` or AWS account-scoped exception could surface a generic 500 when a sampled vulnerability row had a missing or unresolvable `asset` relation, because the preview code assumed `vuln.asset` and `vuln.asset.id` were always present. 
- The change aims to make the impact-preview path resilient to rare data-integrity edge cases so UI flows (preview/create) don't fail for a single malformed row.

### Description
- Hardened `VulnerabilityService.previewExceptionImpact()` by switching from `map` to `mapNotNull` and skipping any sample vulnerability whose `asset` or `asset.id` is null. 
- Added a `log.warn` when skipping malformed rows instead of dereferencing null and throwing, and reused a validated `asset` local when building `VulnerabilityWithExceptionDto`. 
- Updated the `calculateOverdueStatus` call and DTO construction to use the validated `asset` reference to avoid NPEs during preview mapping.

### Testing
- Attempted to compile the backend with `./gradlew :backendng:compileKotlin`, which failed due to the environment lacking the Java 21 toolchain (toolchain download not configured). 
- No other automated tests were run in this environment; the fix is a defensive change that should be covered by existing backend unit/integration tests when run in a proper Java toolchain environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17ea78e69c832396a7ec8eaf906eaf)