### PR TITLE
chore(build): target Java 25

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Security requirement, vulnerability and risk management platform.
 
 ## Stack
 
-- Backend: Kotlin 2.3.21 / Java 21, Micronaut 4.10, Hibernate JPA → `src/backendng/`
+- Backend: Kotlin 2.3.21 / Java 25, Micronaut 4.10, Hibernate JPA → `src/backendng/`
 - Frontend: Astro 6.3 + React 19 islands, Axios, JWT in localStorage → `src/frontend/`
 - CLI: Kotlin + Picocli 4.7.7, AWS SDK v2 → `src/cli/`
 - DB: MariaDB 11.4, Flyway + Hibernate auto-migration

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Security requirement, vulnerability and risk-assessment platform.
 
 ## Stack
 
-Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 (Kotlin DSL) · Picocli 4.7.7 · AWS SDK v2.
+Kotlin 2.3.21 / Java 25 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 (Kotlin DSL) · Picocli 4.7.7 · AWS SDK v2.
 
 ## Quick Start (development)
 
-Prereqs: Java 21, Node 20+, MariaDB 11.4+, Git.
+Prereqs: Java 25, Node 20+, MariaDB 11.4+, Git.
 
 ```bash
 git clone https://github.com/schmalle/secman.git && cd secman

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,6 @@ subprojects {
 ext {
     set("kotlinVersion", "2.3.21")
     set("micronautVersion", "4.10.13")
-    set("jvmTarget", "21")
+    set("jvmTarget", "25")
     set("picocliVersion", "4.7.7")
 }

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Secman Backend Container
 # Expects the fat JAR to be pre-built on the host (build-all.sh handles this).
 # This avoids needing 4GB+ RAM inside Docker for the Kotlin/Gradle compilation.
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 
 LABEL maintainer="secman"
 LABEL description="Secman backend (Micronaut/Kotlin)"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@
         [CLI] ─── HTTPS ──► Backend REST API
 ```
 
-Stack: Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7 · AWS SDK v2.
+Stack: Kotlin 2.3.21 / Java 25 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7 · AWS SDK v2.
 
 ## Backend (`src/backendng/`)
 

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -81,8 +81,8 @@ is not required.
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-# Java 21 (Amazon Corretto build via SDKMAN)
-sdk install java 21-amzn
+# Java 25 (Amazon Corretto build via SDKMAN)
+sdk install java 25-amzn
 
 # Gradle 9.5.0 (project version)
 sdk install gradle 9.5
@@ -99,10 +99,10 @@ in the cron environment.
 ### Java + Gradle via system packages (alternative)
 
 ```bash
-# Java 21 (Corretto)
-sudo dnf install -y java-21-amazon-corretto-devel   # AL2023
-# or, on AL2:
-sudo amazon-linux-extras enable corretto21 && sudo yum install -y java-21-amazon-corretto-devel
+# Java 25 (Corretto)
+sudo dnf install -y java-25-amazon-corretto-devel   # AL2023, if available
+# On AL2 or older distro releases, install an OpenJDK/Corretto 25 package
+# from your Java vendor if the OS repositories do not provide one.
 
 # System Gradle (optional — ./gradlew works as a fallback)
 curl -fsSL https://services.gradle.org/distributions/gradle-9.5-bin.zip -o /tmp/gradle.zip

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -268,8 +268,8 @@ java -jar "$JAR" query servers --severity HIGH,CRITICAL --min-days-open 1 --save
 
 `crontab -e` examples:
 ```cron
-PATH=/usr/bin:/bin:/usr/local/bin:/usr/lib/jvm/java-21-amazon-corretto/bin
-JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto
+PATH=/usr/bin:/bin:/usr/local/bin:/usr/lib/jvm/java-25-amazon-corretto/bin
+JAVA_HOME=/usr/lib/jvm/java-25-amazon-corretto
 
 0 2 * * *          /opt/secman/bin/cron-query-servers.sh >> /opt/secman/logs/cronjob.log 2>&1
 0 9-17 * * 1-5     /opt/secman/bin/cron-query-servers.sh

--- a/docs/COMPILE_DIST_SETUP.md
+++ b/docs/COMPILE_DIST_SETUP.md
@@ -61,7 +61,7 @@ operator to be explicit about the SSH user.
 On the **build host** (where you run the script):
 
 - `bash` 4+, `ssh`, `rsync`, `npm` available on `PATH`.
-- A working JDK 21 toolchain (used via `./gradlew`).
+- A working JDK 25 toolchain (used via `./gradlew`).
 - The Gradle wrapper (`./gradlew`) executable in the repo root.
 - Internet access for Gradle and npm dependency resolution (unless caches
   are pre-warmed).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Linux production. Backend (`:8080`) + Frontend (`:4321`) behind nginx with SSL termination, MariaDB on `:3306`. Stack: Kotlin 2.3.21/Java 21/Micronaut 4.10 + Astro 6.3/React 19/Node 20 + MariaDB 11.4. Tested on Amazon Linux 2023, Ubuntu 20.04+, RHEL 8+.
+Linux production. Backend (`:8080`) + Frontend (`:4321`) behind nginx with SSL termination, MariaDB on `:3306`. Stack: Kotlin 2.3.21/Java 25/Micronaut 4.10 + Astro 6.3/React 19/Node 20 + MariaDB 11.4. Tested on Amazon Linux 2023, Ubuntu 20.04+, RHEL 8+.
 
 System: 2c/4G/20G minimum, 4c+/8G+/50G+ SSD recommended. Outbound 443 needed for SMTP/CrowdStrike. Inbound 80/443.
 
@@ -8,7 +8,7 @@ System: 2c/4G/20G minimum, 4c+/8G+/50G+ SSD recommended. Outbound 443 needed for
 
 ```bash
 # Amazon Linux / RHEL
-sudo dnf install -y java-21-amazon-corretto-devel git nginx
+sudo dnf install -y java-25-amazon-corretto-devel git nginx
 curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
 sudo dnf install -y nodejs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Security requirement, vulnerability and risk assessment management tool.
    /*      ───►  Frontend :4321 (Astro/React SSR)
 ```
 
-Stack: Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 / React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7.
+Stack: Kotlin 2.3.21 / Java 25 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 / React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7.
 
 ## Index
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -56,7 +56,7 @@ SELECT table_name, ROUND(data_length/1024/1024,2) AS mb
 
 | Symptom | Fix |
 |---|---|
-| `Command not found` in cron | add `PATH` and `JAVA_HOME` to crontab (point at `/usr/lib/jvm/java-21-amazon-corretto/bin`) |
+| `Command not found` in cron | add `PATH` and `JAVA_HOME` to crontab (point at `/usr/lib/jvm/java-25-amazon-corretto/bin`) |
 | `Credentials not found` | check format — no spaces around `=` (`FALCON_CLIENT_ID=abc` not `FALCON_CLIENT_ID = abc`); `chmod 600` |
 | CrowdStrike `401 Unauthorized` | verify client/secret + region in `FALCON_BASE_URL` (US-1/US-2/EU-1/GOV); required scopes |
 | Out of memory | `java -Xmx1g -jar secman-cli.jar …` (or in cron wrapper) |

--- a/scripts/compiledistsetup.sh
+++ b/scripts/compiledistsetup.sh
@@ -42,7 +42,7 @@
 #   so runtime scripts that reference the repository-like tree keep working.
 #
 # PREREQUISITES
-#   Build host : bash, ssh, rsync, npm, JDK 21 toolchain, ./gradlew.
+#   Build host : bash, ssh, rsync, npm, JDK 25 toolchain, ./gradlew.
 #   Each target: sshd reachable on port 22, rsync installed, build host's
 #                public key in ~<user>/.ssh/authorized_keys, write access
 #                to <remote-dir>.

--- a/scripts/secmancli
+++ b/scripts/secmancli
@@ -17,7 +17,7 @@
 #   ./scripts/secmancli send-notifications --dry-run
 #
 # Prerequisites:
-#   1. Java 21 must be installed and in PATH
+#   1. Java 25 must be installed and in PATH
 #   2. Proton Pass CLI (pass-cli) must be installed and logged in
 #   3. Build the JAR first: ./gradlew :cli:shadowJar
 

--- a/scripts/secmanclisupport
+++ b/scripts/secmanclisupport
@@ -8,7 +8,7 @@
 #   ./scripts/secman query servers --dry-run
 #
 # Prerequisites:
-#   1. Java 21 must be installed and in PATH
+#   1. Java 25 must be installed and in PATH
 #   2. Build the JAR first: ./gradlew :cli:shadowJar
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/startbackenddevaws.sh
+++ b/scripts/startbackenddevaws.sh
@@ -63,7 +63,7 @@ command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required. See docs/A
 command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq is required. See docs/AWS.md.";       exit 1; }
 command -v openssl >/dev/null 2>&1 || { echo "ERROR: openssl is required.";          exit 1; }
 command -v java >/dev/null 2>&1 || {
-  echo "ERROR: java not found. Install via SDKMAN ('sdk install java 21-amzn') or set SDKMAN_DIR."
+  echo "ERROR: java not found. Install via SDKMAN ('sdk install java 25-amzn') or set SDKMAN_DIR."
   exit 1
 }
 

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -131,12 +131,12 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("21")
-    targetCompatibility = JavaVersion.toVersion("21")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 allOpen {

--- a/src/shared/build.gradle.kts
+++ b/src/shared/build.gradle.kts
@@ -44,12 +44,12 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 tasks {


### PR DESCRIPTION
### Motivation
- Update the project's Java target/toolchain from Java 21 to Java 25 so builds, container runtime and documentation consistently reference the newer Java platform.
- Keep developer scripts and deployment docs aligned with the updated build target to avoid confusion for contributors and operators.

### Description
- Bumped root `jvmTarget` to `25` in `build.gradle.kts` and updated `jvmToolchain` / `sourceCompatibility` / `targetCompatibility` to Java 25 in `src/shared/build.gradle.kts` and `src/backendng/build.gradle.kts`.
- Switched the backend Docker base image to `eclipse-temurin:25-jre` in `docker/backend/Dockerfile` and adjusted install/runtime guidance in several docs and scripts.
- Updated operational and developer-facing references from Java 21 → Java 25 across README/CLAUDE/docs (`docs/*`, `README.md`, `CLAUDE.md`) and helper scripts (`scripts/secmancli`, `scripts/secmanclisupport`, `scripts/compiledistsetup.sh`, `scripts/startbackenddevaws.sh`).
- No code logic, schema, dependency, or feature changes were made; only build/tooling, container base image, scripts, and docs were updated.

### Testing
- Verified the active JDK with `java -version` which reported an OpenJDK 25 runtime and then ran `./gradlew :shared:compileKotlin :backendng:compileKotlin :cli:compileKotlin --no-daemon` which completed successfully.
- Ran a full build with `./gradlew build --no-daemon` and it completed successfully with all tasks passing.
- Ran `git diff --check` and a repository-wide grep to ensure no remaining Java-21 references, and both checks returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2064d5cf7c8323ba90dbcda5838b78)