### PR TITLE
fix(frontend): rename "Created By" to "Approved By" in vulnerability exceptions UI

### DIFF
--- a/src/frontend/src/components/VulnerabilityExceptionForm.tsx
+++ b/src/frontend/src/components/VulnerabilityExceptionForm.tsx
@@ -568,7 +568,7 @@ const VulnerabilityExceptionForm: React.FC<VulnerabilityExceptionFormProps> = ({
                             </>
                         )}
 
-                        <dt className="col-sm-3">Created By</dt>
+                        <dt className="col-sm-3">Approved By</dt>
                         <dd className="col-sm-9">{exception.createdBy}</dd>
                     </dl>
                 </div>

--- a/src/frontend/src/components/VulnerabilityExceptionsTable.tsx
+++ b/src/frontend/src/components/VulnerabilityExceptionsTable.tsx
@@ -388,7 +388,7 @@ const VulnerabilityExceptionsTable: React.FC = () => {
                                                 <th>Affected</th>
                                                 <th>Expiration</th>
                                                 <th>Reason</th>
-                                                <th>Created By</th>
+                                                <th>Approved By</th>
                                                 <th>Status</th>
                                                 <th>Actions</th>
                                             </tr>


### PR DESCRIPTION
### Motivation
- The exceptions UI was showing "Created By" while the field represents the reviewer/approver for approved exception requests, so the label was changed to "Approved By" for clarity and consistency with the approval workflow.

### Description
- Renamed the column and detail/form label from `Created By` to `Approved By` in `src/frontend/src/components/VulnerabilityExceptionsTable.tsx` and `src/frontend/src/components/VulnerabilityExceptionForm.tsx` and committed with message `fix(frontend): rename exception approver label`.

### Testing
- Ran `cd src/frontend && npm install`, `cd src/frontend && npm run lint` (completed with existing warnings), and `cd src/frontend && npm run build` which all succeeded; these steps validate the frontend compiles and lints in this environment.
- E2E gates could not be executed here: `SECMAN_BACKEND_URL=... ./tests/js-error-scanner-pp.sh` was blocked due to missing `pass-cli`, and `./scripts/test/test-e2e-vuln-exception-full.sh` was blocked due to missing `mariadb` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218c2cc92c8323aaf594d38b5b07c4)