### PR TITLE
feat(frontend): add role filter to User Management

### DIFF
--- a/src/frontend/src/components/UserManagement.tsx
+++ b/src/frontend/src/components/UserManagement.tsx
@@ -57,6 +57,7 @@ const UserManagement = () => {
 
     // State for search, sort, pagination
     const [searchQuery, setSearchQuery] = useState('');
+    const [roleFilter, setRoleFilter] = useState('');
     const [sortField, setSortField] = useState<SortField>('username');
     const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
     const [currentPage, setCurrentPage] = useState(1);
@@ -601,6 +602,12 @@ const UserManagement = () => {
     };
 
 
+    const roleFilterOptions = useMemo(() => {
+        const roles = new Set(AVAILABLE_ROLES);
+        users.forEach(user => (user.roles ?? []).forEach(role => roles.add(role)));
+        return Array.from(roles).sort();
+    }, [users]);
+
     // --- Filtering, Sorting, Pagination ---
     const filteredAndSortedUsers = useMemo(() => {
         let result = [...users];
@@ -614,6 +621,10 @@ const UserManagement = () => {
                 (u.roles ?? []).some(r => r.toLowerCase().includes(q)) ||
                 (u.workgroups ?? []).some(wg => wg.name.toLowerCase().includes(q))
             );
+        }
+
+        if (roleFilter) {
+            result = result.filter(u => (u.roles ?? []).includes(roleFilter));
         }
 
         // Sort
@@ -646,16 +657,16 @@ const UserManagement = () => {
         });
 
         return result;
-    }, [users, searchQuery, sortField, sortDirection]);
+    }, [users, searchQuery, roleFilter, sortField, sortDirection]);
 
     const totalPages = Math.max(1, Math.ceil(filteredAndSortedUsers.length / pageSize));
     const safePage = Math.min(currentPage, totalPages);
     const paginatedUsers = filteredAndSortedUsers.slice((safePage - 1) * pageSize, safePage * pageSize);
 
-    // Reset to page 1 when search changes
+    // Reset to page 1 when filters change
     useEffect(() => {
         setCurrentPage(1);
-    }, [searchQuery, pageSize]);
+    }, [searchQuery, roleFilter, pageSize]);
 
     const handleSort = (field: SortField) => {
         if (sortField === field) {
@@ -1190,6 +1201,25 @@ const UserManagement = () => {
                             </button>
                         )}
                     </div>
+                    <div className="input-group" style={{ maxWidth: '260px' }}>
+                        <span className="input-group-text"><i className="bi bi-shield-check"></i></span>
+                        <select
+                            className="form-select"
+                            aria-label="Filter users by role"
+                            value={roleFilter}
+                            onChange={e => setRoleFilter(e.target.value)}
+                        >
+                            <option value="">All roles</option>
+                            {roleFilterOptions.map(role => (
+                                <option key={role} value={role}>{role}</option>
+                            ))}
+                        </select>
+                        {roleFilter && (
+                            <button className="btn btn-outline-secondary" type="button" onClick={() => setRoleFilter('')} aria-label="Clear role filter">
+                                <i className="bi bi-x-lg"></i>
+                            </button>
+                        )}
+                    </div>
                     <small className="text-muted text-nowrap">
                         {filteredAndSortedUsers.length === users.length
                             ? `${users.length} users`
@@ -1286,8 +1316,8 @@ const UserManagement = () => {
                     ) : (
                         <tr>
                             <td colSpan={6} className="text-center">
-                                {searchQuery
-                                    ? `No users matching "${searchQuery}"`
+                                {searchQuery || roleFilter
+                                    ? `No users matching ${[searchQuery && `"${searchQuery}"`, roleFilter && `role ${roleFilter}`].filter(Boolean).join(' and ')}`
                                     : (error && !error.includes("Access Denied") ? "Could not load users." : "No users found.")}
                             </td>
                         </tr>


### PR DESCRIPTION
### Motivation
- Make it easier for admins to narrow the user list by role in addition to the existing free-text search on the User Management page.

### Description
- Added a `roleFilter` state and exact-role filtering to the list logic in `src/frontend/src/components/UserManagement.tsx` so the table can be filtered by a selected role.
- Built the role dropdown options from the canonical `AVAILABLE_ROLES` plus any roles returned by the backend and placed the dropdown next to the existing search box for quick access.
- Updated pagination reset behavior and the empty-state message so page and messaging respond correctly to combined text + role filters.
- UI additions are purely frontend and contained to `UserManagement.tsx` (no backend changes required).

### Testing
- Ran frontend lint with `cd src/frontend && npm run lint`, which completed (repository-wide warnings remain but no new errors introduced).
- Built the frontend with `cd src/frontend && npm run build`, which completed successfully.
- Attempted automated E2E checks but they were blocked by the environment: `./tests/js-error-scanner-pp.sh` requires `pass-cli` (not installed here) and `./scripts/test/test-e2e-vuln-exception-full.sh` requires the `mariadb` CLI (not available here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218b6793c883238f3b264f7c40f468)