### PR TITLE
feat(products): search installed products by server

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/InstalledProductController.kt
@@ -36,6 +36,19 @@ open class InstalledProductController(
         return HttpResponse.ok(installedProductListService.list(authentication, search, limit))
     }
 
+    @Get("/by-server")
+    open fun listByServer(
+        authentication: Authentication,
+        @QueryValue server: String,
+        @Nullable @QueryValue limit: Int?
+    ): HttpResponse<*> {
+        return try {
+            HttpResponse.ok(installedProductListService.listForServer(authentication, server, limit))
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.badRequest(mapOf("error" to (e.message ?: "Invalid request")))
+        }
+    }
+
     @Post("/import")
     @Secured("ADMIN", "VULN")
     open fun importProducts(

--- a/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/InstalledProductRepository.kt
@@ -40,6 +40,44 @@ interface InstalledProductRepository : JpaRepository<InstalledProduct, Long> {
     fun searchWithAsset(search: String?, pageable: Pageable): List<InstalledProduct>
 
     @Query("""
+        SELECT p FROM InstalledProduct p
+        JOIN FETCH p.asset
+        WHERE (:server IS NULL OR :server = ''
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :server, '%'))
+            OR LOWER(COALESCE(p.asset.ip, '')) LIKE LOWER(CONCAT('%', :server, '%')))
+        ORDER BY p.asset.name ASC, p.name ASC, p.vendor ASC, p.version ASC
+    """)
+    fun searchByServerWithAsset(server: String?, pageable: Pageable): List<InstalledProduct>
+
+    @Query("""
+        SELECT p FROM InstalledProduct p
+        JOIN FETCH p.asset
+        WHERE p.asset.id IN (:assetIds)
+          AND (:server IS NULL OR :server = ''
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :server, '%'))
+            OR LOWER(COALESCE(p.asset.ip, '')) LIKE LOWER(CONCAT('%', :server, '%')))
+        ORDER BY p.asset.name ASC, p.name ASC, p.vendor ASC, p.version ASC
+    """)
+    fun searchByServerForAssetsWithAsset(server: String?, assetIds: Set<Long>, pageable: Pageable): List<InstalledProduct>
+
+    @Query("""
+        SELECT COUNT(DISTINCT p.asset.id) FROM InstalledProduct p
+        WHERE (:server IS NULL OR :server = ''
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :server, '%'))
+            OR LOWER(COALESCE(p.asset.ip, '')) LIKE LOWER(CONCAT('%', :server, '%')))
+    """)
+    fun countDistinctAssetsByServer(server: String?): Long
+
+    @Query("""
+        SELECT COUNT(DISTINCT p.asset.id) FROM InstalledProduct p
+        WHERE p.asset.id IN (:assetIds)
+          AND (:server IS NULL OR :server = ''
+            OR LOWER(p.asset.name) LIKE LOWER(CONCAT('%', :server, '%'))
+            OR LOWER(COALESCE(p.asset.ip, '')) LIKE LOWER(CONCAT('%', :server, '%')))
+    """)
+    fun countDistinctAssetsByServerForAssets(server: String?, assetIds: Set<Long>): Long
+
+    @Query("""
         SELECT DISTINCT asset FROM InstalledProduct p
         JOIN p.asset asset
         WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :productName, '%'))

--- a/src/backendng/src/main/kotlin/com/secman/service/InstalledProductListService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/InstalledProductListService.kt
@@ -15,8 +15,24 @@ open class InstalledProductListService(
 ) {
     @Transactional(readOnly = true)
     open fun list(authentication: Authentication, search: String?, limit: Int?): InstalledProductListResponse {
-        val effectiveLimit = (limit ?: 500).coerceIn(1, 2000)
         val normalizedSearch = search?.trim().orEmpty()
+        return listMatchingProducts(authentication, normalizedSearch, limit)
+    }
+
+    @Transactional(readOnly = true)
+    open fun listForServer(authentication: Authentication, server: String?, limit: Int?): InstalledProductListResponse {
+        val normalizedServer = server?.trim().orEmpty()
+        require(normalizedServer.isNotEmpty()) { "Server search term is required" }
+        return listMatchingProducts(authentication, normalizedServer, limit, matchServerOnly = true)
+    }
+
+    private fun listMatchingProducts(
+        authentication: Authentication,
+        normalizedSearch: String,
+        limit: Int?,
+        matchServerOnly: Boolean = false
+    ): InstalledProductListResponse {
+        val effectiveLimit = (limit ?: 500).coerceIn(1, 2000)
         val isAdmin = authentication.roles.contains("ADMIN")
         val accessibleAssetIds = if (isAdmin) null else accessibleAssetIdsCache.get(authentication)
 
@@ -29,15 +45,31 @@ open class InstalledProductListService(
         }
 
         val pageable = Pageable.from(0, effectiveLimit)
-        val products = if (accessibleAssetIds == null) {
-            installedProductRepository.searchWithAsset(normalizedSearch, pageable)
+        val products = if (matchServerOnly) {
+            if (accessibleAssetIds == null) {
+                installedProductRepository.searchByServerWithAsset(normalizedSearch, pageable)
+            } else {
+                installedProductRepository.searchByServerForAssetsWithAsset(normalizedSearch, accessibleAssetIds, pageable)
+            }
         } else {
-            installedProductRepository.searchForAssetsWithAsset(normalizedSearch, accessibleAssetIds, pageable)
+            if (accessibleAssetIds == null) {
+                installedProductRepository.searchWithAsset(normalizedSearch, pageable)
+            } else {
+                installedProductRepository.searchForAssetsWithAsset(normalizedSearch, accessibleAssetIds, pageable)
+            }
         }
-        val totalSystems = if (accessibleAssetIds == null) {
-            installedProductRepository.countDistinctAssets(normalizedSearch)
+        val totalSystems = if (matchServerOnly) {
+            if (accessibleAssetIds == null) {
+                installedProductRepository.countDistinctAssetsByServer(normalizedSearch)
+            } else {
+                installedProductRepository.countDistinctAssetsByServerForAssets(normalizedSearch, accessibleAssetIds)
+            }
         } else {
-            installedProductRepository.countDistinctAssetsForAssets(normalizedSearch, accessibleAssetIds)
+            if (accessibleAssetIds == null) {
+                installedProductRepository.countDistinctAssets(normalizedSearch)
+            } else {
+                installedProductRepository.countDistinctAssetsForAssets(normalizedSearch, accessibleAssetIds)
+            }
         }
 
         return InstalledProductListResponse(

--- a/src/backendng/src/test/kotlin/com/secman/service/InstalledProductListServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/InstalledProductListServiceTest.kt
@@ -1,0 +1,84 @@
+package com.secman.service
+
+import com.secman.domain.Asset
+import com.secman.domain.InstalledProduct
+import com.secman.repository.InstalledProductRepository
+import io.micronaut.data.model.Pageable
+import io.micronaut.security.authentication.Authentication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class InstalledProductListServiceTest {
+    private lateinit var installedProductRepository: InstalledProductRepository
+    private lateinit var accessibleAssetIdsCache: AccessibleAssetIdsCache
+    private lateinit var service: InstalledProductListService
+
+    @BeforeEach
+    fun setUp() {
+        installedProductRepository = mockk()
+        accessibleAssetIdsCache = mockk()
+        service = InstalledProductListService(installedProductRepository, accessibleAssetIdsCache)
+    }
+
+    @Test
+    fun `listForServer returns products for matching server names for admins`() {
+        val authentication = Authentication.build("admin", listOf("ADMIN"))
+        val asset = asset(42L, "server01", "10.0.0.15")
+        val chrome = product(100L, asset, "Chrome", "120.0")
+        every { installedProductRepository.searchByServerWithAsset("server01", any<Pageable>()) } returns listOf(chrome)
+        every { installedProductRepository.countDistinctAssetsByServer("server01") } returns 1L
+
+        val result = service.listForServer(authentication, " server01 ", 50)
+
+        assertThat(result.products).hasSize(1)
+        assertThat(result.products[0].hostname).isEqualTo("server01")
+        assertThat(result.products[0].name).isEqualTo("Chrome")
+        assertThat(result.products[0].version).isEqualTo("120.0")
+        assertThat(result.totalSystems).isEqualTo(1L)
+        verify(exactly = 0) { accessibleAssetIdsCache.get(any()) }
+    }
+
+    @Test
+    fun `listForServer scopes server results to accessible assets for non-admins`() {
+        val authentication = Authentication.build("champion", listOf("SECCHAMPION"))
+        val asset = asset(7L, "app-server", "10.0.0.7")
+        val product = product(101L, asset, "OpenJDK", "21")
+        every { accessibleAssetIdsCache.get(authentication) } returns setOf(7L)
+        every { installedProductRepository.searchByServerForAssetsWithAsset("app", setOf(7L), any<Pageable>()) } returns listOf(product)
+        every { installedProductRepository.countDistinctAssetsByServerForAssets("app", setOf(7L)) } returns 1L
+
+        val result = service.listForServer(authentication, "app", 25)
+
+        assertThat(result.products).extracting<String> { it.name }.containsExactly("OpenJDK")
+        assertThat(result.totalSystems).isEqualTo(1L)
+    }
+
+    @Test
+    fun `listForServer rejects blank server search terms`() {
+        val authentication = Authentication.build("admin", listOf("ADMIN"))
+
+        assertThatThrownBy { service.listForServer(authentication, "   ", 25) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Server search term is required")
+    }
+
+    private fun asset(id: Long, name: String, ip: String): Asset = Asset(
+        id = id,
+        name = name,
+        type = "SERVER",
+        ip = ip,
+        owner = "owner"
+    )
+
+    private fun product(id: Long, asset: Asset, name: String, version: String): InstalledProduct = InstalledProduct(
+        id = id,
+        asset = asset,
+        name = name,
+        version = version
+    )
+}

--- a/src/frontend/src/components/InstalledProducts.tsx
+++ b/src/frontend/src/components/InstalledProducts.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import HtmlEditor from './admin/HtmlEditor';
-import { getInstalledProducts, type InstalledProductResponse } from '../services/installedProductService';
+import { getInstalledProducts, getInstalledProductsByServer, type InstalledProductResponse } from '../services/installedProductService';
 import {
   createProductBroadcast,
   getProductRecipientCount,
@@ -12,6 +12,7 @@ import { canNotifyProductUsers } from './productNotifyAccess';
 const InstalledProducts: React.FC = () => {
   const [products, setProducts] = useState<InstalledProductResponse[]>([]);
   const [search, setSearch] = useState('');
+  const [serverSearch, setServerSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [totalSystems, setTotalSystems] = useState(0);
@@ -30,7 +31,11 @@ const InstalledProducts: React.FC = () => {
   useEffect(() => {
     const timeout = window.setTimeout(() => {
       setLoading(true);
-      getInstalledProducts(search)
+      const request = serverSearch.trim()
+        ? getInstalledProductsByServer(serverSearch)
+        : getInstalledProducts(search);
+
+      request
         .then((response) => {
           setProducts(response.products ?? []);
           setTotalSystems(response.totalSystems);
@@ -41,7 +46,7 @@ const InstalledProducts: React.FC = () => {
     }, 250);
 
     return () => window.clearTimeout(timeout);
-  }, [search]);
+  }, [search, serverSearch]);
 
   const openNotifyModal = async (productName: string) => {
     setNotifyProduct(productName);
@@ -97,7 +102,7 @@ const InstalledProducts: React.FC = () => {
       <div className="d-flex justify-content-between align-items-center mb-4">
         <div>
           <h1 className="h3 mb-1">Installed products</h1>
-          <p className="text-muted mb-0">Products imported from CrowdStrike Discover for systems known in Secman.</p>
+          <p className="text-muted mb-0">Products imported from CrowdStrike Discover for systems known in Secman. Search a server to return the products installed on matching systems.</p>
         </div>
         <div className="text-end">
           <div className="fw-semibold">{products.length}</div>
@@ -107,27 +112,46 @@ const InstalledProducts: React.FC = () => {
 
       <div className="card mb-3">
         <div className="card-body">
-          <label className="form-label" htmlFor="installed-product-search">Search products, vendors, versions, or systems</label>
-          <div className="d-flex gap-2">
-            <input
-              id="installed-product-search"
-              className="form-control"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="e.g. Chrome, Microsoft, server01"
-            />
-            {canNotifyUsers && notifyProductName && (
-              <button
-                type="button"
-                className="btn btn-outline-primary flex-shrink-0"
-                onClick={() => openNotifyModal(notifyProductName)}
-                disabled={loading || products.length === 0}
-                title={`Notify users for ${notifyProductName}`}
-              >
-                <i className="bi bi-envelope me-1"></i>
-                Notify users
-              </button>
-            )}
+          <div className="row g-3">
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="installed-product-server-search">Search by server</label>
+              <input
+                id="installed-product-server-search"
+                className="form-control"
+                value={serverSearch}
+                onChange={(event) => setServerSearch(event.target.value)}
+                placeholder="e.g. server01 or 10.0.0.15"
+              />
+              <div className="form-text">Returns the installed products for matching server names or IP addresses.</div>
+            </div>
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="installed-product-search">Search products, vendors, versions, or systems</label>
+              <div className="d-flex gap-2">
+                <input
+                  id="installed-product-search"
+                  className="form-control"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="e.g. Chrome, Microsoft, server01"
+                  disabled={Boolean(serverSearch.trim())}
+                />
+                {canNotifyUsers && notifyProductName && (
+                  <button
+                    type="button"
+                    className="btn btn-outline-primary flex-shrink-0"
+                    onClick={() => openNotifyModal(notifyProductName)}
+                    disabled={loading || products.length === 0}
+                    title={`Notify users for ${notifyProductName}`}
+                  >
+                    <i className="bi bi-envelope me-1"></i>
+                    Notify users
+                  </button>
+                )}
+              </div>
+              {serverSearch.trim() && (
+                <div className="form-text">Product search is paused while server search is active.</div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/frontend/src/components/ProductsOverview.test.ts
+++ b/src/frontend/src/components/ProductsOverview.test.ts
@@ -42,6 +42,16 @@ test('installed products exposes the product notify action', () => {
     assert.match(source, /createProductBroadcast/);
 });
 
+test('installed products supports server-specific product lookup', () => {
+    const componentSource = readFileSync(new URL('./InstalledProducts.tsx', import.meta.url), 'utf8');
+    const serviceSource = readFileSync(new URL('../services/installedProductService.ts', import.meta.url), 'utf8');
+
+    assert.match(componentSource, /Search by server/);
+    assert.match(componentSource, /getInstalledProductsByServer\(serverSearch\)/);
+    assert.match(serviceSource, /getInstalledProductsByServer/);
+    assert.match(serviceSource, /\/api\/installed-products\/by-server/);
+});
+
 test('installed products renders only product, version, and system columns', () => {
     const source = readFileSync(new URL('./InstalledProducts.tsx', import.meta.url), 'utf8');
 

--- a/src/frontend/src/services/installedProductService.ts
+++ b/src/frontend/src/services/installedProductService.ts
@@ -31,3 +31,14 @@ export async function getInstalledProducts(search = '', limit = 500): Promise<In
   }
   return response.json();
 }
+
+export async function getInstalledProductsByServer(server = '', limit = 500): Promise<InstalledProductListResponse> {
+  const params = new URLSearchParams();
+  if (server.trim()) params.append('server', server.trim());
+  params.append('limit', String(limit));
+  const response = await authenticatedGet(`/api/installed-products/by-server?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch installed products for server: ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
### Motivation
- Provide a server-focused lookup so operators can search by server name or IP and retrieve the list of installed products observed on matching systems while preserving existing product search UX.
- Ensure the server lookup respects existing access controls so non-admin users only see products for assets they are allowed to access.

### Description
- Added a new endpoint `GET /api/installed-products/by-server` that validates a non-empty `server` query and returns the same `InstalledProductListResponse` shape as the existing product listing.
- Extended `InstalledProductRepository` with server-focused queries and counting methods (`searchByServerWithAsset`, `searchByServerForAssetsWithAsset`, `countDistinctAssetsByServer`, `countDistinctAssetsByServerForAssets`) that support both global (admin) and scoped (non-admin) access.
- Refactored `InstalledProductListService` to introduce `listForServer` and a shared `listMatchingProducts` helper that toggles between product search and server-only search while honoring accessible asset scoping.
- Frontend changes add `getInstalledProductsByServer` API helper and a `Search by server` input to `InstalledProducts.tsx` which pauses general product search while a server search term is active.
- Added unit tests `InstalledProductListServiceTest` (server admin lookup, non-admin scoping, blank-term validation) and a frontend source-level test asserting the new UI/API wiring in `ProductsOverview.test.ts`.

### Testing
- Ran backend unit tests with `./gradlew :backendng:test --tests "com.secman.service.InstalledProductListServiceTest"` and the test suite passed after ensuring a JDK 21 toolchain was available. (succeeded)
- Executed the focused frontend node tests with `node --test src/frontend/src/components/ProductsOverview.test.ts` and all added assertions passed. (succeeded)
- Linted the changed frontend files with `npx eslint src/components/InstalledProducts.tsx src/services/installedProductService.ts src/components/ProductsOverview.test.ts` and the checks for the modified files passed; a full `cd src/frontend && npm run lint` still reports pre-existing project-wide lint issues unrelated to this change. (partial — focused lint passed, full lint reports unrelated errors)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20411e60288323ad593f6c2ec111df)