### PR TITLE
Import CrowdStrike Installed Products: CLI, backend, and UI

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
@@ -1,0 +1,84 @@
+package com.secman.controller
+
+import com.secman.dto.InstalledProductImportRequest
+import com.secman.dto.InstalledProductListResponse
+import com.secman.dto.InstalledProductResponse
+import com.secman.repository.InstalledProductRepository
+import com.secman.service.InstalledProductImportService
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+
+@Controller("/api/installed-products")
+@Secured("ADMIN", "VULN", "SECCHAMPION")
+@ExecuteOn(TaskExecutors.BLOCKING)
+open class InstalledProductController(
+    private val installedProductRepository: InstalledProductRepository,
+    private val installedProductImportService: InstalledProductImportService
+) {
+    private val log = LoggerFactory.getLogger(InstalledProductController::class.java)
+
+    @Get
+    open fun list(
+        @Nullable @QueryValue search: String?,
+        @Nullable @QueryValue limit: Int?
+    ): HttpResponse<InstalledProductListResponse> {
+        val effectiveLimit = (limit ?: 500).coerceIn(1, 2000)
+        val normalizedSearch = search?.trim().orEmpty()
+        val products = installedProductRepository.search(normalizedSearch).take(effectiveLimit)
+        return HttpResponse.ok(
+            InstalledProductListResponse(
+                products = products.map { product ->
+                    InstalledProductResponse(
+                        id = requireNotNull(product.id),
+                        assetId = requireNotNull(product.asset.id),
+                        hostname = product.asset.name,
+                        name = product.name,
+                        vendor = product.vendor,
+                        version = product.version,
+                        category = product.category,
+                        installationPath = product.installationPath,
+                        installedAt = product.installedAt,
+                        lastUsedAt = product.lastUsedAt,
+                        lastUpdatedAt = product.lastUpdatedAt,
+                        importedAt = product.importedAt
+                    )
+                },
+                totalProducts = products.size,
+                totalSystems = installedProductRepository.countDistinctAssets(normalizedSearch)
+            )
+        )
+    }
+
+    @Post("/import")
+    @Secured("ADMIN", "VULN")
+    open fun importProducts(
+        @Body @Valid request: InstalledProductImportRequest,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        log.info(
+            "Installed products import request: products={}, dryRun={}, user={}",
+            request.products.size,
+            request.dryRun,
+            authentication.name
+        )
+        return try {
+            HttpResponse.ok(installedProductImportService.importProducts(request.products, request.dryRun))
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.badRequest(mapOf("error" to (e.message ?: "Invalid request")))
+        } catch (e: Exception) {
+            log.error("Installed products import failed for user={}", authentication.name, e)
+            HttpResponse.serverError(mapOf("error" to "An internal error occurred while importing installed products"))
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/InstalledProduct.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/InstalledProduct.kt
@@ -1,0 +1,87 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "installed_product",
+    indexes = [
+        Index(name = "idx_installed_product_asset", columnList = "asset_id"),
+        Index(name = "idx_installed_product_name", columnList = "name"),
+        Index(name = "idx_installed_product_vendor", columnList = "vendor"),
+        Index(name = "idx_installed_product_external", columnList = "external_id")
+    ]
+)
+@Serdeable
+data class InstalledProduct(
+    @Id
+    @GeneratedValue
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "asset_id", nullable = false)
+    var asset: Asset,
+
+    @Column(name = "external_id", length = 255)
+    var externalId: String? = null,
+
+    @Column(name = "crowdstrike_aid", length = 64)
+    var crowdStrikeAid: String? = null,
+
+    @Column(nullable = false, length = 512)
+    var name: String,
+
+    @Column(length = 255)
+    var vendor: String? = null,
+
+    @Column(length = 255)
+    var version: String? = null,
+
+    @Column(length = 255)
+    var category: String? = null,
+
+    @Column(name = "installation_path", length = 1024)
+    var installationPath: String? = null,
+
+    @Column(name = "installed_at")
+    var installedAt: LocalDateTime? = null,
+
+    @Column(name = "last_used_at")
+    var lastUsedAt: LocalDateTime? = null,
+
+    @Column(name = "last_updated_at")
+    var lastUpdatedAt: LocalDateTime? = null,
+
+    @Column(name = "imported_at", nullable = false)
+    var importedAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null
+) {
+    @PrePersist
+    fun onCreate() {
+        val now = LocalDateTime.now()
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/dto/InstalledProductDtos.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/InstalledProductDtos.kt
@@ -1,0 +1,47 @@
+package com.secman.dto
+
+import com.secman.crowdstrike.dto.InstalledProductDto
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.Valid
+import java.time.LocalDateTime
+
+@Serdeable
+data class InstalledProductImportRequest(
+    @field:Valid
+    val products: List<InstalledProductDto>,
+    val dryRun: Boolean = false
+)
+
+@Serdeable
+data class InstalledProductImportResponse(
+    val productsProcessed: Int,
+    val productsImported: Int,
+    val productsUpdated: Int,
+    val productsSkipped: Int,
+    val unknownSystems: Int,
+    val dryRun: Boolean,
+    val errors: List<String> = emptyList()
+)
+
+@Serdeable
+data class InstalledProductResponse(
+    val id: Long,
+    val assetId: Long,
+    val hostname: String,
+    val name: String,
+    val vendor: String?,
+    val version: String?,
+    val category: String?,
+    val installationPath: String?,
+    val installedAt: LocalDateTime?,
+    val lastUsedAt: LocalDateTime?,
+    val lastUpdatedAt: LocalDateTime?,
+    val importedAt: LocalDateTime
+)
+
+@Serdeable
+data class InstalledProductListResponse(
+    val products: List<InstalledProductResponse>,
+    val totalProducts: Int,
+    val totalSystems: Long
+)

--- a/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
@@ -1,0 +1,40 @@
+package com.secman.repository
+
+import com.secman.domain.InstalledProduct
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+
+@Repository
+interface InstalledProductRepository : JpaRepository<InstalledProduct, Long> {
+    fun findByExternalId(externalId: String): InstalledProduct?
+
+    @Query("""
+        SELECT p FROM InstalledProduct p
+        WHERE p.asset.id = :assetId
+          AND LOWER(p.name) = LOWER(:name)
+          AND COALESCE(LOWER(p.vendor), '') = COALESCE(LOWER(:vendor), '')
+          AND COALESCE(LOWER(p.version), '') = COALESCE(LOWER(:version), '')
+    """)
+    fun findLogicalDuplicate(assetId: Long, name: String, vendor: String?, version: String?): InstalledProduct?
+
+    @Query("""
+        SELECT p FROM InstalledProduct p
+        WHERE (:search IS NULL OR :search = ''
+            OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.vendor, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :search, '%')))
+        ORDER BY p.name ASC, p.vendor ASC, p.version ASC, p.asset.name ASC
+    """)
+    fun search(search: String?): List<InstalledProduct>
+
+    @Query("""
+        SELECT COUNT(DISTINCT p.asset.id) FROM InstalledProduct p
+        WHERE (:search IS NULL OR :search = ''
+            OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.vendor, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%')))
+    """)
+    fun countDistinctAssets(search: String?): Long
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/InstalledProductImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/InstalledProductImportService.kt
@@ -1,0 +1,111 @@
+package com.secman.service
+
+import com.secman.crowdstrike.dto.InstalledProductDto
+import com.secman.domain.Asset
+import com.secman.domain.InstalledProduct
+import com.secman.dto.InstalledProductImportResponse
+import com.secman.repository.AssetRepository
+import com.secman.repository.InstalledProductRepository
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+@Singleton
+open class InstalledProductImportService(
+    private val assetRepository: AssetRepository,
+    private val installedProductRepository: InstalledProductRepository
+) {
+    private val log = LoggerFactory.getLogger(InstalledProductImportService::class.java)
+
+    @Transactional
+    open fun importProducts(products: List<InstalledProductDto>, dryRun: Boolean): InstalledProductImportResponse {
+        var imported = 0
+        var updated = 0
+        var skipped = 0
+        var unknownSystems = 0
+        val errors = mutableListOf<String>()
+        val now = LocalDateTime.now()
+
+        products.forEach { dto ->
+            try {
+                val asset = resolveAsset(dto.hostname)
+                if (asset == null) {
+                    unknownSystems++
+                    skipped++
+                    return@forEach
+                }
+                if (dto.name.isBlank()) {
+                    skipped++
+                    errors.add("Skipped blank product name for ${dto.hostname}")
+                    return@forEach
+                }
+                if (dryRun) {
+                    imported++
+                    return@forEach
+                }
+
+                val assetId = requireNotNull(asset.id)
+                val existing = dto.externalId?.takeIf { it.isNotBlank() }?.let { installedProductRepository.findByExternalId(it) }
+                    ?: installedProductRepository.findLogicalDuplicate(assetId, dto.name, dto.vendor, dto.version)
+
+                if (existing == null) {
+                    installedProductRepository.save(
+                        InstalledProduct(
+                            asset = asset,
+                            externalId = dto.externalId?.take(255),
+                            crowdStrikeAid = dto.aid?.take(64),
+                            name = dto.name.take(512),
+                            vendor = dto.vendor?.take(255),
+                            version = dto.version?.take(255),
+                            category = dto.category?.take(255),
+                            installationPath = dto.installationPath?.take(1024),
+                            installedAt = dto.installedAt,
+                            lastUsedAt = dto.lastUsedAt,
+                            lastUpdatedAt = dto.lastUpdatedAt,
+                            importedAt = now
+                        )
+                    )
+                    imported++
+                } else {
+                    existing.asset = asset
+                    existing.externalId = dto.externalId?.take(255) ?: existing.externalId
+                    existing.crowdStrikeAid = dto.aid?.take(64)
+                    existing.name = dto.name.take(512)
+                    existing.vendor = dto.vendor?.take(255)
+                    existing.version = dto.version?.take(255)
+                    existing.category = dto.category?.take(255)
+                    existing.installationPath = dto.installationPath?.take(1024)
+                    existing.installedAt = dto.installedAt
+                    existing.lastUsedAt = dto.lastUsedAt
+                    existing.lastUpdatedAt = dto.lastUpdatedAt
+                    existing.importedAt = now
+                    installedProductRepository.update(existing)
+                    updated++
+                }
+            } catch (e: Exception) {
+                skipped++
+                val message = "Failed to import product '${dto.name}' for '${dto.hostname}': ${e.message}"
+                log.warn(message, e)
+                if (errors.size < 100) errors.add(message)
+            }
+        }
+
+        return InstalledProductImportResponse(
+            productsProcessed = products.size,
+            productsImported = imported,
+            productsUpdated = updated,
+            productsSkipped = skipped,
+            unknownSystems = unknownSystems,
+            dryRun = dryRun,
+            errors = errors
+        )
+    }
+
+    private fun resolveAsset(hostname: String): Asset? {
+        val trimmed = hostname.trim()
+        if (trimmed.isBlank()) return null
+        return assetRepository.findByNameIgnoreCase(trimmed)
+            ?: trimmed.substringBefore('.').takeIf { it.isNotBlank() && it != trimmed }?.let { assetRepository.findByNameIgnoreCase(it) }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -1337,7 +1337,7 @@ open class VulnerabilityService(
             VulnerabilityWithExceptionDto(
                 id = vuln.id,
                 asset = asset,
-                assetId = asset.id,
+                assetId = requireNotNull(asset.id),
                 assetName = asset.name,
                 assetIp = asset.ip,
                 cloudInstanceId = asset.cloudInstanceId,

--- a/src/backendng/src/main/resources/db/migration/V230__installed_products.sql
+++ b/src/backendng/src/main/resources/db/migration/V230__installed_products.sql
@@ -1,0 +1,25 @@
+CREATE TABLE installed_product (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    asset_id BIGINT NOT NULL,
+    external_id VARCHAR(255) NULL,
+    crowdstrike_aid VARCHAR(64) NULL,
+    name VARCHAR(512) NOT NULL,
+    vendor VARCHAR(255) NULL,
+    version VARCHAR(255) NULL,
+    category VARCHAR(255) NULL,
+    installation_path VARCHAR(1024) NULL,
+    installed_at DATETIME(6) NULL,
+    last_used_at DATETIME(6) NULL,
+    last_updated_at DATETIME(6) NULL,
+    imported_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_installed_product_asset FOREIGN KEY (asset_id) REFERENCES asset(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_installed_product_asset ON installed_product(asset_id);
+CREATE INDEX idx_installed_product_name ON installed_product(name);
+CREATE INDEX idx_installed_product_vendor ON installed_product(vendor);
+CREATE INDEX idx_installed_product_external ON installed_product(external_id);
+CREATE INDEX idx_installed_product_logical ON installed_product(asset_id, name, vendor, version);

--- a/src/backendng/src/test/kotlin/com/secman/service/InstalledProductImportServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/InstalledProductImportServiceTest.kt
@@ -1,0 +1,85 @@
+package com.secman.service
+
+import com.secman.crowdstrike.dto.InstalledProductDto
+import com.secman.domain.Asset
+import com.secman.domain.InstalledProduct
+import com.secman.repository.AssetRepository
+import com.secman.repository.InstalledProductRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class InstalledProductImportServiceTest {
+    private lateinit var assetRepository: AssetRepository
+    private lateinit var installedProductRepository: InstalledProductRepository
+    private lateinit var service: InstalledProductImportService
+
+    @BeforeEach
+    fun setUp() {
+        assetRepository = mockk()
+        installedProductRepository = mockk()
+        service = InstalledProductImportService(assetRepository, installedProductRepository)
+    }
+
+    @Test
+    fun `imports product for known asset`() {
+        val asset = asset(1L, "server01")
+        every { assetRepository.findByNameIgnoreCase("server01.example.com") } returns null
+        every { assetRepository.findByNameIgnoreCase("server01") } returns asset
+        every { installedProductRepository.findByExternalId("app-1") } returns null
+        every { installedProductRepository.findLogicalDuplicate(1L, "Chrome", "Google", "1.2.3") } returns null
+        val saved = slot<InstalledProduct>()
+        every { installedProductRepository.save(capture(saved)) } answers { saved.captured.apply { id = 10L } }
+
+        val result = service.importProducts(
+            listOf(InstalledProductDto(externalId = "app-1", hostname = "server01.example.com", name = "Chrome", vendor = "Google", version = "1.2.3")),
+            dryRun = false
+        )
+
+        assertThat(result.productsProcessed).isEqualTo(1)
+        assertThat(result.productsImported).isEqualTo(1)
+        assertThat(result.productsUpdated).isEqualTo(0)
+        assertThat(saved.captured.asset.name).isEqualTo("server01")
+        assertThat(saved.captured.name).isEqualTo("Chrome")
+    }
+
+    @Test
+    fun `dry run counts known products without saving`() {
+        val asset = asset(2L, "workstation01")
+        every { assetRepository.findByNameIgnoreCase("workstation01") } returns asset
+
+        val result = service.importProducts(
+            listOf(InstalledProductDto(hostname = "workstation01", name = "Firefox")),
+            dryRun = true
+        )
+
+        assertThat(result.dryRun).isTrue()
+        assertThat(result.productsImported).isEqualTo(1)
+        verify(exactly = 0) { installedProductRepository.save(any()) }
+        verify(exactly = 0) { installedProductRepository.update(any<InstalledProduct>()) }
+    }
+
+    @Test
+    fun `skips products for unknown systems`() {
+        every { assetRepository.findByNameIgnoreCase("unknown") } returns null
+
+        val result = service.importProducts(
+            listOf(InstalledProductDto(hostname = "unknown", name = "Chrome")),
+            dryRun = false
+        )
+
+        assertThat(result.productsSkipped).isEqualTo(1)
+        assertThat(result.unknownSystems).isEqualTo(1)
+    }
+
+    private fun asset(id: Long, name: String): Asset = Asset(
+        id = id,
+        name = name,
+        type = "SERVER",
+        owner = "owner"
+    )
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -9,6 +9,7 @@ import com.secman.cli.commands.DeduplicateVulnerabilitiesCommand
 import com.secman.cli.commands.DeleteAssetNotSeenCommand
 import com.secman.cli.commands.DeleteAllRequirementsCommand
 import com.secman.cli.commands.ExportRequirementsCommand
+import com.secman.cli.commands.InstalledProductsCommand
 import com.secman.cli.commands.ManageUserMappingsCommand
 import com.secman.cli.commands.ManageWorkgroupsCommand
 import com.secman.cli.commands.MonitorCommand
@@ -53,6 +54,39 @@ class SecmanCli {
             }
             args[0] == "query" && args.size > 1 && args[1] == "--help" -> showCommandHelp("query")
             args[0] == "query" && args.size > 1 && args[1] == "servers" && args.any { it == "--help" || it == "-h" } -> showCommandHelp("query-servers")
+            args[0] == "installed-products" && args.any { it == "--help" || it == "-h" } -> showCommandHelp("installed-products")
+            args[0] == "installed-products" -> {
+                val command = InstalledProductsCommand()
+                var i = 1
+                while (i < args.size) {
+                    when {
+                        args[i] == "--device-type" && i + 1 < args.size -> {
+                            command.deviceType = args[i + 1]
+                            i++
+                        }
+                        args[i] == "--limit" && i + 1 < args.size -> {
+                            command.limit = args[i + 1].toIntOrNull() ?: 1000
+                            i++
+                        }
+                        args[i] == "--client-id" && i + 1 < args.size -> {
+                            command.clientId = args[i + 1]
+                            i++
+                        }
+                        args[i] == "--client-secret" && i + 1 < args.size -> {
+                            command.clientSecret = args[i + 1]
+                            i++
+                        }
+                        args[i] == "--backend-url" && i + 1 < args.size -> {
+                            command.backendUrl = args[i + 1]
+                            i++
+                        }
+                        args[i] == "--dry-run" -> command.dryRun = true
+                        args[i] == "--verbose" -> command.verbose = true
+                    }
+                    i++
+                }
+                command.execute()
+            }
             args[0] == "query" && args.size > 1 && args[1] == "servers" -> {
                 val serversCommand = ServersCommand()
                 // Parse remaining args into properties
@@ -368,6 +402,7 @@ class SecmanCli {
               CrowdStrike:
                 query                  Query CrowdStrike vulnerabilities for a single host
                 query servers          Batch query and import server vulnerabilities
+                installed-products     Import CrowdStrike installed products for known systems
                 monitor                Continuously monitor for HIGH/CRITICAL vulnerabilities
                 config                 Configure CrowdStrike API credentials
                 crowdstrike-last-import  Show timestamp of the most recent CrowdStrike import
@@ -465,6 +500,27 @@ class SecmanCli {
                 See also: secman help query-servers
             """.trimIndent(),
 
+            "installed-products" to """
+                secman installed-products - Import CrowdStrike installed products
+
+                Usage: secman installed-products [options]
+
+                Options:
+                  --device-type <type>     Device type: SERVER, WORKSTATION, or ALL (default: SERVER)
+                  --dry-run                Query CrowdStrike and print summary without writing backend data
+                  --limit <num>            CrowdStrike page size, max 1000 (default: 1000)
+                  --backend-url <url>      Backend API URL (overrides SECMAN_BACKEND_URL/SECMAN_HOST)
+                  --client-id <id>         CrowdStrike API client ID (overrides config file)
+                  --client-secret <secret> CrowdStrike API client secret (overrides config file)
+                  --verbose                Show detailed backend errors
+
+                Requires SECMAN_ADMIN_NAME and SECMAN_ADMIN_PASS unless --dry-run is used.
+
+                Examples:
+                  secman installed-products --device-type SERVER
+                  secman installed-products --device-type WORKSTATION --dry-run
+                  secman installed-products --device-type ALL --limit 500
+            """.trimIndent(),
             "query-servers" to """
                 secman query servers - Batch query and import server vulnerabilities
 

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/InstalledProductsCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/InstalledProductsCommand.kt
@@ -1,0 +1,117 @@
+package com.secman.cli.commands
+
+import com.secman.cli.config.ConfigLoader
+import com.secman.cli.service.CliHttpClient
+import com.secman.cli.service.InstalledProductStorageService
+import com.secman.crowdstrike.client.CrowdStrikeApiClient
+import com.secman.crowdstrike.dto.DeviceType
+import com.secman.crowdstrike.dto.FalconConfigDto
+import io.micronaut.context.ApplicationContext
+import org.slf4j.LoggerFactory
+
+class InstalledProductsCommand {
+    private val log = LoggerFactory.getLogger(InstalledProductsCommand::class.java)
+    private val configLoader = ConfigLoader()
+
+    var deviceType: String = "SERVER"
+    var dryRun: Boolean = false
+    var verbose: Boolean = false
+    var clientId: String? = null
+    var clientSecret: String? = null
+    var limit: Int = 1000
+    var backendUrl: String? = null
+
+    private val appContext by lazy {
+        val resolvedUrl = resolveBackendUrl()
+        ApplicationContext.builder()
+            .properties(mapOf("secman.backend.base-url" to resolvedUrl))
+            .start()
+    }
+    private val apiClient: CrowdStrikeApiClient by lazy { appContext.getBean(CrowdStrikeApiClient::class.java) }
+    private val storageService: InstalledProductStorageService by lazy { appContext.getBean(InstalledProductStorageService::class.java) }
+    private val cliHttpClient: CliHttpClient by lazy { appContext.getBean(CliHttpClient::class.java) }
+
+    fun execute(): Int {
+        return try {
+            val parsedDeviceType = DeviceType.fromString(deviceType)
+            val config = if (clientId != null && clientSecret != null) {
+                FalconConfigDto(clientId = clientId!!, clientSecret = clientSecret!!)
+            } else {
+                configLoader.loadConfig()
+            }
+            val resolvedBackendUrl = resolveBackendUrl()
+            val authToken = if (!dryRun) authenticate(resolvedBackendUrl) else null
+
+            System.out.println("Importing installed products from CrowdStrike")
+            System.out.println("Device type: ${parsedDeviceType.name}")
+            System.out.println("Mode: ${if (dryRun) "dry run" else "import"}")
+
+            var totalQueried = 0
+            var totalImported = 0
+            var totalUpdated = 0
+            var totalSkipped = 0
+            var totalUnknownSystems = 0
+            var batches = 0
+
+            val total = apiClient.queryInstalledProductsStreaming(
+                deviceType = parsedDeviceType.name,
+                config = config,
+                limit = limit.coerceIn(1, 1000)
+            ) { products ->
+                batches++
+                totalQueried += products.size
+                if (dryRun) {
+                    val hostCount = products.map { it.hostname.lowercase() }.distinct().size
+                    System.out.println("Dry-run batch $batches: ${products.size} product rows across $hostCount CrowdStrike hosts")
+                } else {
+                    val result = storageService.importInstalledProducts(products, dryRun = false, authToken = authToken)
+                    totalImported += result.productsImported
+                    totalUpdated += result.productsUpdated
+                    totalSkipped += result.productsSkipped
+                    totalUnknownSystems += result.unknownSystems
+                    if (verbose && result.errors.isNotEmpty()) {
+                        result.errors.forEach { System.err.println("  - $it") }
+                    }
+                    System.out.println("Batch $batches: imported=${result.productsImported}, updated=${result.productsUpdated}, skipped=${result.productsSkipped}, unknown systems=${result.unknownSystems}")
+                }
+            }
+
+            System.out.println("\n--- Installed Products Summary ---")
+            System.out.println("CrowdStrike rows processed: $total")
+            System.out.println("Batches: $batches")
+            if (!dryRun) {
+                System.out.println("Products imported: $totalImported")
+                System.out.println("Products updated: $totalUpdated")
+                System.out.println("Products skipped: $totalSkipped")
+                System.out.println("Unknown Secman systems: $totalUnknownSystems")
+            } else {
+                System.out.println("Dry run only; no backend data was changed.")
+            }
+            0
+        } catch (e: IllegalArgumentException) {
+            System.err.println("Error: ${e.message}")
+            1
+        } catch (e: Exception) {
+            log.error("Installed products import failed", e)
+            System.err.println("Error: ${e.message}")
+            1
+        }
+    }
+
+    private fun authenticate(resolvedBackendUrl: String): String? {
+        val username = System.getenv("SECMAN_ADMIN_NAME")
+        val password = System.getenv("SECMAN_ADMIN_PASS")
+        if (username.isNullOrBlank() || password.isNullOrBlank()) {
+            throw IllegalArgumentException("SECMAN_ADMIN_NAME and SECMAN_ADMIN_PASS environment variables are required")
+        }
+        return cliHttpClient.authenticate(username, password, resolvedBackendUrl)
+            ?: throw IllegalStateException("Failed to authenticate with backend API at $resolvedBackendUrl")
+    }
+
+    private fun resolveBackendUrl(): String = backendUrl
+        ?: System.getenv("SECMAN_BACKEND_URL")
+        ?: System.getenv("SECMAN_HOST")?.let { host ->
+            if (host.startsWith("http://") || host.startsWith("https://")) host else "https://$host"
+        }
+        ?: "http://localhost:8080"
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/service/InstalledProductStorageService.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/service/InstalledProductStorageService.kt
@@ -1,0 +1,49 @@
+package com.secman.cli.service
+
+import com.secman.crowdstrike.dto.InstalledProductDto
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import jakarta.inject.Singleton
+
+@Singleton
+class InstalledProductStorageService(
+    @Client("\${secman.backend.base-url:http://localhost:8080}")
+    private val httpClient: HttpClient
+) {
+    fun importInstalledProducts(
+        products: List<InstalledProductDto>,
+        dryRun: Boolean,
+        authToken: String?
+    ): InstalledProductStorageResult {
+        val body = mapOf("products" to products, "dryRun" to dryRun)
+        val request = HttpRequest.POST("/api/installed-products/import", body)
+            .contentType(io.micronaut.http.MediaType.APPLICATION_JSON)
+        if (authToken != null) {
+            request.header("Authorization", "Bearer $authToken")
+        }
+        val response: HttpResponse<Map<*, *>> = httpClient.toBlocking().exchange(request, Map::class.java)
+        val responseBody = response.body()
+        @Suppress("UNCHECKED_CAST")
+        return InstalledProductStorageResult(
+            productsProcessed = (responseBody?.get("productsProcessed") as? Number)?.toInt() ?: products.size,
+            productsImported = (responseBody?.get("productsImported") as? Number)?.toInt() ?: 0,
+            productsUpdated = (responseBody?.get("productsUpdated") as? Number)?.toInt() ?: 0,
+            productsSkipped = (responseBody?.get("productsSkipped") as? Number)?.toInt() ?: 0,
+            unknownSystems = (responseBody?.get("unknownSystems") as? Number)?.toInt() ?: 0,
+            dryRun = responseBody?.get("dryRun") as? Boolean ?: dryRun,
+            errors = responseBody?.get("errors") as? List<String> ?: emptyList()
+        )
+    }
+}
+
+data class InstalledProductStorageResult(
+    val productsProcessed: Int,
+    val productsImported: Int,
+    val productsUpdated: Int,
+    val productsSkipped: Int,
+    val unknownSystems: Int,
+    val dryRun: Boolean,
+    val errors: List<String>
+)

--- a/src/cli/src/test/kotlin/com/secman/cli/SecmanCliTest.kt
+++ b/src/cli/src/test/kotlin/com/secman/cli/SecmanCliTest.kt
@@ -86,6 +86,32 @@ class SecmanCliTest {
     }
 
     @Test
+    fun `test help lists installed products command`() {
+        val cli = SecmanCli()
+
+        val (result, output) = captureStdout {
+            cli.execute(arrayOf("help"))
+        }
+
+        assertEquals(0, result)
+        assertTrue(output.contains("installed-products"))
+    }
+
+    @Test
+    fun `test installed products help command returns 0`() {
+        val cli = SecmanCli()
+
+        val (result, output) = captureStdout {
+            cli.execute(arrayOf("help", "installed-products"))
+        }
+
+        assertEquals(0, result)
+        assertTrue(output.contains("secman installed-products"))
+        assertTrue(output.contains("--device-type"))
+        assertTrue(output.contains("--dry-run"))
+    }
+
+    @Test
     fun `test SecmanCli routes to query command`() {
         // Arrange
         val cli = SecmanCli()

--- a/src/frontend/src/components/InstalledProducts.tsx
+++ b/src/frontend/src/components/InstalledProducts.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { getInstalledProducts, type InstalledProductResponse } from '../services/installedProductService';
+
+const InstalledProducts: React.FC = () => {
+  const [products, setProducts] = useState<InstalledProductResponse[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [totalSystems, setTotalSystems] = useState(0);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setLoading(true);
+      getInstalledProducts(search)
+        .then((response) => {
+          setProducts(response.products);
+          setTotalSystems(response.totalSystems);
+          setError(null);
+        })
+        .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load installed products'))
+        .finally(() => setLoading(false));
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <div>
+          <h1 className="h3 mb-1">Installed products</h1>
+          <p className="text-muted mb-0">Products imported from CrowdStrike Discover for systems known in Secman.</p>
+        </div>
+        <div className="text-end">
+          <div className="fw-semibold">{products.length}</div>
+          <div className="text-muted small">rows shown across {totalSystems} systems</div>
+        </div>
+      </div>
+
+      <div className="card mb-3">
+        <div className="card-body">
+          <label className="form-label" htmlFor="installed-product-search">Search products, vendors, versions, or systems</label>
+          <input
+            id="installed-product-search"
+            className="form-control"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="e.g. Chrome, Microsoft, server01"
+          />
+        </div>
+      </div>
+
+      {error && <div className="alert alert-danger">{error}</div>}
+
+      <div className="card">
+        <div className="table-responsive">
+          <table className="table table-hover align-middle mb-0">
+            <thead className="table-light">
+              <tr>
+                <th>Product</th>
+                <th>Vendor</th>
+                <th>Version</th>
+                <th>System</th>
+                <th>Category</th>
+                <th>Last imported</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td colSpan={6} className="text-center py-4">Loading installed products...</td></tr>
+              ) : products.length === 0 ? (
+                <tr><td colSpan={6} className="text-center py-4 text-muted">No installed products found.</td></tr>
+              ) : products.map((product) => (
+                <tr key={product.id}>
+                  <td className="fw-semibold">{product.name}</td>
+                  <td>{product.vendor || '—'}</td>
+                  <td><code>{product.version || '—'}</code></td>
+                  <td><a href={`/assets/${product.assetId}`}>{product.hostname}</a></td>
+                  <td>{product.category || '—'}</td>
+                  <td>{new Date(product.importedAt).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InstalledProducts;

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -314,6 +314,11 @@ const Sidebar = () => {
                                     </a>
                                 </li>
                                 <li>
+                                    <a href="/installed-products" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
+                                        <i className="bi bi-boxes me-2"></i> Installed products
+                                    </a>
+                                </li>
+                                <li>
                                     <a href="/vulnerabilities/exceptions" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
                                         <i className="bi bi-x-circle me-2"></i> Exceptions
                                     </a>

--- a/src/frontend/src/pages/installed-products.astro
+++ b/src/frontend/src/pages/installed-products.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import InstalledProducts from '../components/InstalledProducts';
+---
+
+<Layout title="Installed products">
+  <InstalledProducts client:load />
+</Layout>

--- a/src/frontend/src/services/installedProductService.ts
+++ b/src/frontend/src/services/installedProductService.ts
@@ -1,0 +1,33 @@
+import { authenticatedGet } from './authService';
+
+export interface InstalledProductResponse {
+  id: number;
+  assetId: number;
+  hostname: string;
+  name: string;
+  vendor?: string | null;
+  version?: string | null;
+  category?: string | null;
+  installationPath?: string | null;
+  installedAt?: string | null;
+  lastUsedAt?: string | null;
+  lastUpdatedAt?: string | null;
+  importedAt: string;
+}
+
+export interface InstalledProductListResponse {
+  products: InstalledProductResponse[];
+  totalProducts: number;
+  totalSystems: number;
+}
+
+export async function getInstalledProducts(search = '', limit = 500): Promise<InstalledProductListResponse> {
+  const params = new URLSearchParams();
+  if (search.trim()) params.append('search', search.trim());
+  params.append('limit', String(limit));
+  const response = await authenticatedGet(`/api/installed-products?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch installed products: ${response.status}`);
+  }
+  return response.json();
+}

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClient.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClient.kt
@@ -2,6 +2,7 @@ package com.secman.crowdstrike.client
 
 import com.secman.crowdstrike.dto.CrowdStrikeQueryResponse
 import com.secman.crowdstrike.dto.CrowdStrikeVulnerabilityDto
+import com.secman.crowdstrike.dto.InstalledProductDto
 import com.secman.crowdstrike.dto.FalconConfigDto
 import com.secman.crowdstrike.model.AuthToken
 
@@ -167,4 +168,20 @@ interface CrowdStrikeApiClient {
         deviceBatchSize: Int = 200,
         overdueThreshold: Int = 30
     ): StreamingSummary
+
+    /**
+     * Query installed products from CrowdStrike Discover in streaming pages.
+     *
+     * @param deviceType Device type filter (SERVER, WORKSTATION, or ALL)
+     * @param config CrowdStrike Falcon configuration
+     * @param limit Page size for pagination (max 1000)
+     * @param batchProcessor Callback invoked with each page of installed products
+     * @return Total number of installed product rows processed
+     */
+    fun queryInstalledProductsStreaming(
+        deviceType: String = "SERVER",
+        config: FalconConfigDto,
+        limit: Int = 1000,
+        batchProcessor: (List<InstalledProductDto>) -> Unit
+    ): Int
 }

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/client/CrowdStrikeApiClientImpl.kt
@@ -5,6 +5,7 @@ import com.secman.crowdstrike.dto.CrowdStrikeQueryResponse
 import com.secman.crowdstrike.dto.CrowdStrikeVulnerabilityDto
 import com.secman.crowdstrike.dto.DeviceType
 import com.secman.crowdstrike.dto.FalconConfigDto
+import com.secman.crowdstrike.dto.InstalledProductDto
 import com.secman.crowdstrike.exception.CrowdStrikeException
 import com.secman.crowdstrike.exception.NotFoundException
 import com.secman.crowdstrike.exception.RateLimitException
@@ -487,6 +488,182 @@ open class CrowdStrikeApiClientImpl(
             totalVulnerabilities, deviceChunks.size)
 
         return totalVulnerabilities
+    }
+
+
+    override fun queryInstalledProductsStreaming(
+        deviceType: String,
+        config: FalconConfigDto,
+        limit: Int,
+        batchProcessor: (List<InstalledProductDto>) -> Unit
+    ): Int {
+        val parsedDeviceType = DeviceType.fromString(deviceType)
+        val token = getAuthToken(config)
+        val filters = when (parsedDeviceType) {
+            DeviceType.SERVER -> listOf("host.product_type_desc:'Server'")
+            DeviceType.WORKSTATION -> listOf("host.product_type_desc:'Workstation'")
+            DeviceType.ALL -> listOf("host.product_type_desc:'Server'", "host.product_type_desc:'Workstation'")
+        }
+
+        var totalProcessed = 0
+        filters.forEach { filter ->
+            totalProcessed += queryInstalledProductsForFilter(
+                token = token,
+                filter = filter,
+                limit = limit.coerceIn(1, 1000),
+                batchProcessor = batchProcessor
+            )
+        }
+        return totalProcessed
+    }
+
+    @Retryable(
+        includes = [RateLimitException::class],
+        attempts = "5",
+        delay = "1s",
+        multiplier = "2.0",
+        maxDelay = "60s"
+    )
+    open fun queryInstalledProductsForFilter(
+        token: AuthToken,
+        filter: String,
+        limit: Int,
+        batchProcessor: (List<InstalledProductDto>) -> Unit
+    ): Int {
+        log.info("Querying CrowdStrike installed products with filter: {}", filter)
+        var afterToken: String? = null
+        var totalProcessed = 0
+        var filterProcessed = 0
+        var hasMore = true
+        var page = 0
+
+        while (hasMore) {
+            page++
+            try {
+                val uri = UriBuilder.of("/discover/combined/applications/v1")
+                    .queryParam("filter", filter)
+                    .queryParam("facet", "host_info")
+                    .queryParam("limit", limit)
+                    .apply {
+                        if (!afterToken.isNullOrBlank()) {
+                            queryParam("after", afterToken)
+                        }
+                    }
+                    .build()
+
+                val request = HttpRequest.GET<Any>(uri.toString())
+                    .header("Authorization", "Bearer ${token.accessToken}")
+                    .header("Accept", "application/json")
+
+                val response = httpClient.toBlocking().exchange(request, Map::class.java)
+                when (response.status.code) {
+                    200 -> {
+                        @Suppress("UNCHECKED_CAST")
+                        val responseBody = response.body() as? Map<String, Any>
+                            ?: throw CrowdStrikeException("Empty response from CrowdStrike Discover applications API")
+                        val resources = responseBody["resources"] as? List<*> ?: emptyList<Any>()
+                        val products = mapInstalledProducts(resources)
+                        if (products.isNotEmpty()) {
+                            batchProcessor(products)
+                            totalProcessed += products.size
+                            filterProcessed += products.size
+                        }
+
+                        val meta = responseBody["meta"] as? Map<*, *>
+                        val pagination = meta?.get("pagination") as? Map<*, *>
+                        afterToken = firstNonBlank(
+                            pagination?.get("after")?.toString(),
+                            pagination?.get("next")?.toString(),
+                            responseBody["after"]?.toString()
+                        )
+                        val total = (pagination?.get("total") as? Number)?.toInt()
+                        hasMore = !afterToken.isNullOrBlank() && resources.isNotEmpty() && (total == null || filterProcessed < total)
+                        log.info("Installed products page {} returned {} rows (total processed: {})", page, products.size, totalProcessed)
+                    }
+                    404 -> hasMore = false
+                    429 -> {
+                        val retryAfter = response.headers.get("Retry-After")?.toLongOrNull() ?: 30L
+                        throw RateLimitException("Rate limit exceeded querying installed products", retryAfter)
+                    }
+                    in 500..599 -> throw CrowdStrikeException("CrowdStrike server error querying installed products: ${response.status}")
+                    else -> throw CrowdStrikeException("Unexpected CrowdStrike installed products response: ${response.status}")
+                }
+            } catch (e: io.micronaut.http.client.exceptions.HttpClientResponseException) {
+                when (e.status.code) {
+                    404 -> hasMore = false
+                    429 -> {
+                        val retryAfter = e.response.headers.get("Retry-After")?.toLongOrNull() ?: 30L
+                        throw RateLimitException("Rate limit exceeded querying installed products", retryAfter, e)
+                    }
+                    in 500..599 -> throw CrowdStrikeException("CrowdStrike server error querying installed products: ${e.status}", e)
+                    else -> throw CrowdStrikeException("CrowdStrike installed products API error: ${e.message}", e)
+                }
+            }
+        }
+
+        return totalProcessed
+    }
+
+    private fun mapInstalledProducts(resources: List<*>): List<InstalledProductDto> {
+        return resources.mapNotNull { resource ->
+            val app = resource as? Map<*, *> ?: return@mapNotNull null
+            val host = firstMap(app["host"], app["host_info"], app["hostInfo"])
+            val nestedHost = firstMap(host?.get("host"), app["asset"])
+            val hostname = firstNonBlank(
+                host?.get("hostname")?.toString(),
+                host?.get("host_name")?.toString(),
+                nestedHost?.get("hostname")?.toString(),
+                nestedHost?.get("host_name")?.toString(),
+                app["hostname"]?.toString(),
+                app["host_name"]?.toString()
+            ) ?: return@mapNotNull null
+            val name = firstNonBlank(
+                app["name"]?.toString(),
+                app["product_name"]?.toString(),
+                app["application_name"]?.toString(),
+                app["software_name"]?.toString()
+            ) ?: return@mapNotNull null
+
+            InstalledProductDto(
+                externalId = app["id"]?.toString(),
+                hostname = hostname,
+                aid = firstNonBlank(
+                    host?.get("aid")?.toString(),
+                    host?.get("device_id")?.toString(),
+                    nestedHost?.get("aid")?.toString(),
+                    nestedHost?.get("device_id")?.toString(),
+                    app["aid"]?.toString()
+                ),
+                name = name,
+                vendor = firstNonBlank(app["vendor"]?.toString(), app["publisher"]?.toString()),
+                version = firstNonBlank(app["version"]?.toString(), app["product_version"]?.toString()),
+                category = app["category"]?.toString(),
+                installationPath = firstNonBlank(
+                    (app["installation_paths"] as? List<*>)?.firstOrNull()?.toString(),
+                    app["installation_path"]?.toString()
+                ),
+                installedAt = parseCrowdStrikeDate(app["installation_timestamp"]?.toString()),
+                lastUsedAt = parseCrowdStrikeDate(app["last_used_timestamp"]?.toString()),
+                lastUpdatedAt = parseCrowdStrikeDate(app["last_updated_timestamp"]?.toString())
+            )
+        }
+    }
+
+    private fun firstMap(vararg values: Any?): Map<*, *>? {
+        return values.firstNotNullOfOrNull { it as? Map<*, *> }
+    }
+
+    private fun parseCrowdStrikeDate(value: String?): LocalDateTime? {
+        if (value.isNullOrBlank()) return null
+        return try {
+            LocalDateTime.ofInstant(Instant.parse(value), ZoneId.systemDefault())
+        } catch (e: Exception) {
+            try {
+                LocalDateTime.parse(value.replace(" ", "T").replace("Z", ""))
+            } catch (e2: Exception) {
+                null
+            }
+        }
     }
 
     /**

--- a/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/InstalledProductDto.kt
+++ b/src/shared/src/main/kotlin/com/secman/crowdstrike/dto/InstalledProductDto.kt
@@ -1,0 +1,22 @@
+package com.secman.crowdstrike.dto
+
+import io.micronaut.serde.annotation.Serdeable
+import java.time.LocalDateTime
+
+/**
+ * Installed product/application discovered by CrowdStrike Discover.
+ */
+@Serdeable
+data class InstalledProductDto(
+    val externalId: String? = null,
+    val hostname: String,
+    val aid: String? = null,
+    val name: String,
+    val vendor: String? = null,
+    val version: String? = null,
+    val category: String? = null,
+    val installationPath: String? = null,
+    val installedAt: LocalDateTime? = null,
+    val lastUsedAt: LocalDateTime? = null,
+    val lastUpdatedAt: LocalDateTime? = null
+)


### PR DESCRIPTION
### Motivation
- Provide a way to import installed/product/application inventory from CrowdStrike Discover into SecMan for systems known in the database, enabling product-level reporting and drilldowns in Vulnerability Management.
- Allow operators to run the import from the CLI with device-type selection and a dry-run option to preview changes before writing to the backend.
- Expose the imported data in the Vulnerability Management UI via a new “Installed products” page and a sidebar link.

### Description
- Shared: added `InstalledProductDto` to `shared.crowdstrike.dto` and extended `CrowdStrikeApiClient`/`CrowdStrikeApiClientImpl` with a streaming API `queryInstalledProductsStreaming(...)` that pages the CrowdStrike Discover applications endpoint and maps responses to `InstalledProductDto`.
- Backend domain/repo/service/controller: introduced `InstalledProduct` JPA entity, `InstalledProductRepository`, `InstalledProductImportService` (import logic with dry-run support and asset resolution), `InstalledProductController` with `GET /api/installed-products` and `POST /api/installed-products/import`, and DTOs in `InstalledProductDtos.kt` for import requests/responses.
- DB migration: added `V230__installed_products.sql` to create `installed_product` table and indices (logical index non-unique to avoid uniqueness migration failures in-situ).
- CLI: new `installed-products` command wired into `SecmanCli` and `InstalledProductsCommand` that calls the shared `CrowdStrikeApiClient` streaming method, supports `--device-type`, `--limit`, `--dry-run`, `--client-id/--client-secret`, `--backend-url`, and uses `InstalledProductStorageService` to post batches to backend import endpoint when not a dry run.
- Frontend: added a new page/component (`InstalledProducts.tsx`, `installed-products.astro`) and a small API client `installedProductService.ts`, and inserted a sidebar link under Vulnerability Management to `Installed products`.
- Tests: unit tests for import logic (`InstalledProductImportServiceTest`) and CLI help/registration (`SecmanCliTest`) were added.

### Testing
- Ran targeted unit tests: `:backendng:test --tests com.secman.service.InstalledProductImportServiceTest` and `:cli:test --tests com.secman.cli.SecmanCliTest`, both suites completed successfully (tests passed).
- Built the project via `./gradlew build`, which completed successfully after compiling changes and minor Kotlin fixes were applied.
- Frontend lint: ran `npm run lint` in `src/frontend` which reported failures (547 problems: 251 errors, 296 warnings); these are pre-existing/independent UI lint issues and are not introduced by the new installed-products files (the new frontend files are minimal), so frontend lint must be addressed separately before a full frontend gate is cleared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1862ed38708323b4239e233948c5b1)