### PR TITLE
build(kotlin): upgrade to 2.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Security requirement, vulnerability and risk management platform.
 
 ## Stack
 
-- Backend: Kotlin 2.3.21 / Java 21, Micronaut 4.10, Hibernate JPA → `src/backendng/`
+- Backend: Kotlin 2.4.0 / Java 21, Micronaut 4.10, Hibernate JPA → `src/backendng/`
 - Frontend: Astro 6.3 + React 19 islands, Axios, JWT in localStorage → `src/frontend/`
 - CLI: Kotlin + Picocli 4.7.7, AWS SDK v2 → `src/cli/`
 - DB: MariaDB 11.4, Flyway + Hibernate auto-migration

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Security requirement, vulnerability and risk-assessment platform.
 
 ## Stack
 
-Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 (Kotlin DSL) · Picocli 4.7.7 · AWS SDK v2.
+Kotlin 2.4.0 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 (Kotlin DSL) · Picocli 4.7.7 · AWS SDK v2.
 
 ## Quick Start (development)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.3.21" apply false
-    id("org.jetbrains.kotlin.plugin.allopen") version "2.3.21" apply false
-    id("org.jetbrains.kotlin.plugin.jpa") version "2.3.21" apply false
-    id("com.google.devtools.ksp") version "2.3.8" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.4.0" apply false
+    id("org.jetbrains.kotlin.plugin.allopen") version "2.4.0" apply false
+    id("org.jetbrains.kotlin.plugin.jpa") version "2.4.0" apply false
+    id("com.google.devtools.ksp") version "2.3.9" apply false
     id("io.micronaut.application") version "4.6.2" apply false
     id("io.micronaut.library") version "4.6.2" apply false
     id("io.micronaut.aot") version "4.6.2" apply false
@@ -20,7 +20,7 @@ subprojects {
 
 // Common dependency versions
 ext {
-    set("kotlinVersion", "2.3.21")
+    set("kotlinVersion", "2.4.0")
     set("micronautVersion", "4.10.13")
     set("jvmTarget", "21")
     set("picocliVersion", "4.7.7")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@
         [CLI] ─── HTTPS ──► Backend REST API
 ```
 
-Stack: Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7 · AWS SDK v2.
+Stack: Kotlin 2.4.0 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 + React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7 · AWS SDK v2.
 
 ## Backend (`src/backendng/`)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Linux production. Backend (`:8080`) + Frontend (`:4321`) behind nginx with SSL termination, MariaDB on `:3306`. Stack: Kotlin 2.3.21/Java 21/Micronaut 4.10 + Astro 6.3/React 19/Node 20 + MariaDB 11.4. Tested on Amazon Linux 2023, Ubuntu 20.04+, RHEL 8+.
+Linux production. Backend (`:8080`) + Frontend (`:4321`) behind nginx with SSL termination, MariaDB on `:3306`. Stack: Kotlin 2.4.0/Java 21/Micronaut 4.10 + Astro 6.3/React 19/Node 20 + MariaDB 11.4. Tested on Amazon Linux 2023, Ubuntu 20.04+, RHEL 8+.
 
 System: 2c/4G/20G minimum, 4c+/8G+/50G+ SSD recommended. Outbound 443 needed for SMTP/CrowdStrike. Inbound 80/443.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Security requirement, vulnerability and risk assessment management tool.
    /*      ───►  Frontend :4321 (Astro/React SSR)
 ```
 
-Stack: Kotlin 2.3.21 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 / React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7.
+Stack: Kotlin 2.4.0 / Java 21 · Micronaut 4.10 · Hibernate JPA · Astro 6.3 / React 19 · Bootstrap 5.3 · MariaDB 11.4 · Gradle 9.5.0 · Picocli 4.7.7.
 
 ## Index
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,10 +4,10 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("org.jetbrains.kotlin.jvm") version "2.3.21"
-        id("org.jetbrains.kotlin.plugin.allopen") version "2.3.21"
-        id("org.jetbrains.kotlin.plugin.jpa") version "2.3.21"
-        id("com.google.devtools.ksp") version "2.3.7"
+        id("org.jetbrains.kotlin.jvm") version "2.4.0"
+        id("org.jetbrains.kotlin.plugin.allopen") version "2.4.0"
+        id("org.jetbrains.kotlin.plugin.jpa") version "2.4.0"
+        id("com.google.devtools.ksp") version "2.3.9"
         id("io.micronaut.application") version "4.6.2"
         id("io.micronaut.library") version "4.6.2"
         id("io.micronaut.aot") version "4.6.2"

--- a/specs/087-crowdstrike-legacy-stale-cleanup/plan.md
+++ b/specs/087-crowdstrike-legacy-stale-cleanup/plan.md
@@ -9,7 +9,7 @@ Extend the CrowdStrike stale-asset cleanup pipeline to find a second, additive c
 
 ## Technical Context
 
-**Language/Version**: Kotlin 2.3.21 / Java 21 (backend); TypeScript with Astro 6.2 + React 19 islands (frontend).
+**Language/Version**: Kotlin 2.4.0 / Java 21 (backend); TypeScript with Astro 6.2 + React 19 islands (frontend).
 **Primary Dependencies**: Micronaut 4.10 (DI, scheduling, security), Hibernate JPA, Micronaut Data, Flyway, Apache POI 5.3 (unused for this feature), Bootstrap 5.3, Axios.
 **Storage**: MariaDB 11.4 in production; H2 in-memory for unit tests; Testcontainers MariaDB 11.4 for integration tests. Both H2 and MariaDB support `COALESCE` in JPQL.
 **Testing**: JUnit 6, Mockk, AssertJ, `@MicronautTest`, Testcontainers (`BaseIntegrationTest` helper). User has explicitly requested unit + integration tests for this feature (see spec FR-001..016 mapped to acceptance scenarios), so test prep is in scope under Constitution Principle IV.

--- a/specs/088-ai-risk-assessment-answers/plan.md
+++ b/specs/088-ai-risk-assessment-answers/plan.md
@@ -5,7 +5,7 @@
 
 ## Tech stack
 
-- **Backend**: Kotlin 2.3.21 / Java 21, Micronaut 4.10, Hibernate JPA. New code under `src/backendng/src/main/kotlin/com/secman/`.
+- **Backend**: Kotlin 2.4.0 / Java 21, Micronaut 4.10, Hibernate JPA. New code under `src/backendng/src/main/kotlin/com/secman/`.
 - **Frontend**: Astro 6.3 + React 19 islands, Axios, Bootstrap classes. New + extended components under `src/frontend/src/components/`.
 - **DB**: MariaDB 11.4 via Flyway. New migration **V215**.
 - **External**: OpenRouter (`https://openrouter.ai/api/v1`) — already wired in `application.yml` for `TranslationService`. JDK `HttpClient` pattern (not Micronaut `@Client`).

--- a/src/backendng/build.gradle.kts
+++ b/src/backendng/build.gradle.kts
@@ -164,13 +164,6 @@ micronaut {
 }
 
 
-// Configure Kotlin compiler options
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    compilerOptions {
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
-    }
-}
-
 // Configure test task to use JUnit 5 platform - Feature 056
 tasks.test {
     useJUnitPlatform()

--- a/src/backendng/gradle.properties
+++ b/src/backendng/gradle.properties
@@ -1,5 +1,5 @@
 micronautVersion=4.10.13
-kotlinVersion=2.3.21
+kotlinVersion=2.4.0
 
 # Incremental KSP annotation processing
 ksp.incremental=true

--- a/src/cli/build.gradle.kts
+++ b/src/cli/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation("software.amazon.awssdk:s3")
     
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.21")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.3.21")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.4.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.4.0")
     
     // Logging
     runtimeOnly("ch.qos.logback:logback-classic")
@@ -69,12 +69,6 @@ kotlin {
 }
 
 tasks {
-    compileKotlin {
-        compilerOptions {
-            freeCompilerArgs.add("-Xannotation-default-target=param-property")
-        }
-    }
-
     // Enable JUnit 5 platform for tests - Feature 056
     test {
         useJUnitPlatform()

--- a/src/cli/gradle.properties
+++ b/src/cli/gradle.properties
@@ -1,2 +1,2 @@
 micronautVersion=4.10.13
-kotlinVersion=2.3.21
+kotlinVersion=2.4.0

--- a/src/shared/build.gradle.kts
+++ b/src/shared/build.gradle.kts
@@ -53,12 +53,6 @@ kotlin {
 }
 
 tasks {
-    compileKotlin {
-        compilerOptions {
-            freeCompilerArgs.add("-Xannotation-default-target=param-property")
-        }
-    }
-    
     test {
         useJUnitPlatform()
     }

--- a/src/shared/gradle.properties
+++ b/src/shared/gradle.properties
@@ -1,2 +1,2 @@
 micronautVersion=4.10.13
-kotlinVersion=2.3.21
+kotlinVersion=2.4.0


### PR DESCRIPTION
### Motivation
- Bump the project Kotlin toolchain to `2.4.0` so new language improvements and bugfixes are available across the backend/cli/shared modules.
- Keep the Kotlin Symbol Processing (KSP) plugin aligned to a published compatible version for this Kotlin upgrade.
- Refresh repository documentation and spec files so the project guidance no longer references the older `2.3.21` version.

### Description
- Updated root plugin declarations and the shared `kotlinVersion` to `2.4.0` and adjusted `settings.gradle.kts` plugin-management to match `2.4.0` for Kotlin plugins.
- Aligned the Gradle KSP plugin to the compatible published `2.3.9` artifact and removed the now-redundant compiler flag `-Xannotation-default-target=param-property` that is unnecessary on Kotlin `2.4`.
- Updated module properties and explicit CLI Kotlin runtime dependencies (`kotlin-reflect`, `kotlin-stdlib-jdk8`) to `2.4.0` and removed redundant per-module compile option blocks.
- Updated README/docs/CLAUDE/spec plan references to Kotlin `2.4.0` to keep developer guidance and specs consistent with the change.

### Testing
- Ran `./gradlew build -Dorg.gradle.java.installations.paths=/root/.local/share/mise/installs/java/21.0.2,/root/.local/share/mise/installs/java/25.0.2` and the build completed successfully.
- Attempted to run the JS error scanner via `./tests/js-error-scanner-pp.sh` but it could not run in this environment because `pass-cli` is not installed, so the dual-role scanner was not executed here.
- Attempted to run the full vuln-exception E2E driver `./scripts/test/test-e2e-vuln-exception-full.sh --verbose` but it could not run here because the `mariadb` CLI/service is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2065e79ef08323ba16e31609e38e51)