### PR TITLE
Add Word export template support: upload, validation, persistence, rendering, UI and APIs

### DIFF
--- a/specs/089-requirement-word-template-upload/checklists/requirements.md
+++ b/specs/089-requirement-word-template-upload/checklists/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Checklist — Requirement Word Export Templates
+
+## Completeness
+
+- [x] Problem, goals, non-goals, and user stories are documented.
+- [x] Latest saved template and ad hoc upload behavior are specified.
+- [x] UI attributes/options are proposed for the export window.
+- [x] Backend API, data model, implementation phases, and tests are planned.
+- [x] Security review covers upload, storage, rendering, RBAC, audit, and residual risks.
+
+## Ambiguities to confirm before implementation
+
+- [ ] Confirm whether latest saved template should be single global latest or scoped by workgroup/product/release.
+- [ ] Confirm maximum template size and whether antivirus scanning is available in target deployments.
+- [ ] Confirm whether normal REQ/REPORT users may select saved templates or if REQADMIN must export official documents.
+- [ ] Confirm required corporate classification labels.

--- a/specs/089-requirement-word-template-upload/security-review.md
+++ b/specs/089-requirement-word-template-upload/security-review.md
@@ -1,0 +1,101 @@
+# Security Review — Requirement Word Export Templates
+
+**Feature**: 089 — Requirement Word Export Templates
+**Review status**: Design review complete; implementation must complete verification checklist before merge.
+**Decision**: Approved to implement only with the mandatory controls below.
+
+## Scope reviewed
+
+The feature introduces upload, validation, persistence, rendering, and reuse of Microsoft Word `.docx` templates for requirement exports. It affects authenticated browser flows, CLI/MCP export paths, document generation, persistent file storage, audit logging, and role-based access control.
+
+## Key assets
+
+- Requirement content and release snapshots included in generated exports.
+- Uploaded template binaries and metadata.
+- User identity, role, and export audit history.
+- Backend file storage and document processing runtime.
+- Generated `.docx` output returned to users.
+
+## Threat model
+
+| Threat | Risk | Required mitigation |
+|---|---|---|
+| Malicious upload disguised as `.docx` | Remote code execution, parser exploit, malicious content propagation | Verify extension, MIME, ZIP signature, OpenXML content types, and reject macro-enabled or non-Word packages. Use patched Apache POI/XML libraries. |
+| ZIP bomb or oversized package | Memory/CPU exhaustion | Enforce max compressed size, max uncompressed size, max entries, max XML part size, max image count/size, stream parsing where possible, and request body limits. |
+| Macros, OLE, embedded packages, active content | Malware distribution to export recipients | Reject `vbaProject.bin`, OLE objects, embedded packages, ActiveX, remote templates, external relationships, and unsupported relationship types. |
+| SSRF via external relationships or remote images | Backend network access during parsing/rendering | Disable external resource resolution; reject external targets; never fetch remote relationships. |
+| Template injection into generated XML | Broken documents, data exfiltration links, stored XSS-like issues in Office | Escape placeholder values, restrict placeholders to allowlist, validate final package relationships, and do not allow arbitrary XML fragments as placeholder values. |
+| Unauthorized template management | Official exports modified by untrusted users | Restrict upload/activation/deactivation/download to ADMIN/REQADMIN; enforce server-side checks independent of UI. |
+| Unauthorized export data access | Requirement data disclosure | Reuse existing export authorization and scope filtering; template selection must not widen data access. |
+| Path traversal or unsafe filenames | File overwrite/read, response header injection | Generate storage keys server-side; sanitize display filename; use safe `Content-Disposition`; never use client filenames as paths. |
+| Persistent malicious file storage | Long-lived malware at rest | Store outside web root/object-store private bucket; scan if AV service is available; retain SHA-256; allow retirement/deletion according to policy. |
+| Audit gap or repudiation | Cannot prove which template produced an official export | Log upload, validation, activation, deactivation, deletion/retirement, and every export usage with actor, template id/checksum, mode, scope, and timestamp. |
+| Information leakage in validation errors | Server path or XML internals exposed | Return normalized validation codes/messages; log technical details server-side only. |
+| Concurrency/default race | Wrong latest template used | Resolve template id at export start inside a transaction; record resolved id/checksum in usage event and output metadata. |
+| Dependency vulnerabilities | Parser compromise | Pin and scan dependencies; include POI/XML parser CVE review before release. |
+
+## Mandatory security controls
+
+### Upload validation
+
+- Accept only `.docx`, not `.doc`, `.dotm`, `.docm`, `.rtf`, `.html`, or renamed macro-enabled packages.
+- Validate:
+  - request content length and configured file-size limit;
+  - ZIP magic bytes and valid central directory;
+  - `[Content_Types].xml` OpenXML Word document type;
+  - absence of `word/vbaProject.bin`, ActiveX, OLE, embedded package parts, and external relationship targets;
+  - bounded number and size of ZIP entries, XML parts, media files, styles, numbering, headers, and footers;
+  - presence of `${requirements}` unless append mode is explicitly selected.
+- Compute SHA-256 before persistence and store it in metadata and audit events.
+
+### Rendering isolation
+
+- Render templates in a bounded worker path with configured timeouts and memory-conscious parsing.
+- Disable XML external entity resolution and any external resource fetching.
+- Treat all placeholder values as plain text and escape them through the document API.
+- Re-validate the final generated package relationships before returning the download.
+
+### Authorization and RBAC
+
+- Upload, activate, deactivate, retire, delete, and original-template download: ADMIN/REQADMIN only.
+- Export with active templates: roles already allowed to export requirements, without increasing the requirement data scope.
+- Server-side role checks are mandatory for every endpoint; frontend role hiding is convenience only.
+- MCP/CLI paths must use the same backend checks and must not bypass validation.
+
+### Storage and retention
+
+- Store templates outside the static web root or in a private object-store bucket with generated opaque keys.
+- Do not persist ad hoc templates unless explicitly saved by an authorized user.
+- If malware scanning infrastructure exists, scan saved templates before activation; otherwise document the residual risk and keep validation strict.
+- Hard delete only unused drafts. Retire used templates to preserve export provenance.
+
+### Audit and monitoring
+
+- Audit events must include actor id, actor username/email where available, IP/session/request id where available, template id, checksum, selected mode, export scope, release/use-case/language, outcome, and timestamp.
+- Add metrics/alerts for repeated validation failures, oversized uploads, rejected active content, and template render failures.
+- Log validation details at a safe level without storing full document content in logs.
+
+## Privacy and data classification
+
+- Templates may contain company logos, classifications, and static introductory text. Treat saved templates as internal business documents.
+- Exported documents contain requirement data and potentially release/use-case context. Existing download handling and transport security requirements continue to apply.
+- `${exportedBy}` and audit events introduce user identity into documents/logs; this must be intentional and visible in the UI option labels.
+
+## Residual risks
+
+- Office clients may still warn users about content depending on local security policy even after server-side validation.
+- Apache POI/OpenXML parsing can still receive malformed edge cases; dependency patching and resource limits are required operational controls.
+- Without antivirus scanning, validation reduces but does not eliminate all malware risks in stored templates.
+
+## Security verification checklist
+
+- [ ] Unit tests reject macro-enabled files, OLE/embedded packages, external relationships, missing placeholders, and ZIP bombs.
+- [ ] Integration tests prove REQ/REPORT cannot upload, activate, deactivate, delete, or download original templates.
+- [ ] Export tests prove template selection does not change requirement scope or release/use-case filters.
+- [ ] Audit tests prove upload, validation failure, activation/deactivation, ad hoc export, saved export, and no-template export are logged.
+- [ ] Dependency scan confirms document-processing libraries have no known high/critical CVEs at release time.
+- [ ] Manual security review verifies response headers, filename sanitization, and no server paths/stack traces in validation errors.
+
+## Go/no-go recommendation
+
+Proceed with implementation only if the validator is built before persistence/rendering and all upload endpoints are protected by ADMIN/REQADMIN. Do not ship ad hoc template upload until resource limits, forbidden relationship detection, and audit events are in place.

--- a/specs/089-requirement-word-template-upload/spec.md
+++ b/specs/089-requirement-word-template-upload/spec.md
@@ -1,0 +1,226 @@
+# Feature 089 — Requirement Word Export Templates
+
+**Branch**: `work`
+**Status**: Planned — ready for implementation
+**Owner roles touched**: REQ, REQADMIN, ADMIN, REPORT
+**Security review**: Required because the feature adds authenticated file upload, server-side document parsing, persistent binary storage, and export-time template processing.
+
+## Problem
+
+Requirement Word exports currently generate a fixed `.docx` from code. Users can export current requirements or release/use-case subsets, but they cannot apply a company-specific Word template containing headers, footers, logos, introductory text, document control pages, or approved styles. This creates manual post-processing after every export and increases the risk that official requirement documents diverge from the exported source data.
+
+## Goal
+
+Allow authorized users to upload a reusable `.docx` export template into Secman and select it for Word requirement exports. The export window must support both:
+
+1. **Ad hoc template upload**: use a file for this export run without making it the default.
+2. **Saved latest template**: persist approved templates in Secman and automatically use the latest active template on the next Word export unless the user opts out or picks another template.
+
+## Non-goals
+
+- No template support for Excel exports in v1.
+- No arbitrary scripting, macros, external template links, or embedded active content.
+- No rich template designer in Secman; users prepare `.docx` files in Word/LibreOffice.
+- No public unauthenticated template management endpoint.
+- No replacement of requirement data authorization; exports must keep the existing requirement/release/use-case filtering behavior.
+
+## User stories
+
+### US1 (P1) — Upload and save a default Word template
+
+As a REQADMIN, I want to upload a corporate `.docx` template and save it in Secman so that future Word exports automatically use the latest approved formatting, headers, footer text, and introductory content.
+
+**Independent test**: Upload a valid `.docx` with a header, footer, logo, intro section, and the `${requirements}` placeholder; verify it appears in the template list as active; export requirements without choosing a template; verify the generated Word file uses that latest active template.
+
+### US2 (P1) — Use a one-time ad hoc template during export
+
+As a user exporting requirements, I want to attach a template directly in the export dialog for this one export without changing the stored default so that I can produce a project-specific document.
+
+**Independent test**: With default template A saved, upload ad hoc template B in the export dialog, export once, and verify the output uses B while the latest saved template remains A for the next export.
+
+### US3 (P2) — Choose template behavior per export
+
+As a user exporting requirements, I want to choose whether the export uses the latest saved template, a specific saved template, an ad hoc upload, or the system default so that I can generate the right output for draft, official, and customer-specific scenarios.
+
+**Independent test**: Export the same requirement subset using each mode and verify the output reflects the selected mode while the underlying requirement content and authorization scope remain unchanged.
+
+### US4 (P2) — Review template metadata and audit usage
+
+As an ADMIN or REQADMIN, I want to see who uploaded a template, when it was uploaded, whether it is active, and where it has been used so that document provenance can be audited.
+
+**Independent test**: Upload two templates, deactivate the older one, export with the latest active template, and verify audit entries capture uploader, selected template, checksum, export actor, scope, and timestamp.
+
+### US5 (P3) — Preview template validity before saving
+
+As a REQADMIN, I want Secman to validate a template and show detected placeholders/options before saving it so that broken templates are not discovered during an official export.
+
+**Independent test**: Upload templates with missing `${requirements}`, duplicate placeholders, external relationships, and unsupported file type; verify validation warnings/errors before persistence.
+
+## Functional requirements
+
+- FR-1: Secman must accept only `.docx` template uploads with the OpenXML Word MIME type and a valid ZIP/OpenXML structure.
+- FR-2: Template uploads must be restricted to ADMIN and REQADMIN by default. REQ and REPORT users may select active templates for export but must not create, update, or delete templates unless an explicit configuration enables it.
+- FR-3: The export dialog must offer template modes: `Latest saved template`, `Specific saved template`, `Ad hoc upload for this export`, and `No template / Secman default`.
+- FR-4: If the user leaves the template mode unchanged, Word exports must use the latest active saved template when one exists; otherwise they must fall back to the existing generated document layout.
+- FR-5: Ad hoc templates must be processed only for the current request and must not be persisted as saved templates unless the user also has upload permission and explicitly chooses `Save as reusable template`.
+- FR-6: Saved templates must store metadata: display name, description, version label, uploaded filename, content type, file size, SHA-256 checksum, status, uploadedBy, createdAt, activatedAt, deactivatedAt, lastUsedAt, and optional retention/deletion fields.
+- FR-7: The system must keep immutable binary contents for a template version. Editing metadata must not mutate the original uploaded bytes; replacing a template creates a new version row.
+- FR-8: The export renderer must insert generated requirement content at `${requirements}`. If the placeholder is missing and the user selected `append mode`, generated requirements must be appended after the template body; otherwise validation must reject the template.
+- FR-9: Supported placeholders in v1 must include `${requirements}`, `${documentTitle}`, `${exportDate}`, `${releaseVersion}`, `${releaseStatus}`, `${useCaseName}`, `${exportedBy}`, `${language}`, `${requirementCount}`, and `${classification}`.
+- FR-10: The renderer must preserve template headers, footers, page margins, numbering definitions, styles, static intro text, and static images that pass validation.
+- FR-11: The renderer must strip or reject macros, OLE objects, embedded packages, external relationships, external hyperlinks in headers/footers unless allowed by configuration, remote images, and active content.
+- FR-12: The export API must support template selection for all current Word export variants: all requirements, use-case exports, release snapshots, translated exports, and MCP/CLI Word exports.
+- FR-13: Template validation failures must produce user-friendly error messages without leaking server paths, stack traces, or raw document XML.
+- FR-14: Every upload, validation failure, activation/deactivation, deletion, and export usage must be written to the audit log.
+- FR-15: Downloading a saved template for review must be restricted to ADMIN and REQADMIN and must set safe `Content-Disposition` filenames.
+- FR-16: Template size, placeholder count, image count, and total uncompressed ZIP size must be bounded by configuration.
+- FR-17: The feature must be covered by backend unit/integration tests, frontend component/E2E tests, CLI tests for template options, and MCP contract tests where applicable.
+
+## UI proposal
+
+### Export window attributes/options
+
+Add a **Word template** section that appears only when the selected export format is Word (`.docx`). Meaningful fields:
+
+| Field | Type | Default | Purpose |
+|---|---|---:|---|
+| Template mode | Radio group | Latest saved template | Controls automatic latest-template behavior, specific selection, ad hoc upload, or no template. |
+| Saved template | Select | Latest active | Lists active templates with name, version, uploader, upload date, and last-used date. Enabled for `Specific saved template`. |
+| Ad hoc template file | File picker | Empty | Accepts one `.docx` for `Ad hoc upload for this export`. |
+| Save as reusable template | Checkbox | Off | Only visible for ADMIN/REQADMIN during ad hoc upload; persists the uploaded file after successful validation. |
+| Template name | Text | Filename stem | Required when saving reusable templates. |
+| Version label | Text | Auto timestamp | Optional human-readable version such as `Corporate 2026-Q2`. |
+| Description | Text area | Empty | Documents template intent, approved audience, or project/customer context. |
+| Missing placeholder behavior | Select | Reject | `Reject` requires `${requirements}`; `Append after template body` appends generated content. |
+| Include cover metadata | Checkbox | On | Populates document title, release/use-case/language, export date, exported-by, and requirement count placeholders. |
+| Classification | Select/text | Internal | Populates `${classification}` and supports future policy-driven labels. |
+| Validate only | Button | — | Runs server validation and reports placeholders, blocked objects, size, images, and styles before export/save. |
+| Preview summary | Read-only panel | — | Shows selected template checksum prefix, validation status, active/latest marker, and warnings. |
+
+### Template management window
+
+Add an ADMIN/REQADMIN management panel under Import/Export or Admin → Requirements:
+
+- Upload new template.
+- List saved templates with active/latest badges.
+- Activate/deactivate a template version.
+- Download original template for review.
+- Delete only unused draft templates; otherwise mark retired to preserve audit history.
+- Show validation report, checksum, createdBy, createdAt, lastUsedAt, and export usage count.
+
+## API plan
+
+All management endpoints require authentication and ADMIN or REQADMIN unless noted.
+
+| Method | Path | Request | Response | Notes |
+|---|---|---|---|---|
+| `GET` | `/api/requirement-export-templates` | — | `200 TemplateSummary[]` | REQ/REPORT can list active summaries for selection; ADMIN/REQADMIN also see inactive/retired with query flags. |
+| `POST` | `/api/requirement-export-templates/validate` | multipart `.docx` | `200 ValidationReport` | Does not persist bytes. Used by export dialog and management page. |
+| `POST` | `/api/requirement-export-templates` | multipart `.docx` + metadata | `201 TemplateSummary` | Persists immutable version after validation. |
+| `GET` | `/api/requirement-export-templates/latest` | — | `200 TemplateSummary` or `204` | Returns latest active template metadata. |
+| `GET` | `/api/requirement-export-templates/{id}` | — | `200 TemplateDetail` | Metadata and validation report. |
+| `GET` | `/api/requirement-export-templates/{id}/download` | — | `.docx` | ADMIN/REQADMIN only. |
+| `POST` | `/api/requirement-export-templates/{id}/activate` | — | `200 TemplateSummary` | Marks active and deactivates conflicting latest if single-active policy is enabled. |
+| `POST` | `/api/requirement-export-templates/{id}/deactivate` | — | `200 TemplateSummary` | Retains template for audit. |
+| `DELETE` | `/api/requirement-export-templates/{id}` | — | `204` | Hard delete only if never used and policy permits; otherwise `409` with retire guidance. |
+| `GET` | `/api/requirement-export-templates/{id}/usage` | — | `200 UsageEvent[]` | Audit/traceability. |
+
+Extend existing Word export endpoints with query/form parameters:
+
+- `templateMode=LATEST|SAVED|ADHOC|NONE`
+- `templateId=<id>` when `SAVED`
+- `missingPlaceholderBehavior=REJECT|APPEND`
+- `classification=<value>`
+- Multipart body with `templateFile` when `ADHOC`
+- Backward-compatible default: omitted parameters behave as `LATEST` when an active template exists, else current built-in renderer.
+
+For `GET` exports that need ad hoc upload, add parallel `POST` endpoints (for example `/api/requirements/export/docx`) accepting multipart form data while keeping the current `GET` endpoints for saved/latest/none modes.
+
+## Data model plan
+
+### `requirement_export_template`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT PK | Template version identifier. |
+| `name` | VARCHAR(200) | User-visible display name. |
+| `description` | TEXT nullable | Administrative description. |
+| `version_label` | VARCHAR(100) nullable | Human-readable version. |
+| `status` | ENUM(`ACTIVE`,`INACTIVE`,`RETIRED`,`REJECTED`) | Only ACTIVE can be used by default exports. |
+| `original_filename` | VARCHAR(255) | Sanitized filename. |
+| `content_type` | VARCHAR(128) | Must be `.docx` MIME. |
+| `file_size_bytes` | BIGINT | Enforce configured max. |
+| `sha256` | CHAR(64) | Deduplication and audit. |
+| `storage_key` | VARCHAR(512) | Object-store/file-store key, not a raw path. |
+| `validation_report_json` | JSON | Placeholder and sanitization results. |
+| `uploaded_by_user_id` | BIGINT FK | Uploader. |
+| `created_at` | TIMESTAMP | Upload timestamp. |
+| `activated_at` | TIMESTAMP nullable | Activation timestamp. |
+| `deactivated_at` | TIMESTAMP nullable | Deactivation timestamp. |
+| `last_used_at` | TIMESTAMP nullable | Export usage tracking. |
+
+### `requirement_export_template_usage`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT PK | Usage event. |
+| `template_id` | BIGINT FK nullable | Null for ad hoc or system default exports. |
+| `template_sha256` | CHAR(64) nullable | Captures ad hoc template checksum too. |
+| `exported_by_user_id` | BIGINT FK | Actor. |
+| `export_scope` | ENUM(`ALL`,`USE_CASE`,`RELEASE`,`TRANSLATED`,`MCP`,`CLI`) | Export type. |
+| `release_id` | BIGINT nullable | Scope detail. |
+| `usecase_id` | BIGINT nullable | Scope detail. |
+| `language` | VARCHAR(32) nullable | Translation export language. |
+| `template_mode` | ENUM(`LATEST`,`SAVED`,`ADHOC`,`NONE`) | Selected mode. |
+| `created_at` | TIMESTAMP | Export timestamp. |
+
+## Implementation plan
+
+1. **Backend domain**
+   - Add entities/repositories for templates and usage events.
+   - Add Flyway migration with indexes on `status`, `created_at`, `sha256`, and `last_used_at`.
+   - Add configuration properties for upload size, uncompressed ZIP limit, image count, external relationship policy, and ad hoc retention.
+
+2. **Validation and sanitization service**
+   - Build a `RequirementExportTemplateValidationService` that opens `.docx` as ZIP/OpenXML, checks MIME/extension/signature, detects placeholders, rejects forbidden relationship types and macros, enforces limits, and returns a structured validation report.
+   - Build a storage abstraction that writes immutable bytes outside the web root or to an object store using generated keys.
+
+3. **Rendering service**
+   - Extract current Word export creation from `RequirementController` into a `RequirementWordExportService`.
+   - Add template-aware rendering: load template, populate placeholders, insert generated requirement blocks at `${requirements}` or append mode, preserve allowed styles/headers/footers, and write final `.docx`.
+   - Keep a no-template code path that matches current output for backward compatibility.
+
+4. **API/controllers**
+   - Add template management controller.
+   - Extend existing export endpoints with template mode/ID for saved/latest/none and add multipart POST variants for ad hoc uploads.
+   - Update translated, release, use-case, MCP, and CLI export code paths to use the shared rendering service.
+
+5. **Frontend**
+   - Update the Export and Import/Export requirement panels with the Word template section.
+   - Add template management UI for ADMIN/REQADMIN.
+   - Use `data-testid` selectors for template mode, saved template select, ad hoc file picker, validate button, and save checkbox.
+
+6. **CLI/MCP**
+   - CLI: add `--template latest|none|<id>`, `--template-file <path>`, `--save-template`, `--template-name`, and `--classification` for `export-requirements --format docx`.
+   - MCP: extend `export_requirements` schema with `templateMode`, `templateId`, and `classification`; do not support binary ad hoc upload through MCP in v1 unless a safe file-reference mechanism already exists.
+
+7. **Observability and audit**
+   - Emit structured audit events for upload, validation failure, activation/deactivation, deletion/retirement, and export usage.
+   - Add metrics for validation failures by reason, template export count, and render latency.
+
+8. **Tests**
+   - Unit tests for validator with valid `.docx`, macro-enabled renamed files, ZIP bombs, external relationships, missing placeholders, and oversized images.
+   - Integration tests for role enforcement and persistence using MariaDB/Testcontainers.
+   - Controller tests for saved/latest/ad hoc/no-template export modes.
+   - Frontend tests for UI state transitions and permissions.
+   - E2E tests for upload latest template, ad hoc export, and fallback to default renderer.
+
+## Acceptance criteria
+
+- A REQADMIN can upload and activate a `.docx` template with header/footer/intro and `${requirements}`.
+- A normal export uses the latest active template by default and falls back to current generated layout when no active template exists.
+- A user can perform one export with an ad hoc template without changing the saved latest template.
+- The UI clearly shows which template will be used before export.
+- Invalid or unsafe templates are rejected with actionable messages.
+- Exports are audited with actor, template identity/checksum, scope, and timestamp.
+- All current Word export variants continue to work, including release/use-case/translated exports, CLI, and MCP.

--- a/specs/089-requirement-word-template-upload/tasks.md
+++ b/specs/089-requirement-word-template-upload/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — Requirement Word Export Templates
+
+## Phase 1 — Backend foundation
+
+- [ ] Add Flyway migration for `requirement_export_template` and `requirement_export_template_usage`.
+- [ ] Add Kotlin entities, repositories, DTOs, and configuration properties.
+- [ ] Extract current Word export creation into `RequirementWordExportService` while preserving existing output.
+- [ ] Add `RequirementExportTemplateValidationService` with OpenXML validation and structured reports.
+- [ ] Add immutable storage abstraction for saved template bytes.
+
+## Phase 2 — API and rendering
+
+- [ ] Add template management controller with ADMIN/REQADMIN RBAC.
+- [ ] Extend Word export endpoints with `templateMode`, `templateId`, `classification`, and missing-placeholder behavior.
+- [ ] Add multipart POST export endpoints for ad hoc templates.
+- [ ] Implement template rendering with placeholder replacement and requirement insertion.
+- [ ] Add audit events and usage recording.
+
+## Phase 3 — UI, CLI, and MCP
+
+- [ ] Add Word template section to export dialogs.
+- [ ] Add ADMIN/REQADMIN template management panel.
+- [ ] Extend CLI `export-requirements --format docx` with template options.
+- [ ] Extend MCP `export_requirements` schema for saved/latest/no-template modes.
+
+## Phase 4 — Tests and security verification
+
+- [ ] Add validator unit tests for unsafe and valid templates.
+- [ ] Add integration tests for RBAC, persistence, latest-template selection, and audit events.
+- [ ] Add controller tests for latest/saved/ad hoc/no-template exports.
+- [ ] Add frontend tests for UI states and permission visibility.
+- [ ] Run `/e2ejs` and `/e2evulnexception` after implementation.
+- [ ] Complete the security verification checklist in `security-review.md`.

--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
@@ -1,10 +1,18 @@
 package com.secman.controller
 
+import com.secman.domain.MissingPlaceholderBehavior
 import com.secman.domain.Requirement
+import com.secman.domain.RequirementExportScope
+import com.secman.domain.RequirementExportTemplate
+import com.secman.domain.RequirementExportTemplateMode
+import com.secman.domain.RequirementExportTemplateStatus
+import com.secman.domain.RequirementExportTemplateUsage
 import com.secman.domain.RequirementSnapshot
 import com.secman.util.ExcelSanitizer
 import com.secman.domain.UseCase
 import com.secman.domain.Norm
+import com.secman.repository.RequirementExportTemplateRepository
+import com.secman.repository.RequirementExportTemplateUsageRepository
 import com.secman.repository.RequirementRepository
 import com.secman.repository.RequirementSnapshotRepository
 import com.secman.repository.ReleaseRepository
@@ -14,11 +22,13 @@ import com.secman.service.TranslationService
 import com.secman.service.InputValidationService
 import com.secman.service.RequirementService
 import com.secman.service.RequirementIdService
+import com.secman.service.RequirementExportTemplateValidationService
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.model.Pageable
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.*
+import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.http.server.types.files.StreamedFile
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
@@ -28,6 +38,7 @@ import jakarta.transaction.Transactional
 import jakarta.validation.Valid
 import org.apache.poi.xwpf.usermodel.XWPFDocument
 import org.apache.poi.xwpf.usermodel.XWPFParagraph
+import org.apache.poi.xwpf.usermodel.XWPFTable
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -57,7 +68,10 @@ open class RequirementController(
     private val releaseRepository: ReleaseRepository,
     private val snapshotRepository: RequirementSnapshotRepository,
     private val requirementService: RequirementService,
-    private val requirementIdService: RequirementIdService
+    private val requirementIdService: RequirementIdService,
+    private val exportTemplateRepository: RequirementExportTemplateRepository,
+    private val exportTemplateUsageRepository: RequirementExportTemplateUsageRepository,
+    private val exportTemplateValidationService: RequirementExportTemplateValidationService
 ) {
 
     @Serdeable
@@ -393,51 +407,74 @@ open class RequirementController(
     }
 
     @Get("/export/docx")
-    fun exportToDocx(@Nullable @QueryValue("releaseId") releaseId: Long?): HttpResponse<*> {
-        val requirements: List<Requirement>
-        val filename: String
-        val title: String
+    fun exportToDocx(
+        @Nullable @QueryValue("releaseId") releaseId: Long?,
+        @QueryValue(defaultValue = "LATEST") templateMode: String,
+        @Nullable @QueryValue("templateId") templateId: Long?,
+        @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
+        @Nullable @QueryValue("classification") classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        val exportData = resolveRequirementExportData(releaseId)
+            ?: return HttpResponse.notFound(mapOf("error" to "Release not found"))
 
-        if (releaseId != null) {
-            // Export from release snapshot
-            val releaseOpt = releaseRepository.findById(releaseId)
-            if (releaseOpt.isEmpty) {
-                return HttpResponse.notFound(mapOf("error" to "Release not found"))
-            }
+        return exportWordDocument(
+            requirements = exportData.requirements,
+            title = exportData.title,
+            filename = exportData.filename,
+            templateMode = templateMode,
+            templateId = templateId,
+            adHocTemplate = null,
+            missingPlaceholderBehavior = missingPlaceholderBehavior,
+            classification = classification,
+            language = null,
+            scope = if (releaseId != null) RequirementExportScope.RELEASE else RequirementExportScope.ALL,
+            releaseId = releaseId,
+            usecaseId = null,
+            authentication = authentication
+        )
+    }
 
-            val release = releaseOpt.get()
-            val snapshots = snapshotRepository.findByReleaseId(releaseId)
+    @Post("/export/docx")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    fun exportToDocxWithAdHocTemplate(
+        @Nullable @QueryValue("releaseId") releaseId: Long?,
+        @Part templateFile: CompletedFileUpload,
+        @Nullable @Part templateMode: String?,
+        @Nullable @Part missingPlaceholderBehavior: String?,
+        @Nullable @Part classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        val exportData = resolveRequirementExportData(releaseId)
+            ?: return HttpResponse.notFound(mapOf("error" to "Release not found"))
 
-            // Convert snapshots to Requirements for export
-            requirements = snapshots.map { snapshotToRequirement(it) }.sortedWith(
-                compareBy<Requirement> { it.chapter ?: "" }.thenBy { it.id ?: 0 }
-            )
-
-            val dateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
-            filename = "requirements_v${release.version}_$dateStr.docx"
-            title = "Requirements - Release ${release.version}"
-        } else {
-            // Export current requirements (default behavior)
-            requirements = requirementRepository.findAll().sortedWith(
-                compareBy<Requirement> { it.chapter ?: "" }.thenBy { it.id ?: 0 }
-            )
-            filename = "requirements_export.docx"
-            title = "All Requirements"
-        }
-
-        val document = createWordDocument(requirements, title)
-        val outputStream = ByteArrayOutputStream()
-        document.write(outputStream)
-        document.close()
-
-        val inputStream = ByteArrayInputStream(outputStream.toByteArray())
-
-        return HttpResponse.ok(StreamedFile(inputStream, MediaType.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")))
-            .header("Content-Disposition", "attachment; filename=\"$filename\"")
+        return exportWordDocument(
+            requirements = exportData.requirements,
+            title = exportData.title,
+            filename = exportData.filename,
+            templateMode = templateMode ?: "ADHOC",
+            templateId = null,
+            adHocTemplate = templateFile,
+            missingPlaceholderBehavior = missingPlaceholderBehavior ?: "REJECT",
+            classification = classification,
+            language = null,
+            scope = if (releaseId != null) RequirementExportScope.RELEASE else RequirementExportScope.ALL,
+            releaseId = releaseId,
+            usecaseId = null,
+            authentication = authentication
+        )
     }
 
     @Get("/export/docx/usecase/{usecaseId}")
-    fun exportToDocxByUseCase(@PathVariable usecaseId: Long, @Nullable @QueryValue("releaseId") releaseId: Long?): HttpResponse<*> {
+    fun exportToDocxByUseCase(
+        @PathVariable usecaseId: Long,
+        @Nullable @QueryValue("releaseId") releaseId: Long?,
+        @QueryValue(defaultValue = "LATEST") templateMode: String,
+        @Nullable @QueryValue("templateId") templateId: Long?,
+        @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
+        @Nullable @QueryValue("classification") classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
         val useCaseOptional = useCaseRepository.findById(usecaseId)
 
         if (useCaseOptional.isEmpty) {
@@ -451,17 +488,64 @@ open class RequirementController(
             return HttpResponse.ok(mapOf("message" to "No requirements found for this use case"))
         }
 
-        val document = createWordDocument(requirements, "Requirements for UseCase: ${useCase.name}")
-        val outputStream = ByteArrayOutputStream()
-        document.write(outputStream)
-        document.close()
-
-        val inputStream = ByteArrayInputStream(outputStream.toByteArray())
         val filename = "requirements_usecase_${useCase.name.replace(" ", "_")}.docx"
             .replace("\"", "").replace("\r", "").replace("\n", "")
 
-        return HttpResponse.ok(StreamedFile(inputStream, MediaType.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")))
-            .header("Content-Disposition", "attachment; filename=\"$filename\"")
+        return exportWordDocument(
+            requirements = requirements,
+            title = "Requirements for UseCase: ${useCase.name}",
+            filename = filename,
+            templateMode = templateMode,
+            templateId = templateId,
+            adHocTemplate = null,
+            missingPlaceholderBehavior = missingPlaceholderBehavior,
+            classification = classification,
+            language = null,
+            scope = RequirementExportScope.USE_CASE,
+            releaseId = releaseId,
+            usecaseId = usecaseId,
+            authentication = authentication
+        )
+    }
+
+    @Post("/export/docx/usecase/{usecaseId}")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    fun exportToDocxByUseCaseWithAdHocTemplate(
+        @PathVariable usecaseId: Long,
+        @Nullable @QueryValue("releaseId") releaseId: Long?,
+        @Part templateFile: CompletedFileUpload,
+        @Nullable @Part templateMode: String?,
+        @Nullable @Part missingPlaceholderBehavior: String?,
+        @Nullable @Part classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        val useCaseOptional = useCaseRepository.findById(usecaseId)
+        if (useCaseOptional.isEmpty) {
+            return HttpResponse.notFound<Any>().body(mapOf("error" to "UseCase not found"))
+        }
+        val useCase = useCaseOptional.get()
+        val requirements = getRequirementsByUseCase(usecaseId, releaseId)
+        if (requirements.isEmpty()) {
+            return HttpResponse.ok(mapOf("message" to "No requirements found for this use case"))
+        }
+        val filename = "requirements_usecase_${useCase.name.replace(" ", "_")}.docx"
+            .replace("\"", "").replace("\r", "").replace("\n", "")
+
+        return exportWordDocument(
+            requirements = requirements,
+            title = "Requirements for UseCase: ${useCase.name}",
+            filename = filename,
+            templateMode = templateMode ?: "ADHOC",
+            templateId = null,
+            adHocTemplate = templateFile,
+            missingPlaceholderBehavior = missingPlaceholderBehavior ?: "REJECT",
+            classification = classification,
+            language = null,
+            scope = RequirementExportScope.USE_CASE,
+            releaseId = releaseId,
+            usecaseId = usecaseId,
+            authentication = authentication
+        )
     }
 
     @Get("/export/xlsx")
@@ -531,6 +615,294 @@ open class RequirementController(
         
         return HttpResponse.ok(StreamedFile(inputStream, MediaType.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")))
             .header("Content-Disposition", "attachment; filename=\"$filename\"")
+    }
+
+
+    private data class RequirementExportData(
+        val requirements: List<Requirement>,
+        val filename: String,
+        val title: String
+    )
+
+    private data class ResolvedTemplate(
+        val mode: RequirementExportTemplateMode,
+        val savedTemplate: RequirementExportTemplate?,
+        val bytes: ByteArray?,
+        val sha256: String?
+    )
+
+    private fun resolveRequirementExportData(releaseId: Long?): RequirementExportData? {
+        return if (releaseId != null) {
+            val releaseOpt = releaseRepository.findById(releaseId)
+            if (releaseOpt.isEmpty) {
+                null
+            } else {
+                val release = releaseOpt.get()
+                val snapshots = snapshotRepository.findByReleaseId(releaseId)
+                val requirements = snapshots.map { snapshotToRequirement(it) }.sortedWith(
+                    compareBy<Requirement> { it.chapter ?: "" }.thenBy { it.id ?: 0 }
+                )
+                val dateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+                RequirementExportData(
+                    requirements = requirements,
+                    filename = "requirements_v${release.version}_$dateStr.docx",
+                    title = "Requirements - Release ${release.version}"
+                )
+            }
+        } else {
+            RequirementExportData(
+                requirements = requirementRepository.findAll().sortedWith(
+                    compareBy<Requirement> { it.chapter ?: "" }.thenBy { it.id ?: 0 }
+                ),
+                filename = "requirements_export.docx",
+                title = "All Requirements"
+            )
+        }
+    }
+
+    private fun exportWordDocument(
+        requirements: List<Requirement>,
+        title: String,
+        filename: String,
+        templateMode: String,
+        templateId: Long?,
+        adHocTemplate: CompletedFileUpload?,
+        missingPlaceholderBehavior: String,
+        classification: String?,
+        language: String?,
+        scope: RequirementExportScope,
+        releaseId: Long?,
+        usecaseId: Long?,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        val behavior = parseMissingPlaceholderBehavior(missingPlaceholderBehavior)
+        val resolvedTemplate = try {
+            resolveTemplate(templateMode, templateId, adHocTemplate, behavior)
+                ?: return HttpResponse.badRequest(mapOf("error" to "Selected template was not found or is inactive"))
+        } catch (e: IllegalArgumentException) {
+            return HttpResponse.badRequest(mapOf("error" to (e.message ?: "Template validation failed")))
+        }
+
+        val document = if (resolvedTemplate.bytes != null) {
+            createTemplatedWordDocument(
+                templateBytes = resolvedTemplate.bytes,
+                requirements = requirements,
+                title = title,
+                exportedBy = authentication.name,
+                language = language ?: "english",
+                classification = classification ?: "Internal"
+            )
+        } else {
+            createWordDocument(requirements, title)
+        }
+
+        exportTemplateUsageRepository.save(
+            RequirementExportTemplateUsage(
+                template = resolvedTemplate.savedTemplate,
+                templateSha256 = resolvedTemplate.sha256,
+                exportedBy = authentication.name,
+                exportScope = scope,
+                releaseId = releaseId,
+                usecaseId = usecaseId,
+                language = language,
+                templateMode = resolvedTemplate.mode
+            )
+        )
+        resolvedTemplate.savedTemplate?.let { template ->
+            template.lastUsedAt = Instant.now()
+            exportTemplateRepository.update(template)
+        }
+
+        return streamWordDocument(document, filename)
+    }
+
+    private fun resolveTemplate(
+        templateMode: String,
+        templateId: Long?,
+        adHocTemplate: CompletedFileUpload?,
+        missingPlaceholderBehavior: MissingPlaceholderBehavior
+    ): ResolvedTemplate? {
+        val mode = parseTemplateMode(templateMode)
+        return when (mode) {
+            RequirementExportTemplateMode.NONE -> ResolvedTemplate(mode, null, null, null)
+            RequirementExportTemplateMode.LATEST -> {
+                val latest = exportTemplateRepository.findFirstByStatusOrderByCreatedAtDesc(RequirementExportTemplateStatus.ACTIVE)
+                if (latest.isPresent) {
+                    val template = latest.get()
+                    ResolvedTemplate(mode, template, template.content, template.sha256)
+                } else {
+                    ResolvedTemplate(RequirementExportTemplateMode.NONE, null, null, null)
+                }
+            }
+            RequirementExportTemplateMode.SAVED -> {
+                if (templateId == null) return null
+                val template = exportTemplateRepository.findById(templateId)
+                if (template.isEmpty || template.get().status != RequirementExportTemplateStatus.ACTIVE) return null
+                ResolvedTemplate(mode, template.get(), template.get().content, template.get().sha256)
+            }
+            RequirementExportTemplateMode.ADHOC -> {
+                if (adHocTemplate == null) return null
+                val bytes = adHocTemplate.bytes
+                val report = exportTemplateValidationService.validate(
+                    bytes = bytes,
+                    filename = adHocTemplate.filename,
+                    contentType = adHocTemplate.contentType.map { it.toString() }.orElse(null),
+                    requireRequirementsPlaceholder = missingPlaceholderBehavior == MissingPlaceholderBehavior.REJECT
+                )
+                if (!report.valid) {
+                    throw IllegalArgumentException(report.errors.joinToString("; "))
+                }
+                ResolvedTemplate(mode, null, bytes, report.sha256)
+            }
+        }
+    }
+
+
+    private fun parseTemplateMode(templateMode: String): RequirementExportTemplateMode = try {
+        RequirementExportTemplateMode.valueOf(templateMode.trim().uppercase(Locale.ROOT))
+    } catch (e: Exception) {
+        RequirementExportTemplateMode.LATEST
+    }
+
+    private fun parseMissingPlaceholderBehavior(value: String): MissingPlaceholderBehavior = try {
+        MissingPlaceholderBehavior.valueOf(value.trim().uppercase(Locale.ROOT))
+    } catch (e: Exception) {
+        MissingPlaceholderBehavior.REJECT
+    }
+
+    private fun createTemplatedWordDocument(
+        templateBytes: ByteArray,
+        requirements: List<Requirement>,
+        title: String,
+        exportedBy: String,
+        language: String,
+        classification: String
+    ): XWPFDocument {
+        val document = XWPFDocument(ByteArrayInputStream(templateBytes))
+        val replacements = mapOf(
+            "requirements" to "",
+            "documentTitle" to title,
+            "exportDate" to LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+            "releaseVersion" to title.substringAfter("Release ", ""),
+            "releaseStatus" to "",
+            "useCaseName" to title.substringAfter("UseCase: ", ""),
+            "exportedBy" to exportedBy,
+            "language" to language,
+            "requirementCount" to requirements.size.toString(),
+            "classification" to classification
+        )
+        replacePlaceholders(document, replacements)
+        document.createParagraph().createRun().addBreak(org.apache.poi.xwpf.usermodel.BreakType.PAGE)
+        appendRequirementContent(document, requirements)
+        return document
+    }
+
+    private fun replacePlaceholders(document: XWPFDocument, replacements: Map<String, String>) {
+        document.paragraphs.forEach { replacePlaceholdersInParagraph(it, replacements) }
+        document.tables.forEach { replacePlaceholdersInTable(it, replacements) }
+        document.headerList.forEach { header ->
+            header.paragraphs.forEach { replacePlaceholdersInParagraph(it, replacements) }
+            header.tables.forEach { replacePlaceholdersInTable(it, replacements) }
+        }
+        document.footerList.forEach { footer ->
+            footer.paragraphs.forEach { replacePlaceholdersInParagraph(it, replacements) }
+            footer.tables.forEach { replacePlaceholdersInTable(it, replacements) }
+        }
+    }
+
+    private fun replacePlaceholdersInTable(table: XWPFTable, replacements: Map<String, String>) {
+        table.rows.forEach { row ->
+            row.tableCells.forEach { cell ->
+                cell.paragraphs.forEach { replacePlaceholdersInParagraph(it, replacements) }
+                cell.tables.forEach { replacePlaceholdersInTable(it, replacements) }
+            }
+        }
+    }
+
+    private fun replacePlaceholdersInParagraph(paragraph: XWPFParagraph, replacements: Map<String, String>) {
+        if (paragraph.runs.isEmpty()) return
+        val fullText = paragraph.runs.joinToString(separator = "") { it.text() ?: "" }
+        var replaced = fullText
+        replacements.forEach { (key, value) ->
+            replaced = replaced.replace("${'$'}{$key}", value)
+        }
+        if (replaced == fullText) return
+        paragraph.runs.drop(1).forEach { paragraph.removeRun(1) }
+        paragraph.runs.firstOrNull()?.setText(replaced, 0)
+    }
+
+    private fun streamWordDocument(document: XWPFDocument, filename: String): HttpResponse<*> {
+        val outputStream = ByteArrayOutputStream()
+        document.write(outputStream)
+        document.close()
+        val inputStream = ByteArrayInputStream(outputStream.toByteArray())
+        return HttpResponse.ok(StreamedFile(inputStream, MediaType.of(RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE)))
+            .header("Content-Disposition", "attachment; filename=\"${filename.replace("\"", "").replace("\r", "").replace("\n", "")}\"")
+    }
+
+    private fun appendRequirementContent(document: XWPFDocument, requirements: List<Requirement>) {
+        val requirementsByChapter = requirements.groupBy { it.chapter ?: "No Chapter" }
+        var requirementNumber = 1
+        var isFirstChapter = true
+        for ((chapter, chapterRequirements) in requirementsByChapter) {
+            if (!isFirstChapter) {
+                document.createParagraph().createRun().addBreak(org.apache.poi.xwpf.usermodel.BreakType.PAGE)
+            }
+            isFirstChapter = false
+            val chapterParagraph = document.createParagraph()
+            chapterParagraph.style = "Heading1"
+            val chapterRun = chapterParagraph.createRun()
+            chapterRun.setText(chapter)
+            chapterRun.fontSize = 16
+            chapterRun.isBold = true
+            document.createParagraph()
+
+            for (requirement in chapterRequirements) {
+                val reqHeaderParagraph = document.createParagraph()
+                val ctp = reqHeaderParagraph.ctp
+                val ppr = if (ctp.isSetPPr) ctp.pPr else ctp.addNewPPr()
+                val shd = if (ppr.isSetShd) ppr.shd else ppr.addNewShd()
+                shd.fill = "C1D5C0"
+                val reqHeaderRun = reqHeaderParagraph.createRun()
+                reqHeaderRun.setText("REQ-$requirementNumber: ${requirement.shortreq}")
+                reqHeaderRun.fontSize = 12
+                reqHeaderRun.isBold = true
+                requirement.details?.let { document.createParagraph().createRun().setText(it) }
+                requirement.motivation?.let {
+                    val paragraph = document.createParagraph()
+                    paragraph.createRun().apply { setText("Motivation: "); isBold = true }
+                    paragraph.createRun().setText(it)
+                }
+                requirement.example?.let {
+                    val paragraph = document.createParagraph()
+                    paragraph.createRun().apply { setText("Example: "); isBold = true }
+                    paragraph.createRun().setText(it)
+                }
+                requirement.norm?.let {
+                    val paragraph = document.createParagraph()
+                    paragraph.createRun().apply { setText("Norm Reference: "); isBold = true }
+                    paragraph.createRun().setText(it)
+                }
+                val canonicalUseCases = setOf("IT", "OT", "NT")
+                val idSuffix = buildString {
+                    append(requirementNumber)
+                    append(".")
+                    append(requirement.versionNumber)
+                    requirement.usecases.map { it.name }.filter { it in canonicalUseCases }.sorted().forEach {
+                        append(".")
+                        append(it)
+                    }
+                }
+                val idParagraph = document.createParagraph()
+                idParagraph.alignment = org.apache.poi.xwpf.usermodel.ParagraphAlignment.LEFT
+                val idRun = idParagraph.createRun()
+                idRun.setText("ID $idSuffix")
+                idRun.fontSize = 8
+                idRun.color = "999999"
+                document.createParagraph()
+                requirementNumber++
+            }
+        }
     }
 
     private fun createWordDocument(requirements: List<Requirement>, title: String): XWPFDocument {
@@ -748,7 +1120,14 @@ open class RequirementController(
     }
 
     @Get("/export/docx/translated/{language}")
-    fun exportToDocxTranslated(@PathVariable language: String): HttpResponse<*> {
+    fun exportToDocxTranslated(
+        @PathVariable language: String,
+        @QueryValue(defaultValue = "NONE") templateMode: String,
+        @Nullable @QueryValue("templateId") templateId: Long?,
+        @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
+        @Nullable @QueryValue("classification") classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
         val activeConfig = translationService.getActiveConfig()
         if (activeConfig == null) {
             return HttpResponse.badRequest(mapOf(
@@ -766,17 +1145,26 @@ open class RequirementController(
         }
 
         return try {
-            val document = createTranslatedWordDocument(requirements, "Translated Requirements", language)
-            val outputStream = ByteArrayOutputStream()
-            document.write(outputStream)
-            document.close()
-
-            val inputStream = ByteArrayInputStream(outputStream.toByteArray())
-            val languageName = translationService.getSupportedLanguages()[language] ?: language
             val filename = "requirements_translated_${language}_${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}.docx"
-            
-            HttpResponse.ok(StreamedFile(inputStream, MediaType.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")))
-                .header("Content-Disposition", "attachment; filename=\"$filename\"")
+            if (parseTemplateMode(templateMode) == RequirementExportTemplateMode.NONE) {
+                streamWordDocument(createTranslatedWordDocument(requirements, "Translated Requirements", language), filename)
+            } else {
+                exportWordDocument(
+                    requirements = requirements,
+                    title = "Translated Requirements",
+                    filename = filename,
+                    templateMode = templateMode,
+                    templateId = templateId,
+                    adHocTemplate = null,
+                    missingPlaceholderBehavior = missingPlaceholderBehavior,
+                    classification = classification,
+                    language = language,
+                    scope = RequirementExportScope.TRANSLATED,
+                    releaseId = null,
+                    usecaseId = null,
+                    authentication = authentication
+                )
+            }
         } catch (e: Exception) {
             HttpResponse.serverError(mapOf(
                 "error" to "Translation export failed",
@@ -786,7 +1174,16 @@ open class RequirementController(
     }
 
     @Get("/export/docx/usecase/{usecaseId}/translated/{language}")
-    fun exportToDocxTranslatedByUseCase(@PathVariable usecaseId: Long, @PathVariable language: String, @Nullable @QueryValue("releaseId") releaseId: Long?): HttpResponse<*> {
+    fun exportToDocxTranslatedByUseCase(
+        @PathVariable usecaseId: Long,
+        @PathVariable language: String,
+        @Nullable @QueryValue("releaseId") releaseId: Long?,
+        @QueryValue(defaultValue = "NONE") templateMode: String,
+        @Nullable @QueryValue("templateId") templateId: Long?,
+        @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
+        @Nullable @QueryValue("classification") classification: String?,
+        authentication: Authentication
+    ): HttpResponse<*> {
         val activeConfig = translationService.getActiveConfig()
         if (activeConfig == null) {
             return HttpResponse.badRequest(mapOf(
@@ -808,18 +1205,27 @@ open class RequirementController(
         }
 
         return try {
-            val document = createTranslatedWordDocument(requirements, "Translated Requirements for UseCase: ${useCase.name}", language)
-            val outputStream = ByteArrayOutputStream()
-            document.write(outputStream)
-            document.close()
-
-            val inputStream = ByteArrayInputStream(outputStream.toByteArray())
-            val languageName = translationService.getSupportedLanguages()[language] ?: language
             val filename = "requirements_usecase_${useCase.name.replace(" ", "_")}_translated_${language}_${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}.docx"
                 .replace("\"", "").replace("\r", "").replace("\n", "")
-            
-            HttpResponse.ok(StreamedFile(inputStream, MediaType.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")))
-                .header("Content-Disposition", "attachment; filename=\"$filename\"")
+            if (parseTemplateMode(templateMode) == RequirementExportTemplateMode.NONE) {
+                streamWordDocument(createTranslatedWordDocument(requirements, "Translated Requirements for UseCase: ${useCase.name}", language), filename)
+            } else {
+                exportWordDocument(
+                    requirements = requirements,
+                    title = "Translated Requirements for UseCase: ${useCase.name}",
+                    filename = filename,
+                    templateMode = templateMode,
+                    templateId = templateId,
+                    adHocTemplate = null,
+                    missingPlaceholderBehavior = missingPlaceholderBehavior,
+                    classification = classification,
+                    language = language,
+                    scope = RequirementExportScope.TRANSLATED,
+                    releaseId = releaseId,
+                    usecaseId = usecaseId,
+                    authentication = authentication
+                )
+            }
         } catch (e: Exception) {
             HttpResponse.serverError(mapOf(
                 "error" to "Translation export failed",

--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementExportTemplateController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementExportTemplateController.kt
@@ -1,0 +1,241 @@
+package com.secman.controller
+
+import com.secman.domain.RequirementExportTemplate
+import com.secman.domain.RequirementExportTemplateStatus
+import com.secman.repository.RequirementExportTemplateRepository
+import com.secman.repository.RequirementExportTemplateUsageRepository
+import com.secman.service.RequirementExportTemplateValidationService
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.*
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.server.types.files.StreamedFile
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.transaction.Transactional
+import java.io.ByteArrayInputStream
+import java.time.Instant
+
+@Controller("/api/requirement-export-templates")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+@ExecuteOn(TaskExecutors.BLOCKING)
+open class RequirementExportTemplateController(
+    private val templateRepository: RequirementExportTemplateRepository,
+    private val usageRepository: RequirementExportTemplateUsageRepository,
+    private val validationService: RequirementExportTemplateValidationService
+) {
+    @Serdeable
+    data class TemplateSummary(
+        val id: Long,
+        val name: String,
+        val description: String?,
+        val versionLabel: String?,
+        val status: RequirementExportTemplateStatus,
+        val originalFilename: String,
+        val fileSizeBytes: Long,
+        val sha256: String,
+        val uploadedBy: String,
+        val createdAt: Instant,
+        val activatedAt: Instant?,
+        val deactivatedAt: Instant?,
+        val lastUsedAt: Instant?,
+        val usageCount: Long? = null
+    )
+
+    @Serdeable
+    data class TemplateDetail(
+        val summary: TemplateSummary,
+        val validationReportJson: String?
+    )
+
+    @Serdeable
+    data class ErrorResponse(val error: String)
+
+    @Get
+    open fun list(@QueryValue(defaultValue = "false") includeInactive: Boolean): List<TemplateSummary> {
+        val templates = if (includeInactive) {
+            templateRepository.findAll().sortedWith(compareByDescending<RequirementExportTemplate> { it.status == RequirementExportTemplateStatus.ACTIVE }.thenByDescending { it.createdAt })
+        } else {
+            templateRepository.findByStatusOrderByCreatedAtDesc(RequirementExportTemplateStatus.ACTIVE)
+        }
+        return templates.map { it.toSummary() }
+    }
+
+    @Get("/latest")
+    open fun latest(): HttpResponse<*> {
+        val latest = templateRepository.findFirstByStatusOrderByCreatedAtDesc(RequirementExportTemplateStatus.ACTIVE)
+        return if (latest.isPresent) {
+            HttpResponse.ok(latest.get().toSummary())
+        } else {
+            HttpResponse.noContent<Any>()
+        }
+    }
+
+    @Post("/validate")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Secured("ADMIN", "REQADMIN")
+    open fun validate(
+        @Part templateFile: CompletedFileUpload,
+        @Nullable @Part requireRequirementsPlaceholder: Boolean?
+    ): HttpResponse<*> {
+        val report = validationService.validate(
+            bytes = templateFile.bytes,
+            filename = templateFile.filename,
+            contentType = templateFile.contentType.map { it.toString() }.orElse(null),
+            requireRequirementsPlaceholder = requireRequirementsPlaceholder ?: true
+        )
+        return if (report.valid) HttpResponse.ok(report) else HttpResponse.badRequest(report)
+    }
+
+    @Post
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Secured("ADMIN", "REQADMIN")
+    @Transactional
+    open fun upload(
+        @Part templateFile: CompletedFileUpload,
+        @Part name: String?,
+        @Part description: String?,
+        @Part versionLabel: String?,
+        @Nullable @Part activate: Boolean?,
+        @Nullable @Part requireRequirementsPlaceholder: Boolean?,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        val bytes = templateFile.bytes
+        val report = validationService.validate(
+            bytes = bytes,
+            filename = templateFile.filename,
+            contentType = templateFile.contentType.map { it.toString() }.orElse(null),
+            requireRequirementsPlaceholder = requireRequirementsPlaceholder ?: true
+        )
+        if (!report.valid) {
+            return HttpResponse.badRequest(report)
+        }
+
+        val now = Instant.now()
+        val template = RequirementExportTemplate(
+            name = name?.takeIf { it.isNotBlank() }?.trim() ?: templateFile.filename.substringBeforeLast('.').ifBlank { "Requirement export template" },
+            description = description?.takeIf { it.isNotBlank() }?.trim(),
+            versionLabel = versionLabel?.takeIf { it.isNotBlank() }?.trim(),
+            status = if (activate != false) RequirementExportTemplateStatus.ACTIVE else RequirementExportTemplateStatus.INACTIVE,
+            originalFilename = sanitizeFilename(templateFile.filename),
+            contentType = RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE,
+            fileSizeBytes = bytes.size.toLong(),
+            sha256 = report.sha256,
+            content = bytes,
+            validationReportJson = validationService.toJson(report),
+            uploadedBy = authentication.name,
+            createdAt = now,
+            activatedAt = if (activate != false) now else null
+        )
+        val saved = templateRepository.save(template)
+        return HttpResponse.created(saved.toSummary())
+    }
+
+    @Get("/{id}")
+    @Secured("ADMIN", "REQADMIN")
+    open fun detail(@PathVariable id: Long): HttpResponse<*> {
+        val template = templateRepository.findById(id)
+        return if (template.isPresent) {
+            HttpResponse.ok(TemplateDetail(template.get().toSummary(usageRepository.countByTemplateId(id)), template.get().validationReportJson))
+        } else {
+            HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+    }
+
+    @Get("/{id}/download")
+    @Secured("ADMIN", "REQADMIN")
+    open fun download(@PathVariable id: Long): HttpResponse<*> {
+        val template = templateRepository.findById(id)
+        if (template.isEmpty) {
+            return HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+        val selected = template.get()
+        return HttpResponse.ok(StreamedFile(ByteArrayInputStream(selected.content), MediaType.of(RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE)))
+            .header("Content-Disposition", "attachment; filename=\"${sanitizeFilename(selected.originalFilename)}\"")
+    }
+
+    @Post("/{id}/activate")
+    @Secured("ADMIN", "REQADMIN")
+    @Transactional
+    open fun activate(@PathVariable id: Long): HttpResponse<*> {
+        val template = templateRepository.findById(id)
+        if (template.isEmpty) {
+            return HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+        val selected = template.get()
+        selected.status = RequirementExportTemplateStatus.ACTIVE
+        selected.activatedAt = Instant.now()
+        selected.deactivatedAt = null
+        return HttpResponse.ok(templateRepository.update(selected).toSummary())
+    }
+
+    @Post("/{id}/deactivate")
+    @Secured("ADMIN", "REQADMIN")
+    @Transactional
+    open fun deactivate(@PathVariable id: Long): HttpResponse<*> {
+        val template = templateRepository.findById(id)
+        if (template.isEmpty) {
+            return HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+        val selected = template.get()
+        selected.status = RequirementExportTemplateStatus.INACTIVE
+        selected.deactivatedAt = Instant.now()
+        return HttpResponse.ok(templateRepository.update(selected).toSummary())
+    }
+
+    @Delete("/{id}")
+    @Secured("ADMIN", "REQADMIN")
+    @Transactional
+    open fun delete(@PathVariable id: Long): HttpResponse<*> {
+        if (!templateRepository.existsById(id)) {
+            return HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+        val usageCount = usageRepository.countByTemplateId(id)
+        if (usageCount > 0) {
+            val template = templateRepository.findById(id).get()
+            template.status = RequirementExportTemplateStatus.RETIRED
+            template.deactivatedAt = Instant.now()
+            templateRepository.update(template)
+            return HttpResponse.ok(mapOf("message" to "Template has been retired because it was already used by exports."))
+        }
+        templateRepository.deleteById(id)
+        return HttpResponse.noContent<Any>()
+    }
+
+    @Get("/{id}/usage")
+    @Secured("ADMIN", "REQADMIN")
+    open fun usage(@PathVariable id: Long): HttpResponse<*> {
+        if (!templateRepository.existsById(id)) {
+            return HttpResponse.notFound(ErrorResponse("Template not found"))
+        }
+        return HttpResponse.ok(usageRepository.findByTemplateIdOrderByCreatedAtDesc(id))
+    }
+
+    private fun RequirementExportTemplate.toSummary(usageCount: Long? = null): TemplateSummary = TemplateSummary(
+        id = id ?: 0,
+        name = name,
+        description = description,
+        versionLabel = versionLabel,
+        status = status,
+        originalFilename = originalFilename,
+        fileSizeBytes = fileSizeBytes,
+        sha256 = sha256,
+        uploadedBy = uploadedBy,
+        createdAt = createdAt,
+        activatedAt = activatedAt,
+        deactivatedAt = deactivatedAt,
+        lastUsedAt = lastUsedAt,
+        usageCount = usageCount
+    )
+
+    private fun sanitizeFilename(filename: String): String = filename
+        .substringAfterLast('/')
+        .substringAfterLast('\\')
+        .replace(Regex("[\\r\\n\"]"), "")
+        .ifBlank { "requirement-template.docx" }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/RequirementExportTemplate.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/RequirementExportTemplate.kt
@@ -1,0 +1,78 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "requirement_export_template",
+    indexes = [
+        Index(name = "idx_req_export_template_status_created", columnList = "status, created_at"),
+        Index(name = "idx_req_export_template_sha256", columnList = "sha256")
+    ]
+)
+@Serdeable
+data class RequirementExportTemplate(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(nullable = false, length = 200)
+    var name: String,
+
+    @Column(columnDefinition = "TEXT")
+    var description: String? = null,
+
+    @Column(name = "version_label", length = 100)
+    var versionLabel: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(nullable = false, length = 20)
+    var status: RequirementExportTemplateStatus = RequirementExportTemplateStatus.ACTIVE,
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    var originalFilename: String,
+
+    @Column(name = "content_type", nullable = false, length = 128)
+    var contentType: String,
+
+    @Column(name = "file_size_bytes", nullable = false)
+    var fileSizeBytes: Long,
+
+    @Column(nullable = false, length = 64)
+    var sha256: String,
+
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "content", nullable = false, columnDefinition = "LONGBLOB")
+    var content: ByteArray,
+
+    @Column(name = "validation_report_json", columnDefinition = "TEXT")
+    var validationReportJson: String? = null,
+
+    @Column(name = "uploaded_by", nullable = false, length = 255)
+    var uploadedBy: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now(),
+
+    @Column(name = "activated_at")
+    var activatedAt: Instant? = Instant.now(),
+
+    @Column(name = "deactivated_at")
+    var deactivatedAt: Instant? = null,
+
+    @Column(name = "last_used_at")
+    var lastUsedAt: Instant? = null
+)
+
+enum class RequirementExportTemplateStatus {
+    ACTIVE,
+    INACTIVE,
+    RETIRED,
+    REJECTED
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/RequirementExportTemplateUsage.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/RequirementExportTemplateUsage.kt
@@ -1,0 +1,75 @@
+package com.secman.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.*
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "requirement_export_template_usage",
+    indexes = [
+        Index(name = "idx_req_export_template_usage_template", columnList = "template_id"),
+        Index(name = "idx_req_export_template_usage_created", columnList = "created_at")
+    ]
+)
+@Serdeable
+data class RequirementExportTemplateUsage(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id")
+    var template: RequirementExportTemplate? = null,
+
+    @Column(name = "template_sha256", length = 64)
+    var templateSha256: String? = null,
+
+    @Column(name = "exported_by", nullable = false, length = 255)
+    var exportedBy: String,
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(name = "export_scope", nullable = false, length = 20)
+    var exportScope: RequirementExportScope,
+
+    @Column(name = "release_id")
+    var releaseId: Long? = null,
+
+    @Column(name = "usecase_id")
+    var usecaseId: Long? = null,
+
+    @Column(length = 32)
+    var language: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(name = "template_mode", nullable = false, length = 20)
+    var templateMode: RequirementExportTemplateMode,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.now()
+)
+
+enum class RequirementExportScope {
+    ALL,
+    USE_CASE,
+    RELEASE,
+    TRANSLATED,
+    MCP,
+    CLI
+}
+
+enum class RequirementExportTemplateMode {
+    LATEST,
+    SAVED,
+    ADHOC,
+    NONE
+}
+
+enum class MissingPlaceholderBehavior {
+    REJECT,
+    APPEND
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/RequirementExportTemplateRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/RequirementExportTemplateRepository.kt
@@ -1,0 +1,13 @@
+package com.secman.repository
+
+import com.secman.domain.RequirementExportTemplate
+import com.secman.domain.RequirementExportTemplateStatus
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+@Repository
+interface RequirementExportTemplateRepository : JpaRepository<RequirementExportTemplate, Long> {
+    fun findByStatusOrderByCreatedAtDesc(status: RequirementExportTemplateStatus): List<RequirementExportTemplate>
+    fun findFirstByStatusOrderByCreatedAtDesc(status: RequirementExportTemplateStatus): Optional<RequirementExportTemplate>
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/RequirementExportTemplateUsageRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/RequirementExportTemplateUsageRepository.kt
@@ -1,0 +1,11 @@
+package com.secman.repository
+
+import com.secman.domain.RequirementExportTemplateUsage
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+
+@Repository
+interface RequirementExportTemplateUsageRepository : JpaRepository<RequirementExportTemplateUsage, Long> {
+    fun findByTemplateIdOrderByCreatedAtDesc(templateId: Long): List<RequirementExportTemplateUsage>
+    fun countByTemplateId(templateId: Long): Long
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/RequirementExportTemplateValidationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/RequirementExportTemplateValidationService.kt
@@ -1,0 +1,205 @@
+package com.secman.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.context.annotation.Value
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.inject.Singleton
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.zip.ZipInputStream
+
+@Singleton
+open class RequirementExportTemplateValidationService(
+    private val objectMapper: ObjectMapper,
+    @Value("\${secman.requirement-export-templates.max-file-size-bytes:5242880}")
+    private val maxFileSizeBytes: Long,
+    @Value("\${secman.requirement-export-templates.max-uncompressed-size-bytes:20971520}")
+    private val maxUncompressedSizeBytes: Long,
+    @Value("\${secman.requirement-export-templates.max-zip-entries:512}")
+    private val maxZipEntries: Int
+) {
+    companion object {
+        const val DOCX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        val ALLOWED_PLACEHOLDERS = setOf(
+            "requirements",
+            "documentTitle",
+            "exportDate",
+            "releaseVersion",
+            "releaseStatus",
+            "useCaseName",
+            "exportedBy",
+            "language",
+            "requirementCount",
+            "classification"
+        )
+    }
+
+    @Serdeable
+    data class ValidationReport(
+        val valid: Boolean,
+        val errors: List<String> = emptyList(),
+        val warnings: List<String> = emptyList(),
+        val placeholders: List<String> = emptyList(),
+        val sha256: String,
+        val fileSizeBytes: Long,
+        val uncompressedSizeBytes: Long = 0,
+        val entryCount: Int = 0
+    )
+
+    fun validate(
+        bytes: ByteArray,
+        filename: String?,
+        contentType: String?,
+        requireRequirementsPlaceholder: Boolean = true
+    ): ValidationReport {
+        val errors = mutableListOf<String>()
+        val warnings = mutableListOf<String>()
+        val placeholders = linkedSetOf<String>()
+        val safeFilename = filename.orEmpty().lowercase(Locale.ROOT)
+        val normalizedContentType = contentType?.substringBefore(';')?.trim().orEmpty()
+        val sha256 = sha256(bytes)
+
+        if (!safeFilename.endsWith(".docx")) {
+            errors += "Only .docx Word templates are supported."
+        }
+        if (safeFilename.endsWith(".docm") || safeFilename.endsWith(".dotm")) {
+            errors += "Macro-enabled Word templates are not allowed."
+        }
+        if (normalizedContentType.isNotBlank() && normalizedContentType != DOCX_MEDIA_TYPE && normalizedContentType != "application/octet-stream") {
+            errors += "Invalid content type for a Word template."
+        }
+        if (bytes.isEmpty()) {
+            errors += "Template file is empty."
+        }
+        if (bytes.size > maxFileSizeBytes) {
+            errors += "Template exceeds the maximum allowed file size."
+        }
+        if (bytes.size < 4 || bytes[0] != 'P'.code.toByte() || bytes[1] != 'K'.code.toByte()) {
+            errors += "Template is not a valid OpenXML ZIP package."
+        }
+
+        var hasContentTypes = false
+        var hasWordDocument = false
+        var hasMainDocumentContentType = false
+        var uncompressedSize = 0L
+        var entryCount = 0
+
+        if (errors.none { it == "Template is not a valid OpenXML ZIP package." }) {
+            try {
+                ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                    var entry = zip.nextEntry
+                    val buffer = ByteArray(8192)
+                    while (entry != null) {
+                        entryCount++
+                        if (entryCount > maxZipEntries) {
+                            errors += "Template contains too many files."
+                            break
+                        }
+
+                        val entryName = entry.name.replace('\\', '/')
+                        if (entryName.contains("../") || entryName.startsWith('/')) {
+                            errors += "Template contains an unsafe ZIP entry path."
+                        }
+                        if (isForbiddenEntry(entryName)) {
+                            errors += "Template contains unsupported active or embedded content."
+                        }
+
+                        val entryBytes = readEntry(zip, buffer) { readBytes ->
+                            uncompressedSize += readBytes
+                            uncompressedSize <= maxUncompressedSizeBytes
+                        }
+                        if (uncompressedSize > maxUncompressedSizeBytes) {
+                            errors += "Template uncompressed size exceeds the configured limit."
+                            break
+                        }
+
+                        when (entryName) {
+                            "[Content_Types].xml" -> {
+                                hasContentTypes = true
+                                val xml = entryBytes.toString(Charsets.UTF_8)
+                                hasMainDocumentContentType = xml.contains("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml")
+                                if (xml.contains("macroEnabled", ignoreCase = true) || xml.contains("vbaProject", ignoreCase = true)) {
+                                    errors += "Macro-enabled Word packages are not allowed."
+                                }
+                            }
+                            "word/document.xml" -> {
+                                hasWordDocument = true
+                                placeholders += extractPlaceholders(entryBytes.toString(Charsets.UTF_8))
+                            }
+                            else -> {
+                                if (entryName.startsWith("word/header") || entryName.startsWith("word/footer")) {
+                                    placeholders += extractPlaceholders(entryBytes.toString(Charsets.UTF_8))
+                                }
+                                if (entryName.endsWith(".rels")) {
+                                    val rels = entryBytes.toString(Charsets.UTF_8)
+                                    if (rels.contains("TargetMode=\"External\"") || rels.contains("TargetMode='External'")) {
+                                        errors += "External links, remote images, and remote templates are not allowed."
+                                    }
+                                }
+                            }
+                        }
+
+                        entry = zip.nextEntry
+                    }
+                }
+            } catch (e: Exception) {
+                errors += "Template is not a valid .docx file."
+            }
+        }
+
+        if (!hasContentTypes) errors += "Template is missing OpenXML content types."
+        if (!hasWordDocument) errors += "Template is missing the Word document body."
+        if (!hasMainDocumentContentType) errors += "Template is not a standard .docx Word document."
+        if (requireRequirementsPlaceholder && "requirements" !in placeholders) {
+            errors += "Template must include the ${'$'}{requirements} placeholder or use append mode."
+        }
+
+        val unsupportedPlaceholders = placeholders - ALLOWED_PLACEHOLDERS
+        if (unsupportedPlaceholders.isNotEmpty()) {
+            warnings += "Unsupported placeholders will be left unchanged: ${unsupportedPlaceholders.sorted().joinToString(", ")}."
+        }
+
+        return ValidationReport(
+            valid = errors.isEmpty(),
+            errors = errors.distinct(),
+            warnings = warnings.distinct(),
+            placeholders = placeholders.sorted(),
+            sha256 = sha256,
+            fileSizeBytes = bytes.size.toLong(),
+            uncompressedSizeBytes = uncompressedSize,
+            entryCount = entryCount
+        )
+    }
+
+    fun toJson(report: ValidationReport): String = objectMapper.writeValueAsString(report)
+
+    fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString(separator = "") { "%02x".format(it) }
+
+    private fun isForbiddenEntry(entryName: String): Boolean {
+        val lower = entryName.lowercase(Locale.ROOT)
+        return lower.endsWith("vbaproject.bin") ||
+            lower.contains("/activex/") ||
+            lower.contains("/embeddings/") ||
+            lower.contains("oleobject") ||
+            lower.endsWith(".bin") && lower.contains("word/")
+    }
+
+    private fun readEntry(zip: ZipInputStream, buffer: ByteArray, allowMore: (Long) -> Boolean): ByteArray {
+        val output = java.io.ByteArrayOutputStream()
+        while (true) {
+            val read = zip.read(buffer)
+            if (read == -1) break
+            if (!allowMore(read.toLong())) break
+            output.write(buffer, 0, read)
+        }
+        return output.toByteArray()
+    }
+
+    private fun extractPlaceholders(xml: String): Set<String> {
+        val regex = Regex("\\$\\{([A-Za-z][A-Za-z0-9]*)}")
+        return regex.findAll(xml).map { it.groupValues[1] }.toSet()
+    }
+}

--- a/src/backendng/src/main/resources/db/migration/V231__requirement_export_templates.sql
+++ b/src/backendng/src/main/resources/db/migration/V231__requirement_export_templates.sql
@@ -1,0 +1,37 @@
+CREATE TABLE requirement_export_template (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    description TEXT NULL,
+    version_label VARCHAR(100) NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    original_filename VARCHAR(255) NOT NULL,
+    content_type VARCHAR(128) NOT NULL,
+    file_size_bytes BIGINT NOT NULL,
+    sha256 CHAR(64) NOT NULL,
+    content LONGBLOB NOT NULL,
+    validation_report_json TEXT NULL,
+    uploaded_by VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    activated_at TIMESTAMP NULL,
+    deactivated_at TIMESTAMP NULL,
+    last_used_at TIMESTAMP NULL,
+    INDEX idx_req_export_template_status_created (status, created_at),
+    INDEX idx_req_export_template_sha256 (sha256)
+);
+
+CREATE TABLE requirement_export_template_usage (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    template_id BIGINT NULL,
+    template_sha256 CHAR(64) NULL,
+    exported_by VARCHAR(255) NOT NULL,
+    export_scope VARCHAR(20) NOT NULL,
+    release_id BIGINT NULL,
+    usecase_id BIGINT NULL,
+    language VARCHAR(32) NULL,
+    template_mode VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_req_export_template_usage_template (template_id),
+    INDEX idx_req_export_template_usage_created (created_at),
+    CONSTRAINT fk_req_export_template_usage_template FOREIGN KEY (template_id)
+        REFERENCES requirement_export_template(id) ON DELETE SET NULL
+);

--- a/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
@@ -4,10 +4,13 @@ import com.secman.domain.Requirement
 import com.secman.domain.UseCase
 import com.secman.repository.NormRepository
 import com.secman.repository.ReleaseRepository
+import com.secman.repository.RequirementExportTemplateRepository
+import com.secman.repository.RequirementExportTemplateUsageRepository
 import com.secman.repository.RequirementRepository
 import com.secman.repository.RequirementSnapshotRepository
 import com.secman.repository.UseCaseRepository
 import com.secman.service.InputValidationService
+import com.secman.service.RequirementExportTemplateValidationService
 import com.secman.service.RequirementIdService
 import com.secman.service.RequirementService
 import com.secman.service.TranslationService
@@ -36,7 +39,10 @@ class RequirementControllerWordExportTest {
         releaseRepository = mockk<ReleaseRepository>(relaxed = true),
         snapshotRepository = mockk<RequirementSnapshotRepository>(relaxed = true),
         requirementService = mockk<RequirementService>(relaxed = true),
-        requirementIdService = mockk<RequirementIdService>(relaxed = true)
+        requirementIdService = mockk<RequirementIdService>(relaxed = true),
+        exportTemplateRepository = mockk<RequirementExportTemplateRepository>(relaxed = true),
+        exportTemplateUsageRepository = mockk<RequirementExportTemplateUsageRepository>(relaxed = true),
+        exportTemplateValidationService = mockk<RequirementExportTemplateValidationService>(relaxed = true)
     )
     private val publicController = PublicRequirementDownloadController(
         requirementRepository = mockk<RequirementRepository>(relaxed = true),

--- a/src/backendng/src/test/kotlin/com/secman/service/RequirementExportTemplateValidationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/RequirementExportTemplateValidationServiceTest.kt
@@ -1,0 +1,90 @@
+package com.secman.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.poi.xwpf.usermodel.XWPFDocument
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+class RequirementExportTemplateValidationServiceTest {
+    private val service = RequirementExportTemplateValidationService(
+        objectMapper = ObjectMapper(),
+        maxFileSizeBytes = 5 * 1024 * 1024,
+        maxUncompressedSizeBytes = 20 * 1024 * 1024,
+        maxZipEntries = 512
+    )
+
+    @Test
+    fun `valid docx template with requirements placeholder passes`() {
+        val report = service.validate(
+            bytes = docxTemplate("Intro ${'$'}{documentTitle}\n${'$'}{requirements}"),
+            filename = "corporate-template.docx",
+            contentType = RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE
+        )
+
+        assertThat(report.valid).isTrue()
+        assertThat(report.placeholders).contains("documentTitle", "requirements")
+        assertThat(report.errors).isEmpty()
+    }
+
+    @Test
+    fun `docx template without requirements placeholder is rejected by default`() {
+        val report = service.validate(
+            bytes = docxTemplate("Intro only"),
+            filename = "corporate-template.docx",
+            contentType = RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE
+        )
+
+        assertThat(report.valid).isFalse()
+        assertThat(report.errors).contains("Template must include the ${'$'}{requirements} placeholder or use append mode.")
+    }
+
+    @Test
+    fun `docx template with macro payload is rejected`() {
+        val report = service.validate(
+            bytes = withExtraZipEntry(docxTemplate("${'$'}{requirements}"), "word/vbaProject.bin"),
+            filename = "renamed-macro.docx",
+            contentType = RequirementExportTemplateValidationService.DOCX_MEDIA_TYPE
+        )
+
+        assertThat(report.valid).isFalse()
+        assertThat(report.errors).contains("Template contains unsupported active or embedded content.")
+    }
+
+    private fun docxTemplate(text: String): ByteArray {
+        val document = XWPFDocument()
+        document.createParagraph().createRun().setText(text)
+        val output = ByteArrayOutputStream()
+        document.write(output)
+        document.close()
+        return output.toByteArray()
+    }
+
+    private fun withExtraZipEntry(docx: ByteArray, name: String): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zipOut ->
+            ZipInputStream(ByteArrayInputStream(docx)).use { zipIn ->
+                var entry = zipIn.nextEntry
+                val buffer = ByteArray(8192)
+                while (entry != null) {
+                    zipOut.putNextEntry(ZipEntry(entry.name))
+                    while (true) {
+                        val read = zipIn.read(buffer)
+                        if (read == -1) break
+                        zipOut.write(buffer, 0, read)
+                    }
+                    zipOut.closeEntry()
+                    entry = zipIn.nextEntry
+                }
+            }
+            zipOut.putNextEntry(ZipEntry(name))
+            zipOut.write(byteArrayOf(1, 2, 3))
+            zipOut.closeEntry()
+        }
+        return output.toByteArray()
+    }
+}

--- a/src/frontend/src/components/Export.tsx
+++ b/src/frontend/src/components/Export.tsx
@@ -8,6 +8,18 @@ interface UseCase {
     name: string;
 }
 
+interface RequirementExportTemplate {
+    id: number;
+    name: string;
+    versionLabel?: string | null;
+    uploadedBy: string;
+    createdAt: string;
+    lastUsedAt?: string | null;
+    sha256: string;
+}
+
+type WordTemplateMode = 'LATEST' | 'SAVED' | 'ADHOC' | 'NONE';
+
 const Export = () => {
     const [isExporting, setIsExporting] = useState<boolean>(false);
     const [exportStatus, setExportStatus] = useState<string>('');
@@ -16,18 +28,28 @@ const Export = () => {
     const [isLoadingUseCases, setIsLoadingUseCases] = useState<boolean>(false);
     const [selectedLanguage, setSelectedLanguage] = useState<string>('english');
     const [translationConfigured, setTranslationConfigured] = useState<boolean>(false);
-    const [selectedReleaseId, setSelectedReleaseId] = useState<number | null>(null);
-
-    // Restore release selection from sessionStorage after mount (avoids SSR hydration mismatch)
-    useEffect(() => {
-        const stored = sessionStorage.getItem('secman_selectedReleaseId');
-        if (stored) {
-            const parsed = parseInt(stored, 10);
-            if (!isNaN(parsed)) {
-                setSelectedReleaseId(parsed);
-            }
+    const [selectedReleaseId, setSelectedReleaseId] = useState<number | null>(() => {
+        if (typeof window === 'undefined') {
+            return null;
         }
-    }, []);
+        const stored = sessionStorage.getItem('secman_selectedReleaseId');
+        if (!stored) {
+            return null;
+        }
+        const parsed = parseInt(stored, 10);
+        return isNaN(parsed) ? null : parsed;
+    });
+    const [wordTemplateMode, setWordTemplateMode] = useState<WordTemplateMode>('LATEST');
+    const [savedTemplates, setSavedTemplates] = useState<RequirementExportTemplate[]>([]);
+    const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null);
+    const [adHocTemplateFile, setAdHocTemplateFile] = useState<File | null>(null);
+    const [saveAdHocAsTemplate, setSaveAdHocAsTemplate] = useState<boolean>(false);
+    const [templateName, setTemplateName] = useState<string>('');
+    const [templateVersionLabel, setTemplateVersionLabel] = useState<string>('');
+    const [templateDescription, setTemplateDescription] = useState<string>('');
+    const [missingPlaceholderBehavior, setMissingPlaceholderBehavior] = useState<'REJECT' | 'APPEND'>('REJECT');
+    const [classification, setClassification] = useState<string>('Internal');
+
 
     useEffect(() => {
         const fetchUseCases = async () => {
@@ -48,23 +70,128 @@ const Export = () => {
             }
         };
 
-        fetchUseCases();
-        checkTranslationConfiguration();
-    }, []);
-
-    const checkTranslationConfiguration = async () => {
-        try {
-            const response = await authenticatedFetch('/api/translation-config/active');
-            if (response.ok) {
-                setTranslationConfigured(true);
-            } else {
+        const checkTranslationConfigurationInEffect = async () => {
+            try {
+                const response = await authenticatedFetch('/api/translation-config/active');
+                setTranslationConfigured(response.ok);
+            } catch (error) {
+                console.error('Error checking translation configuration:', error);
                 setTranslationConfigured(false);
             }
-        } catch (error) {
-            console.error('Error checking translation configuration:', error);
-            setTranslationConfigured(false);
+        };
+
+        const fetchRequirementExportTemplatesInEffect = async () => {
+            try {
+                const response = await authenticatedFetch('/api/requirement-export-templates');
+                if (response.ok) {
+                    const templates = await response.json();
+                    setSavedTemplates(templates);
+                    if (templates.length > 0) {
+                        setSelectedTemplateId(templates[0].id);
+                    }
+                }
+            } catch (error) {
+                console.error('Error fetching Word export templates:', error);
+            }
+        };
+
+        fetchUseCases();
+        checkTranslationConfigurationInEffect();
+        fetchRequirementExportTemplatesInEffect();
+    }, []);
+
+
+    const appendTemplateParams = (endpoint: string): string => {
+        const separator = endpoint.includes('?') ? '&' : '?';
+        const params = new URLSearchParams({
+            templateMode: wordTemplateMode,
+            missingPlaceholderBehavior,
+            classification,
+        });
+        if (wordTemplateMode === 'SAVED' && selectedTemplateId) {
+            params.set('templateId', selectedTemplateId.toString());
         }
+        return `${endpoint}${separator}${params.toString()}`;
     };
+
+    const downloadBlobResponse = async (response: Response, defaultFilename: string) => {
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        const contentDisposition = response.headers.get('Content-Disposition');
+        let filename = defaultFilename;
+        if (contentDisposition) {
+            const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
+            if (filenameMatch) {
+                filename = filenameMatch[1];
+            }
+        }
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+    };
+
+    const saveReusableTemplateIfRequested = async () => {
+        if (wordTemplateMode !== 'ADHOC' || !saveAdHocAsTemplate || !adHocTemplateFile) {
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('templateFile', adHocTemplateFile);
+        formData.append('name', templateName.trim() || adHocTemplateFile.name.replace(/\.docx$/i, ''));
+        formData.append('description', templateDescription);
+        formData.append('versionLabel', templateVersionLabel);
+        formData.append('activate', 'true');
+        formData.append('requireRequirementsPlaceholder', (missingPlaceholderBehavior === 'REJECT').toString());
+
+        const response = await fetch('/api/requirement-export-templates', {
+            method: 'POST',
+            body: formData,
+            credentials: 'include',
+        });
+
+        if (!response.ok) {
+            let errorMsg = 'Could not save the reusable Word template.';
+            try {
+                const errorData = await response.json();
+                errorMsg = errorData.error || errorData.errors?.join('; ') || errorMsg;
+            } catch (e) {
+                errorMsg = response.statusText || errorMsg;
+            }
+            throw new Error(errorMsg);
+        }
+
+        const savedTemplate = await response.json();
+        setSavedTemplates((current) => [savedTemplate, ...current.filter((template) => template.id !== savedTemplate.id)]);
+        setSelectedTemplateId(savedTemplate.id);
+    };
+
+    const requestWordExport = async (endpoint: string): Promise<Response> => {
+        if (wordTemplateMode === 'ADHOC') {
+            if (!adHocTemplateFile) {
+                throw new Error('Please select an ad hoc Word template file first.');
+            }
+            await saveReusableTemplateIfRequested();
+            const formData = new FormData();
+            formData.append('templateFile', adHocTemplateFile);
+            formData.append('templateMode', 'ADHOC');
+            formData.append('missingPlaceholderBehavior', missingPlaceholderBehavior);
+            formData.append('classification', classification);
+            return fetch(endpoint, {
+                method: 'POST',
+                body: formData,
+                credentials: 'include',
+            });
+        }
+
+        return authenticatedFetch(appendTemplateParams(endpoint), {
+            method: 'GET',
+        });
+    };
+
 
     const handleExportToWord = useCallback(async () => {
         setIsExporting(true);
@@ -79,12 +206,16 @@ const Export = () => {
             endpoint += `?releaseId=${selectedReleaseId}`;
         }
 
+        if (isTranslated && wordTemplateMode === 'ADHOC') {
+            setExportStatus('Error: Ad hoc templates are not supported for translated exports yet. Please use a saved/latest template or English export.');
+            setIsExporting(false);
+            return;
+        }
+
         setExportStatus(isTranslated ? `Translating and exporting to ${selectedLanguage}...` : 'Exporting to Word...');
         
         try {
-            const response = await authenticatedFetch(endpoint, {
-                method: 'GET',
-            });
+            const response = await requestWordExport(endpoint);
 
             if (!response.ok) {
                 let errorMsg = 'Failed to export requirements.';
@@ -97,25 +228,7 @@ const Export = () => {
                 throw new Error(errorMsg);
             }
 
-            const blob = await response.blob();
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            
-            const contentDisposition = response.headers.get('Content-Disposition');
-            let filename = 'requirements.docx';
-            if (contentDisposition) {
-                const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
-                if (filenameMatch) {
-                    filename = filenameMatch[1];
-                }
-            }
-            
-            a.download = filename;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            window.URL.revokeObjectURL(url);
+            await downloadBlobResponse(response, 'requirements.docx');
             
             const successMsg = isTranslated 
                 ? `Requirements exported and translated to ${selectedLanguage} successfully`
@@ -127,7 +240,7 @@ const Export = () => {
         } finally {
             setIsExporting(false);
         }
-    }, [selectedLanguage, translationConfigured, selectedReleaseId]);
+    }, [selectedLanguage, translationConfigured, selectedReleaseId, wordTemplateMode, selectedTemplateId, adHocTemplateFile, saveAdHocAsTemplate, templateName, templateVersionLabel, templateDescription, missingPlaceholderBehavior, classification]);
 
     const handleExportByUseCase = useCallback(async () => {
         if (!selectedUseCase) {
@@ -147,15 +260,19 @@ const Export = () => {
             endpoint += `?releaseId=${selectedReleaseId}`;
         }
         
+        if (isTranslated && wordTemplateMode === 'ADHOC') {
+            setExportStatus('Error: Ad hoc templates are not supported for translated exports yet. Please use a saved/latest template or English export.');
+            setIsExporting(false);
+            return;
+        }
+
         const statusMsg = isTranslated 
             ? `Translating and exporting requirements for selected use case to ${selectedLanguage}...`
             : 'Exporting requirements for selected use case...';
         setExportStatus(statusMsg);
         
         try {
-            const response = await authenticatedFetch(endpoint, {
-                method: 'GET',
-            });
+            const response = await requestWordExport(endpoint);
 
             if (!response.ok) {
                 let errorMsg = 'Failed to export requirements.';
@@ -168,25 +285,7 @@ const Export = () => {
                 throw new Error(errorMsg);
             }
 
-            const blob = await response.blob();
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            
-            const contentDisposition = response.headers.get('Content-Disposition');
-            let filename = 'requirements_usecase.docx';
-            if (contentDisposition) {
-                const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/);
-                if (filenameMatch) {
-                    filename = filenameMatch[1];
-                }
-            }
-            
-            a.download = filename;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            window.URL.revokeObjectURL(url);
+            await downloadBlobResponse(response, 'requirements_usecase.docx');
             
             const successMsg = isTranslated 
                 ? `Requirements exported and translated to ${selectedLanguage} successfully for selected use case`
@@ -198,7 +297,7 @@ const Export = () => {
         } finally {
             setIsExporting(false);
         }
-    }, [selectedUseCase, selectedLanguage, translationConfigured, selectedReleaseId]);
+    }, [selectedUseCase, selectedLanguage, translationConfigured, selectedReleaseId, wordTemplateMode, selectedTemplateId, adHocTemplateFile, saveAdHocAsTemplate, templateName, templateVersionLabel, templateDescription, missingPlaceholderBehavior, classification]);
 
     const handleExportToExcel = useCallback(async () => {
         setIsExporting(true);
@@ -480,6 +579,171 @@ const Export = () => {
                             </small>
                         </div>
                     )}
+                </div>
+            </div>
+
+            {/* Word Template Options */}
+            <div className="card border-secondary border-opacity-25 mb-3" data-testid="word-template-options">
+                <div className="card-body">
+                    <div className="d-flex align-items-center justify-content-between mb-3">
+                        <div>
+                            <h6 className="mb-1"><i className="bi bi-file-earmark-word me-2"></i>Word template</h6>
+                            <small className="text-muted">
+                                Use the latest saved Secman template by default, choose a saved template, upload an ad hoc template for one export, or use the built-in layout.
+                            </small>
+                        </div>
+                        {savedTemplates.length > 0 && (
+                            <span className="badge bg-success-subtle text-success">
+                                Latest: {savedTemplates[0].name}
+                            </span>
+                        )}
+                    </div>
+
+                    <div className="row g-3">
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold" htmlFor="word-template-mode">Template mode</label>
+                            <select
+                                id="word-template-mode"
+                                data-testid="word-template-mode"
+                                className="form-select form-select-sm"
+                                value={wordTemplateMode}
+                                onChange={(event) => setWordTemplateMode(event.target.value as WordTemplateMode)}
+                            >
+                                <option value="LATEST">Latest saved template</option>
+                                <option value="SAVED">Specific saved template</option>
+                                <option value="ADHOC">Ad hoc upload for this export</option>
+                                <option value="NONE">No template / Secman default</option>
+                            </select>
+                        </div>
+
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold" htmlFor="saved-word-template">Saved template</label>
+                            <select
+                                id="saved-word-template"
+                                data-testid="saved-word-template"
+                                className="form-select form-select-sm"
+                                value={selectedTemplateId ?? ''}
+                                onChange={(event) => setSelectedTemplateId(event.target.value ? parseInt(event.target.value, 10) : null)}
+                                disabled={wordTemplateMode !== 'SAVED' || savedTemplates.length === 0}
+                            >
+                                {savedTemplates.length === 0 ? (
+                                    <option value="">No saved templates</option>
+                                ) : savedTemplates.map((template) => (
+                                    <option key={template.id} value={template.id}>
+                                        {template.name}{template.versionLabel ? ` (${template.versionLabel})` : ''}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold" htmlFor="adhoc-word-template">Ad hoc template file</label>
+                            <input
+                                id="adhoc-word-template"
+                                data-testid="adhoc-word-template"
+                                className="form-control form-control-sm"
+                                type="file"
+                                accept=".docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                                disabled={wordTemplateMode !== 'ADHOC'}
+                                onChange={(event) => setAdHocTemplateFile(event.target.files?.[0] ?? null)}
+                            />
+                        </div>
+
+                        <div className="col-lg-4">
+                            <div className="form-check mt-4">
+                                <input
+                                    id="save-adhoc-template"
+                                    data-testid="save-adhoc-template"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    checked={saveAdHocAsTemplate}
+                                    disabled={wordTemplateMode !== 'ADHOC'}
+                                    onChange={(event) => setSaveAdHocAsTemplate(event.target.checked)}
+                                />
+                                <label className="form-check-label small" htmlFor="save-adhoc-template">
+                                    Save ad hoc file as latest reusable template
+                                </label>
+                            </div>
+                        </div>
+
+                        {wordTemplateMode === 'ADHOC' && saveAdHocAsTemplate && (
+                            <>
+                                <div className="col-lg-4">
+                                    <label className="form-label small fw-semibold" htmlFor="template-name">Template name</label>
+                                    <input
+                                        id="template-name"
+                                        data-testid="template-name"
+                                        className="form-control form-control-sm"
+                                        type="text"
+                                        value={templateName}
+                                        onChange={(event) => setTemplateName(event.target.value)}
+                                        placeholder={adHocTemplateFile?.name.replace(/\.docx$/i, '') || 'Corporate requirement template'}
+                                    />
+                                </div>
+                                <div className="col-lg-4">
+                                    <label className="form-label small fw-semibold" htmlFor="template-version-label">Version label</label>
+                                    <input
+                                        id="template-version-label"
+                                        data-testid="template-version-label"
+                                        className="form-control form-control-sm"
+                                        type="text"
+                                        value={templateVersionLabel}
+                                        onChange={(event) => setTemplateVersionLabel(event.target.value)}
+                                        placeholder="Corporate 2026-Q2"
+                                    />
+                                </div>
+                                <div className="col-lg-4">
+                                    <label className="form-label small fw-semibold" htmlFor="template-description">Description</label>
+                                    <input
+                                        id="template-description"
+                                        data-testid="template-description"
+                                        className="form-control form-control-sm"
+                                        type="text"
+                                        value={templateDescription}
+                                        onChange={(event) => setTemplateDescription(event.target.value)}
+                                        placeholder="Approved audience or project context"
+                                    />
+                                </div>
+                            </>
+                        )}
+
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold" htmlFor="missing-placeholder-behavior">Missing placeholder behavior</label>
+                            <select
+                                id="missing-placeholder-behavior"
+                                data-testid="missing-placeholder-behavior"
+                                className="form-select form-select-sm"
+                                value={missingPlaceholderBehavior}
+                                onChange={(event) => setMissingPlaceholderBehavior(event.target.value as 'REJECT' | 'APPEND')}
+                            >
+                                <option value="REJECT">{'Reject template without ${requirements}'}</option>
+                                <option value="APPEND">Append requirements after template body</option>
+                            </select>
+                        </div>
+
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold" htmlFor="document-classification">Classification</label>
+                            <input
+                                id="document-classification"
+                                data-testid="document-classification"
+                                className="form-control form-control-sm"
+                                type="text"
+                                value={classification}
+                                onChange={(event) => setClassification(event.target.value)}
+                                placeholder="Internal"
+                            />
+                        </div>
+
+                        <div className="col-lg-4">
+                            <label className="form-label small fw-semibold">Preview summary</label>
+                            <div className="form-control form-control-sm bg-light" data-testid="word-template-preview">
+                                {wordTemplateMode === 'LATEST' && (savedTemplates[0] ? `Latest active: ${savedTemplates[0].name} (${savedTemplates[0].sha256.slice(0, 8)})` : 'No saved template; Secman default will be used')}
+                                {wordTemplateMode === 'SAVED' && (savedTemplates.find((template) => template.id === selectedTemplateId)?.name || 'Select a saved template')}
+                                {wordTemplateMode === 'ADHOC' && (adHocTemplateFile ? `Ad hoc: ${adHocTemplateFile.name}` : 'Choose a .docx file for this export')}
+                                {wordTemplateMode === 'NONE' && 'Built-in Secman Word layout'}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
### Motivation

- Provide corporate/custom `.docx` templates for requirement exports to avoid manual post-processing and preserve headers/footers/styles. 

### Description

- Add domain model, repositories, and Flyway migration for `requirement_export_template` and `requirement_export_template_usage` to store immutable template bytes, metadata, and usage events. 
- Implement `RequirementExportTemplateValidationService` to validate `.docx` OpenXML packages (ZIP signature, content types, forbidden entries, size/entry limits, placeholder detection, SHA-256) and return structured reports. 
- Add `RequirementExportTemplateController` for ADMIN/REQADMIN template management (validate, upload, list, download, activate/deactivate, retire/delete, usage) and extend `RequirementController` export endpoints to support `LATEST|SAVED|ADHOC|NONE` template modes, ad-hoc multipart POST exports, template resolution, placeholder replacement, templated rendering, and usage auditing. 
- Add frontend UI in `Export.tsx` to select mode, choose saved template, upload ad-hoc template, save ad-hoc as reusable template, set missing-placeholder behavior and classification, and stream download handling. 
- Add unit tests for template validation (`RequirementExportTemplateValidationServiceTest`) and update existing word-export tests to accommodate the template-aware export plumbing. 

### Testing

- Added unit tests: `RequirementExportTemplateValidationServiceTest` (valid template, missing placeholder rejection, macro payload rejection) and updated `RequirementControllerWordExportTest` to inject template collaborators. 
- Ran backend unit tests (`./gradlew test`) including the new validation tests and updated controller tests; all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd31929fc8323a82177498cba523b)