### PR TITLE
fix(frontend): rename Products to Vulnerable products in sidebar

### DIFF
--- a/src/frontend/src/components/Sidebar.test.ts
+++ b/src/frontend/src/components/Sidebar.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+test('sidebar labels the products link as vulnerable products', () => {
+  const source = readFileSync(new URL('./Sidebar.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /href="\/products"[\s\S]*Vulnerable products/);
+  assert.doesNotMatch(source, /href="\/products"[\s\S]*> Products/);
+});

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -310,7 +310,7 @@ const Sidebar = () => {
                                 </li>
                                 <li>
                                     <a href="/products" className="d-flex align-items-center p-2 text-dark text-decoration-none rounded hover-bg-secondary">
-                                        <i className="bi bi-box-seam me-2"></i> Products
+                                        <i className="bi bi-box-seam me-2"></i> Vulnerable products
                                     </a>
                                 </li>
                                 <li>


### PR DESCRIPTION
### Motivation
- Clarify navigation by renaming the Vulnerability Management sidebar item from `Products` to `Vulnerable products`.

### Description
- Update `src/frontend/src/components/Sidebar.tsx` to change the sidebar label and add `src/frontend/src/components/Sidebar.test.ts` which asserts the `/products` link uses the new label.

### Testing
- Ran `node --test src/frontend/src/components/Sidebar.test.ts` which passed. 
- Ran `npm run lint` and `npm run build` in `src/frontend`, both completed successfully (lint produced pre-existing warnings but no new errors).
- Full E2E gates (`./tests/js-error-scanner-pp.sh`, `./scripts/test/test-e2e-vuln-exception-full.sh`) were not run here due to missing local tools (`pass-cli`, `mariadb`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218c767e6c83238886d462bd4f1c73)