### PR TITLE
fix(installed-products): harden product import and listing

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
@@ -4,6 +4,7 @@ import com.secman.dto.InstalledProductImportRequest
 import com.secman.dto.InstalledProductListResponse
 import com.secman.dto.InstalledProductResponse
 import com.secman.repository.InstalledProductRepository
+import com.secman.service.AccessibleAssetIdsCache
 import com.secman.service.InstalledProductImportService
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
@@ -24,18 +25,43 @@ import org.slf4j.LoggerFactory
 @ExecuteOn(TaskExecutors.BLOCKING)
 open class InstalledProductController(
     private val installedProductRepository: InstalledProductRepository,
-    private val installedProductImportService: InstalledProductImportService
+    private val installedProductImportService: InstalledProductImportService,
+    private val accessibleAssetIdsCache: AccessibleAssetIdsCache
 ) {
     private val log = LoggerFactory.getLogger(InstalledProductController::class.java)
 
     @Get
     open fun list(
+        authentication: Authentication,
         @Nullable @QueryValue search: String?,
         @Nullable @QueryValue limit: Int?
     ): HttpResponse<InstalledProductListResponse> {
         val effectiveLimit = (limit ?: 500).coerceIn(1, 2000)
         val normalizedSearch = search?.trim().orEmpty()
-        val products = installedProductRepository.search(normalizedSearch).take(effectiveLimit)
+        val isAdmin = authentication.roles.contains("ADMIN")
+        val accessibleAssetIds = if (isAdmin) null else accessibleAssetIdsCache.get(authentication)
+
+        if (accessibleAssetIds != null && accessibleAssetIds.isEmpty()) {
+            return HttpResponse.ok(
+                InstalledProductListResponse(
+                    products = emptyList(),
+                    totalProducts = 0,
+                    totalSystems = 0
+                )
+            )
+        }
+
+        val products = if (accessibleAssetIds == null) {
+            installedProductRepository.search(normalizedSearch).take(effectiveLimit)
+        } else {
+            installedProductRepository.searchForAssets(normalizedSearch, accessibleAssetIds).take(effectiveLimit)
+        }
+        val totalSystems = if (accessibleAssetIds == null) {
+            installedProductRepository.countDistinctAssets(normalizedSearch)
+        } else {
+            installedProductRepository.countDistinctAssetsForAssets(normalizedSearch, accessibleAssetIds)
+        }
+
         return HttpResponse.ok(
             InstalledProductListResponse(
                 products = products.map { product ->
@@ -47,7 +73,7 @@ open class InstalledProductController(
                         vendor = product.vendor,
                         version = product.version,
                         category = product.category,
-                        installationPath = product.installationPath,
+                        installationPath = null,
                         installedAt = product.installedAt,
                         lastUsedAt = product.lastUsedAt,
                         lastUpdatedAt = product.lastUpdatedAt,
@@ -55,7 +81,7 @@ open class InstalledProductController(
                     )
                 },
                 totalProducts = products.size,
-                totalSystems = installedProductRepository.countDistinctAssets(normalizedSearch)
+                totalSystems = totalSystems
             )
         )
     }
@@ -66,6 +92,12 @@ open class InstalledProductController(
         @Body @Valid request: InstalledProductImportRequest,
         authentication: Authentication
     ): HttpResponse<*> {
+        if (request.products.size > InstalledProductImportService.MAX_PRODUCTS_PER_REQUEST) {
+            return HttpResponse.badRequest(
+                mapOf("error" to "At most ${InstalledProductImportService.MAX_PRODUCTS_PER_REQUEST} products can be imported per request")
+            )
+        }
+
         log.info(
             "Installed products import request: products={}, dryRun={}, user={}",
             request.products.size,

--- a/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
@@ -11,6 +11,13 @@ interface InstalledProductRepository : JpaRepository<InstalledProduct, Long> {
 
     @Query("""
         SELECT p FROM InstalledProduct p
+        WHERE p.externalId = :externalId
+          AND p.asset.id = :assetId
+    """)
+    fun findByExternalIdAndAssetId(externalId: String, assetId: Long): InstalledProduct?
+
+    @Query("""
+        SELECT p FROM InstalledProduct p
         WHERE p.asset.id = :assetId
           AND LOWER(p.name) = LOWER(:name)
           AND COALESCE(LOWER(p.vendor), '') = COALESCE(LOWER(:vendor), '')
@@ -30,11 +37,35 @@ interface InstalledProductRepository : JpaRepository<InstalledProduct, Long> {
     fun search(search: String?): List<InstalledProduct>
 
     @Query("""
+        SELECT p FROM InstalledProduct p
+        WHERE p.asset.id IN (:assetIds)
+          AND (:search IS NULL OR :search = ''
+            OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.vendor, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :search, '%')))
+        ORDER BY p.name ASC, p.vendor ASC, p.version ASC, p.asset.name ASC
+    """)
+    fun searchForAssets(search: String?, assetIds: Set<Long>): List<InstalledProduct>
+
+    @Query("""
         SELECT COUNT(DISTINCT p.asset.id) FROM InstalledProduct p
         WHERE (:search IS NULL OR :search = ''
             OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))
             OR LOWER(COALESCE(p.vendor, '')) LIKE LOWER(CONCAT('%', :search, '%'))
-            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%')))
+            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :search, '%')))
     """)
     fun countDistinctAssets(search: String?): Long
+
+    @Query("""
+        SELECT COUNT(DISTINCT p.asset.id) FROM InstalledProduct p
+        WHERE p.asset.id IN (:assetIds)
+          AND (:search IS NULL OR :search = ''
+            OR LOWER(p.name) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.vendor, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(COALESCE(p.version, '')) LIKE LOWER(CONCAT('%', :search, '%'))
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :search, '%')))
+    """)
+    fun countDistinctAssetsForAssets(search: String?, assetIds: Set<Long>): Long
 }

--- a/src/backendng/src/main/kotlin/com/secman/service/InstalledProductImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/InstalledProductImportService.kt
@@ -18,8 +18,16 @@ open class InstalledProductImportService(
 ) {
     private val log = LoggerFactory.getLogger(InstalledProductImportService::class.java)
 
+    companion object {
+        const val MAX_PRODUCTS_PER_REQUEST = 5_000
+    }
+
     @Transactional
     open fun importProducts(products: List<InstalledProductDto>, dryRun: Boolean): InstalledProductImportResponse {
+        require(products.size <= MAX_PRODUCTS_PER_REQUEST) {
+            "At most $MAX_PRODUCTS_PER_REQUEST products can be imported per request"
+        }
+
         var imported = 0
         var updated = 0
         var skipped = 0
@@ -29,15 +37,18 @@ open class InstalledProductImportService(
 
         products.forEach { dto ->
             try {
-                val asset = resolveAsset(dto.hostname)
+                val hostname = normalize(dto.hostname, 255)
+                val name = normalize(dto.name, 512)
+                if (name == null) {
+                    skipped++
+                    errors.add("Skipped blank product name for ${hostname ?: "unknown host"}")
+                    return@forEach
+                }
+
+                val asset = resolveAsset(hostname)
                 if (asset == null) {
                     unknownSystems++
                     skipped++
-                    return@forEach
-                }
-                if (dto.name.isBlank()) {
-                    skipped++
-                    errors.add("Skipped blank product name for ${dto.hostname}")
                     return@forEach
                 }
                 if (dryRun) {
@@ -46,20 +57,36 @@ open class InstalledProductImportService(
                 }
 
                 val assetId = requireNotNull(asset.id)
-                val existing = dto.externalId?.takeIf { it.isNotBlank() }?.let { installedProductRepository.findByExternalId(it) }
-                    ?: installedProductRepository.findLogicalDuplicate(assetId, dto.name, dto.vendor, dto.version)
+                val externalId = normalize(dto.externalId, 255)
+                val vendor = normalize(dto.vendor, 255)
+                val version = normalize(dto.version, 255)
+                val existing = externalId?.let { installedProductRepository.findByExternalIdAndAssetId(it, assetId) }
+                    ?: installedProductRepository.findLogicalDuplicate(assetId, name, vendor, version)
+
+                val conflictingAssetId = externalId
+                    ?.let { installedProductRepository.findByExternalId(it) }
+                    ?.asset
+                    ?.id
+                    ?.takeIf { it != assetId }
+                if (conflictingAssetId != null) {
+                    skipped++
+                    val message = "Skipped product '$name' for '$hostname': external id is already assigned to another asset"
+                    log.warn("{} (externalId={}, conflictingAssetId={})", message, externalId, conflictingAssetId)
+                    if (errors.size < 100) errors.add(message)
+                    return@forEach
+                }
 
                 if (existing == null) {
                     installedProductRepository.save(
                         InstalledProduct(
                             asset = asset,
-                            externalId = dto.externalId?.take(255),
-                            crowdStrikeAid = dto.aid?.take(64),
-                            name = dto.name.take(512),
-                            vendor = dto.vendor?.take(255),
-                            version = dto.version?.take(255),
-                            category = dto.category?.take(255),
-                            installationPath = dto.installationPath?.take(1024),
+                            externalId = externalId,
+                            crowdStrikeAid = normalize(dto.aid, 64),
+                            name = name,
+                            vendor = vendor,
+                            version = version,
+                            category = normalize(dto.category, 255),
+                            installationPath = normalize(dto.installationPath, 1024),
                             installedAt = dto.installedAt,
                             lastUsedAt = dto.lastUsedAt,
                             lastUpdatedAt = dto.lastUpdatedAt,
@@ -69,13 +96,13 @@ open class InstalledProductImportService(
                     imported++
                 } else {
                     existing.asset = asset
-                    existing.externalId = dto.externalId?.take(255) ?: existing.externalId
-                    existing.crowdStrikeAid = dto.aid?.take(64)
-                    existing.name = dto.name.take(512)
-                    existing.vendor = dto.vendor?.take(255)
-                    existing.version = dto.version?.take(255)
-                    existing.category = dto.category?.take(255)
-                    existing.installationPath = dto.installationPath?.take(1024)
+                    existing.externalId = externalId ?: existing.externalId
+                    existing.crowdStrikeAid = normalize(dto.aid, 64)
+                    existing.name = name
+                    existing.vendor = vendor
+                    existing.version = version
+                    existing.category = normalize(dto.category, 255)
+                    existing.installationPath = normalize(dto.installationPath, 1024)
                     existing.installedAt = dto.installedAt
                     existing.lastUsedAt = dto.lastUsedAt
                     existing.lastUpdatedAt = dto.lastUpdatedAt
@@ -102,10 +129,14 @@ open class InstalledProductImportService(
         )
     }
 
-    private fun resolveAsset(hostname: String): Asset? {
-        val trimmed = hostname.trim()
-        if (trimmed.isBlank()) return null
-        return assetRepository.findByNameIgnoreCase(trimmed)
-            ?: trimmed.substringBefore('.').takeIf { it.isNotBlank() && it != trimmed }?.let { assetRepository.findByNameIgnoreCase(it) }
+    private fun resolveAsset(hostname: String?): Asset? {
+        if (hostname.isNullOrBlank()) return null
+        return assetRepository.findByNameIgnoreCase(hostname)
+            ?: hostname.substringBefore('.').takeIf { it.isNotBlank() && it != hostname }?.let { assetRepository.findByNameIgnoreCase(it) }
     }
+
+    private fun normalize(value: String?, maxLength: Int): String? = value
+        ?.trim()
+        ?.takeIf { it.isNotBlank() }
+        ?.take(maxLength)
 }

--- a/src/backendng/src/test/kotlin/com/secman/service/InstalledProductImportServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/InstalledProductImportServiceTest.kt
@@ -30,6 +30,7 @@ class InstalledProductImportServiceTest {
         val asset = asset(1L, "server01")
         every { assetRepository.findByNameIgnoreCase("server01.example.com") } returns null
         every { assetRepository.findByNameIgnoreCase("server01") } returns asset
+        every { installedProductRepository.findByExternalIdAndAssetId("app-1", 1L) } returns null
         every { installedProductRepository.findByExternalId("app-1") } returns null
         every { installedProductRepository.findLogicalDuplicate(1L, "Chrome", "Google", "1.2.3") } returns null
         val saved = slot<InstalledProduct>()
@@ -74,6 +75,47 @@ class InstalledProductImportServiceTest {
 
         assertThat(result.productsSkipped).isEqualTo(1)
         assertThat(result.unknownSystems).isEqualTo(1)
+    }
+
+
+    @Test
+    fun `skips import when external id belongs to another asset`() {
+        val targetAsset = asset(1L, "server01")
+        val otherAsset = asset(2L, "server02")
+        every { assetRepository.findByNameIgnoreCase("server01") } returns targetAsset
+        every { installedProductRepository.findByExternalIdAndAssetId("app-1", 1L) } returns null
+        every { installedProductRepository.findLogicalDuplicate(1L, "Chrome", "Google", "1.2.3") } returns null
+        every { installedProductRepository.findByExternalId("app-1") } returns InstalledProduct(
+            id = 99L,
+            asset = otherAsset,
+            externalId = "app-1",
+            name = "Chrome"
+        )
+
+        val result = service.importProducts(
+            listOf(InstalledProductDto(externalId = "app-1", hostname = "server01", name = "Chrome", vendor = "Google", version = "1.2.3")),
+            dryRun = false
+        )
+
+        assertThat(result.productsSkipped).isEqualTo(1)
+        assertThat(result.errors).anySatisfy { error ->
+            assertThat(error).contains("external id is already assigned to another asset")
+        }
+        verify(exactly = 0) { installedProductRepository.save(any()) }
+        verify(exactly = 0) { installedProductRepository.update(any<InstalledProduct>()) }
+    }
+
+    @Test
+    fun `rejects oversized import batches`() {
+        val products = List(InstalledProductImportService.MAX_PRODUCTS_PER_REQUEST + 1) { index ->
+            InstalledProductDto(hostname = "server$index", name = "Product $index")
+        }
+
+        val thrown = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            service.importProducts(products, dryRun = true)
+        }
+
+        assertThat(thrown.message).contains("At most ${InstalledProductImportService.MAX_PRODUCTS_PER_REQUEST} products")
     }
 
     private fun asset(id: Long, name: String): Asset = Asset(


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from seeing installed-product rows from assets they do not have access to and avoid leaking installation path details.
- Harden the CrowdStrike-installed-product import path against large/batch abuse and cross-asset `externalId` collisions.
- Normalize incoming strings and improve duplicate detection to reduce accidental data corruption during imports.

### Description
- Enforce access control in `InstalledProductController.list` by using `AccessibleAssetIdsCache` and `searchForAssets`/`countDistinctAssetsForAssets` for non-admin callers, and return an empty listing when the user has no accessible assets, and stop returning `installationPath` in list responses.
- Add repository queries in `InstalledProductRepository` including `findByExternalIdAndAssetId`, `searchForAssets`, and `countDistinctAssetsForAssets` to support asset-scoped lookups.
- Harden `InstalledProductImportService` with `MAX_PRODUCTS_PER_REQUEST` limit, input `normalize(...)` trimming/truncation, asset-scoped `externalId` lookup, and a conflict check that skips/records an error if an `externalId` is already assigned to a different asset.
- Add unit tests in `InstalledProductImportServiceTest` to cover external-id collision rejection and oversized-batch rejection.

### Testing
- Ran the backend unit suite for the feature with `./gradlew :backendng:test --tests "com.secman.service.InstalledProductImportServiceTest"`, which completed successfully.
- Attempted frontend automated lint with `cd src/frontend && npm run lint`, which failed due to existing unrelated frontend lint errors (251 errors / 296 warnings) and is outside the backend changes here.
- Attempts to run the JS error scanner and the full vuln+exception E2E driver were blocked by missing environment tools: `pass-cli` (blocks `./tests/js-error-scanner-pp.sh`) and `mariadb` (blocks `./scripts/test/test-e2e-vuln-exception-full.sh`), so those E2E checks could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186df4ce748323af368749b59a5227)