### PR TITLE
docs(cli): expand installed-products guidance

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,6 +72,40 @@ Full env reference: `docs/ENVIRONMENT.md`.
 | `--output-file` / `--format` | — / `json` | `json|csv` |
 | `--verbose` / `--insecure` | false | `--insecure` allows self-signed TLS |
 
+### `installed-products` — CrowdStrike Discover software inventory
+
+Imports installed product/application rows from CrowdStrike Discover into SecMan for assets that already exist in the backend. Use this after `query servers --save` or another asset import has populated the systems table; the command does **not** create missing assets. Unknown hosts are counted as skipped `unknown systems` so operators can identify inventory gaps.
+
+```bash
+# Preview Discover coverage without authenticating to SecMan or writing backend data
+./scripts/secman installed-products --device-type SERVER --dry-run
+
+# Import software inventory for known servers
+./scripts/secman installed-products --device-type SERVER --backend-url https://secman.example.com
+
+# Include servers and workstations, with smaller CrowdStrike pages for constrained environments
+./scripts/secman installed-products --device-type ALL --limit 500 --verbose
+```
+
+| Option | Default | Notes |
+|---|---|---|
+| `--device-type` | `SERVER` | CrowdStrike Discover host filter: `SERVER`, `WORKSTATION`, or `ALL`. `ALL` queries servers and workstations separately. |
+| `--dry-run` | false | Queries CrowdStrike and prints per-batch/summary counts only; does not authenticate to SecMan and does not write backend data. |
+| `--limit` | 1000 | CrowdStrike page size; values are coerced to the API-safe range `1..1000`. This is not a total-row cap. |
+| `--backend-url` | `SECMAN_BACKEND_URL`, then `SECMAN_HOST`, then `http://localhost:8080` | Backend API URL for import mode. `SECMAN_HOST` may be a bare hostname; the CLI prefixes `https://`. |
+| `--client-id` / `--client-secret` | config/env | CrowdStrike API credentials; both must be provided to override `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` or `~/.secman` config. |
+| `--verbose` | false | Prints backend import errors, capped by the backend response. |
+
+Import mode requires `SECMAN_ADMIN_NAME` and `SECMAN_ADMIN_PASS`; the authenticated user must have backend access to `POST /api/installed-products/import` (`ADMIN` or `VULN`). The UI/API listing endpoint `GET /api/installed-products` is available to `ADMIN`, `VULN`, and `SECCHAMPION`, and non-admin listings are filtered to assets the user can access.
+
+Backend import semantics:
+
+- Each CLI batch is posted to `/api/installed-products/import`, which accepts at most 5,000 product rows per request.
+- Rows are matched to an existing asset by case-insensitive hostname; if the CrowdStrike hostname is fully qualified, the short name before the first dot is tried as a fallback.
+- Products are upserted by `(externalId, asset)` when CrowdStrike provides an external ID, otherwise by logical duplicate `(asset, name, vendor, version)`.
+- Product names are required. Blank names, unknown systems, and external IDs already assigned to a different asset are skipped and reflected in the summary.
+- Imported fields include CrowdStrike AID, product name, vendor, version, category, installation path, installed timestamp, last-used timestamp, last-updated timestamp, and SecMan import timestamp.
+
 ### `delete-asset-not-seen` — CrowdStrike stale asset cleanup
 
 Deletes assets that have not appeared in a CrowdStrike import for more than N days. Always run `--dry-run` first.

--- a/docs/CROWDSTRIKE_IMPORT.md
+++ b/docs/CROWDSTRIKE_IMPORT.md
@@ -10,6 +10,27 @@ SECMAN_BACKEND_URL=https://secman.example.com SECMAN_SSL_INSECURE=true \
   --severity CRITICAL,HIGH --min-days-open 1 --last-seen-days 1 --save
 ```
 
+## Installed products import
+
+Installed products are synchronized from CrowdStrike Discover with the separate CLI command `secman installed-products`. This is a software-inventory import, not a vulnerability import, and it intentionally only attaches rows to assets that already exist in SecMan. Run a vulnerability/asset import such as `query servers --save` first when onboarding a new environment.
+
+```bash
+./scripts/secman installed-products --device-type SERVER --dry-run
+./scripts/secman installed-products --device-type SERVER --backend-url https://secman.example.com
+./scripts/secman installed-products --device-type ALL --limit 500 --verbose
+```
+
+Operational notes:
+
+1. `--dry-run` queries CrowdStrike Discover and reports row/host counts without authenticating to the SecMan backend.
+2. Import mode authenticates with `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` and posts each page to `POST /api/installed-products/import`; the backend allows `ADMIN` and `VULN` roles for this endpoint.
+3. CrowdStrike host filters are `SERVER`, `WORKSTATION`, or `ALL`; `ALL` runs the server and workstation filters separately.
+4. Backend matching is hostname-based and case-insensitive, with a fallback from FQDN to short hostname. Missing assets are counted as `unknown systems` and skipped rather than auto-created.
+5. Upserts prefer CrowdStrike external ID scoped to the asset, then fall back to logical duplicate matching on asset, product name, vendor, and version. Conflicting external IDs assigned to another asset are skipped.
+6. `GET /api/installed-products` lists imported products for `ADMIN`, `VULN`, and `SECCHAMPION`; non-admin callers only see products for accessible assets.
+
+See `docs/CLI.md` for the full option table and troubleshooting guidance.
+
 ## Pattern: transactional replace
 
 For each (Asset, batch) pair, in one transaction:

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Stack: Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 /
 | [ENVIRONMENT.md](./ENVIRONMENT.md) | All env vars (backend / frontend / CLI) |
 | [CLI.md](./CLI.md) | CLI commands, cron, S3, AWS Secrets Manager |
 | [MCP.md](./MCP.md) | MCP tools, API keys, delegation, troubleshooting |
-| [CROWDSTRIKE_IMPORT.md](./CROWDSTRIKE_IMPORT.md) | Transactional-replace pattern + JPA cascade trap |
+| [CROWDSTRIKE_IMPORT.md](./CROWDSTRIKE_IMPORT.md) | Vulnerability and installed-product imports, transactional-replace pattern, JPA cascade trap |
 | [TESTING.md](./TESTING.md) | JUnit/Mockk/Testcontainers stack and patterns |
 | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Symptom → fix |
 | [E2E_EXCEPTION_WORKFLOW_TEST.md](./E2E_EXCEPTION_WORKFLOW_TEST.md) | Vuln-exception MCP E2E |

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -402,7 +402,7 @@ class SecmanCli {
               CrowdStrike:
                 query                  Query CrowdStrike vulnerabilities for a single host
                 query servers          Batch query and import server vulnerabilities
-                installed-products     Import CrowdStrike installed products for known systems
+                installed-products     Import CrowdStrike Discover software inventory for known systems
                 monitor                Continuously monitor for HIGH/CRITICAL vulnerabilities
                 config                 Configure CrowdStrike API credentials
                 crowdstrike-last-import  Show timestamp of the most recent CrowdStrike import
@@ -501,25 +501,35 @@ class SecmanCli {
             """.trimIndent(),
 
             "installed-products" to """
-                secman installed-products - Import CrowdStrike installed products
+                secman installed-products - Import CrowdStrike Discover software inventory
 
                 Usage: secman installed-products [options]
 
-                Options:
-                  --device-type <type>     Device type: SERVER, WORKSTATION, or ALL (default: SERVER)
-                  --dry-run                Query CrowdStrike and print summary without writing backend data
-                  --limit <num>            CrowdStrike page size, max 1000 (default: 1000)
-                  --backend-url <url>      Backend API URL (overrides SECMAN_BACKEND_URL/SECMAN_HOST)
-                  --client-id <id>         CrowdStrike API client ID (overrides config file)
-                  --client-secret <secret> CrowdStrike API client secret (overrides config file)
-                  --verbose                Show detailed backend errors
+                Purpose:
+                  Queries CrowdStrike Discover applications and imports installed
+                  product/application rows for assets that already exist in SecMan.
+                  Missing hosts are skipped and counted as unknown systems; this
+                  command does not create assets.
 
-                Requires SECMAN_ADMIN_NAME and SECMAN_ADMIN_PASS unless --dry-run is used.
+                Options:
+                  --device-type <type>     CrowdStrike host filter: SERVER, WORKSTATION, or ALL (default: SERVER)
+                  --dry-run                Query CrowdStrike only; print batch/summary counts without backend auth or writes
+                  --limit <num>            CrowdStrike page size, coerced to 1..1000 (default: 1000)
+                  --backend-url <url>      Backend API URL (overrides SECMAN_BACKEND_URL/SECMAN_HOST; SECMAN_HOST may be bare host)
+                  --client-id <id>         CrowdStrike API client ID (overrides env/config when paired with --client-secret)
+                  --client-secret <secret> CrowdStrike API client secret (overrides env/config when paired with --client-id)
+                  --verbose                Show detailed backend import errors
+
+                Import behavior:
+                  - Requires SECMAN_ADMIN_NAME and SECMAN_ADMIN_PASS unless --dry-run is used.
+                  - Backend role must be ADMIN or VULN for POST /api/installed-products/import.
+                  - Asset matching uses case-insensitive hostname, then short hostname for FQDNs.
+                  - Product upsert uses CrowdStrike external ID scoped to the asset, or asset/name/vendor/version.
 
                 Examples:
-                  secman installed-products --device-type SERVER
-                  secman installed-products --device-type WORKSTATION --dry-run
-                  secman installed-products --device-type ALL --limit 500
+                  secman installed-products --device-type SERVER --dry-run
+                  secman installed-products --device-type SERVER --backend-url https://secman.example.com
+                  secman installed-products --device-type ALL --limit 500 --verbose
             """.trimIndent(),
             "query-servers" to """
                 secman query servers - Batch query and import server vulnerabilities

--- a/src/cli/src/test/kotlin/com/secman/cli/SecmanCliTest.kt
+++ b/src/cli/src/test/kotlin/com/secman/cli/SecmanCliTest.kt
@@ -107,8 +107,11 @@ class SecmanCliTest {
 
         assertEquals(0, result)
         assertTrue(output.contains("secman installed-products"))
+        assertTrue(output.contains("CrowdStrike Discover software inventory"))
         assertTrue(output.contains("--device-type"))
         assertTrue(output.contains("--dry-run"))
+        assertTrue(output.contains("unknown systems"))
+        assertTrue(output.contains("POST /api/installed-products/import"))
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Make the `installed-products` command and its backend contract explicit so operators understand it is a CrowdStrike Discover software-inventory import (not a vuln import) and how unknown hosts are handled.
- Consolidate operational notes into CLI and CrowdStrike docs so examples, auth/RBAC requirements, matching/upsert semantics and batch limits are discoverable in one place.

### Description
- Added a new `installed-products` section to `docs/CLI.md` with examples, option table, auth/RBAC notes and backend import semantics (batch size, host matching, upsert behavior, skipped/unknown systems, imported fields). (`docs/CLI.md`)
- Added an `Installed products import` subsection to `docs/CROWDSTRIKE_IMPORT.md` clarifying that `secman installed-products` is a separate software-inventory import and listing operational notes. (`docs/CROWDSTRIKE_IMPORT.md`)
- Updated `docs/README.md` index to reflect that the CrowdStrike doc covers both vulnerability and installed-product imports. (`docs/README.md`)
- Expanded the CLI help text shown by `secman help installed-products` and adjusted the short command description in the top-level `secman` help. (`src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt`)
- Tightened unit test expectations to assert the new help text content (updated `SecmanCliTest.kt`). (`src/cli/src/test/kotlin/com/secman/cli/SecmanCliTest.kt`)

### Testing
- Ran a grep-based verification to confirm updated strings are present in docs and CLI sources using `rg` and file checks, which succeeded and shows the new help/docs entries are in place.
- Attempted to run the CLI unit test target with `./gradlew :cli:test --tests com.secman.cli.SecmanCliTest`, but the Gradle run failed due to a Java toolchain mismatch (Gradle expected Java 21; environment had Java 25 and no configured toolchain download repositories), so tests could not be executed in this environment.
- Committed the changes (`docs(cli): expand installed-products guidance`) and opened this PR; no further automated gates (E2E) were executed because the unit test run was blocked by the local toolchain issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a825d03ec83239c08c8ea9edab5fe)