### PR TITLE
feat(webdep): add Python web dependency importer

### DIFF
--- a/src/webdep/README.md
+++ b/src/webdep/README.md
@@ -1,0 +1,169 @@
+# SecMan Web Dependency Importer
+
+`secman-webdep` is a Python helper that discovers browser-side dependencies on
+web applications registered in SecMan. It reads asset URIs from SecMan's asset
+inventory (or from a plain text file), downloads each root page (`/`), extracts
+referenced CSS and JavaScript resources, and imports those resources into SecMan
+as installed products via `POST /api/installed-products/import`.
+
+The tool is intentionally implemented with the Python standard library only. It
+can be copied to an administration host and run without installing runtime HTTP
+or HTML parsing packages.
+
+## What gets discovered
+
+The scanner parses the returned HTML and records:
+
+- `<script src="...">` entries as `JavaScript library` products.
+- `<link rel="stylesheet" href="...">` entries as `CSS library` products.
+- `<link rel="preload" as="script" href="...">` entries as JavaScript products.
+- `<link rel="preload" as="style" href="...">` entries as CSS products.
+
+Each discovered resource becomes a SecMan installed-product DTO:
+
+| SecMan field | Value |
+| --- | --- |
+| `hostname` | Asset name from SecMan, or the URI host when `--uri-file` is used. |
+| `name` | Best-effort package/library name derived from common CDN URL layouts or file names. |
+| `vendor` | CDN/vendor host hint, such as `cdnjs`, `jsDelivr`, or the resource hostname. |
+| `version` | Best-effort version parsed from URL path, package marker, or `?v=` query parameter. |
+| `category` | `CSS library` or `JavaScript library`. |
+| `installationPath` | Absolute URL of the dependency resource. |
+| `externalId` | Stable `webdep:` hash for idempotent updates. |
+
+## Requirements
+
+- Python 3.10 or newer.
+- A SecMan user with permission to read assets (`GET /api/assets`) and import
+  installed products (`POST /api/installed-products/import`). In the current
+  backend, import requires `ADMIN` or `VULN`.
+- For unattended automation, use a non-MFA service account. The helper cannot
+  complete interactive MFA challenges.
+
+## Installation
+
+Run directly from the repository:
+
+```bash
+cd src/webdep
+python -m webdep.cli --help
+```
+
+Optional editable install:
+
+```bash
+cd src/webdep
+python -m pip install -e .
+secman-webdep --help
+```
+
+## Basic usage
+
+Scan all HTTP(S) asset URIs visible to the authenticated SecMan user and perform
+an import dry run:
+
+```bash
+python -m webdep.cli \
+  --backend-url https://secman.covestro.net \
+  --username automation-webdep \
+  --dry-run
+```
+
+If `--password` is omitted, the helper prompts for it without echoing. To run in
+a CI job, pass the password through the environment rather than committing it:
+
+```bash
+python -m webdep.cli \
+  --backend-url "$SECMAN_BACKEND_URL" \
+  --username "$SECMAN_WEBDEP_USER" \
+  --password "$SECMAN_WEBDEP_PASSWORD" \
+  --dry-run \
+  --json
+```
+
+To write the discovered products for real, remove `--dry-run`:
+
+```bash
+python -m webdep.cli \
+  --backend-url https://secman.covestro.net \
+  --username automation-webdep
+```
+
+## Reading URIs from a file
+
+Use `--uri-file` to bypass the SecMan asset inventory and scan a supplied list.
+The file format is one URI per line. Blank lines and lines starting with `#` are
+ignored. Bare hostnames are treated as HTTPS URLs. Only `http://` and `https://`
+URIs are scanned.
+
+Example `uris.txt`:
+
+```text
+# Production web applications
+https://portal.example.com/app
+intranet.example.com
+http://legacy.example.net:8080/
+urn:asset:not-scanned
+```
+
+Run:
+
+```bash
+python -m webdep.cli \
+  --backend-url https://secman.covestro.net \
+  --username automation-webdep \
+  --uri-file uris.txt \
+  --dry-run
+```
+
+When `--uri-file` is used, products are mapped back to SecMan by hostname. The
+hostname must match an existing SecMan asset name or the backend import response
+will report it as an unknown system.
+
+## Self-signed certificates
+
+By default, TLS certificates are verified for both SecMan and scanned web
+applications. For development systems or internal applications with self-signed
+certificates, add `--insecure`:
+
+```bash
+python -m webdep.cli \
+  --backend-url https://secman-dev.example.test \
+  --username automation-webdep \
+  --insecure \
+  --dry-run
+```
+
+`--insecure` disables certificate validation and should not be used for routine
+production automation unless certificate trust cannot be fixed.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Scan and import completed without target fetch failures. |
+| `1` | SecMan calls completed, but at least one target URI could not be fetched or parsed. |
+| `2` | Command-line, authentication, SecMan API, or local file error. |
+
+## Operational notes
+
+- The helper always downloads each target's normalized root URI (`/`) and does
+  not crawl deeper pages.
+- Discovery is based on static HTML. Dependencies injected only after JavaScript
+  execution are not visible to this tool.
+- Import calls are batched with `--max-products-per-request` (default `1000`) to
+  stay below the backend request limit.
+- Re-running the helper is safe: stable `externalId` values let SecMan update
+  existing installed-product rows rather than creating duplicates.
+- Use `--json` when integrating with schedulers or log collectors.
+
+## Development
+
+Run the unit tests from `src/webdep`:
+
+```bash
+python -m pytest
+```
+
+If `pytest` is unavailable, the tests are intentionally simple and can be ported
+to `unittest`, but repository check-in should use `pytest` when possible.

--- a/src/webdep/pyproject.toml
+++ b/src/webdep/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "secman-webdep"
+version = "0.1.0"
+description = "Discover frontend CSS/JavaScript dependencies from SecMan asset URIs and import them as installed products."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Proprietary" }
+authors = [{ name = "SecMan contributors" }]
+
+[project.scripts]
+secman-webdep = "webdep.cli:main"
+
+[tool.setuptools]
+packages = ["webdep"]

--- a/src/webdep/tests/conftest.py
+++ b/src/webdep/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/src/webdep/tests/test_discovery.py
+++ b/src/webdep/tests/test_discovery.py
@@ -1,0 +1,36 @@
+from webdep.discovery import describe_dependency, discover_dependencies, normalize_uris
+
+
+def test_discover_dependencies_resolves_and_deduplicates_urls():
+    html = """
+    <html><head>
+      <link rel="stylesheet" href="/static/bootstrap-5.3.2.min.css">
+      <link rel="preload" as="script" href="https://cdn.jsdelivr.net/npm/react@19.1.0/umd/react.production.min.js">
+      <script src="/static/jquery-3.7.1.min.js"></script>
+      <script src="/static/jquery-3.7.1.min.js"></script>
+    </head></html>
+    """
+
+    dependencies = discover_dependencies(html, "https://example.test/app/index.html")
+
+    assert [dependency.name for dependency in dependencies] == ["bootstrap", "react", "jquery"]
+    assert [dependency.version for dependency in dependencies] == ["5.3.2", "19.1.0", "3.7.1"]
+    assert dependencies[0].url == "https://example.test/static/bootstrap-5.3.2.min.css"
+    assert dependencies[1].category == "JavaScript library"
+
+
+def test_describe_dependency_handles_common_cdn_layouts():
+    dependency = describe_dependency(
+        "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js",
+        "JavaScript library",
+    )
+
+    assert dependency.name == "lodash.js"
+    assert dependency.vendor == "cdnjs"
+    assert dependency.version == "4.17.21"
+
+
+def test_normalize_uris_filters_non_http_and_forces_root_path():
+    assert normalize_uris(["example.test/app", "urn:asset:1", "# comment", "https://example.test/other?q=1"]) == [
+        "https://example.test/",
+    ]

--- a/src/webdep/webdep/__init__.py
+++ b/src/webdep/webdep/__init__.py
@@ -1,0 +1,4 @@
+"""SecMan web dependency discovery helper."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/webdep/webdep/cli.py
+++ b/src/webdep/webdep/cli.py
@@ -1,0 +1,195 @@
+"""Command line entry point for SecMan web dependency discovery."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import getpass
+import json
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+import ssl
+from urllib.request import HTTPSHandler, Request, build_opener
+
+from .discovery import WebDependency, discover_dependencies, normalize_uris
+from .secman import SecManClient, SecManClientError
+
+
+@dataclass(frozen=True)
+class ScanTarget:
+    """A root web URI tied to a SecMan asset name."""
+
+    asset_name: str
+    uri: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="secman-webdep",
+        description="Discover CSS/JavaScript dependencies from SecMan asset URIs and import them as installed products.",
+    )
+    parser.add_argument(
+        "--backend-url",
+        default="https://secman.covestro.net",
+        help="SecMan backend base URL (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--username",
+        required=True,
+        help="SecMan username with permission to list assets and import installed products.",
+    )
+    parser.add_argument("--password", help="SecMan password. If omitted, a hidden prompt is shown.")
+    parser.add_argument("--uri-file", help="Optional file containing one URI per line. Lines beginning with # are ignored.")
+    parser.add_argument("--dry-run", action="store_true", help="Scan and call the SecMan import endpoint in dry-run mode.")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Allow self-signed or otherwise untrusted TLS certificates for SecMan and scanned HTTPS targets.",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds (default: %(default)s).")
+    parser.add_argument(
+        "--max-products-per-request",
+        type=int,
+        default=1000,
+        help="Batch size for SecMan installed-product imports (default: %(default)s).",
+    )
+    parser.add_argument("--json", action="store_true", help="Print a machine-readable JSON summary instead of human-readable output.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    password = args.password or getpass.getpass("SecMan password: ")
+    verify_tls = not args.insecure
+
+    client = SecManClient(args.backend_url, verify_tls=verify_tls, timeout=args.timeout)
+    try:
+        client.login(args.username, password)
+        targets = load_targets(client, args.uri_file)
+        products, failures = scan_targets(targets, verify_tls=verify_tls, timeout=args.timeout)
+        import_response = import_in_batches(
+            client,
+            products,
+            dry_run=args.dry_run,
+            batch_size=args.max_products_per_request,
+        )
+    except (OSError, SecManClientError, ValueError) as exc:
+        print(f"secman-webdep: {exc}", file=sys.stderr)
+        return 2
+
+    summary = {
+        "targets": len(targets),
+        "productsDiscovered": len(products),
+        "failures": failures,
+        "dryRun": args.dry_run,
+        "import": import_response,
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print_human_summary(summary)
+    return 0 if not failures else 1
+
+
+def load_targets(client: SecManClient, uri_file: str | None) -> list[ScanTarget]:
+    if uri_file:
+        with open(uri_file, encoding="utf-8") as handle:
+            uris = normalize_uris(handle)
+        return [ScanTarget(asset_name=_asset_name_from_uri(uri), uri=uri) for uri in uris]
+
+    assets = client.assets()
+    targets: list[ScanTarget] = []
+    for asset in assets:
+        for uri in normalize_uris([asset.uri or ""]):
+            targets.append(ScanTarget(asset_name=asset.name, uri=uri))
+    return targets
+
+
+def scan_targets(targets: list[ScanTarget], *, verify_tls: bool, timeout: float) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    context = ssl.create_default_context() if verify_tls else ssl._create_unverified_context()
+    opener = build_opener(HTTPSHandler(context=context))
+    products: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    seen_external_ids: set[str] = set()
+
+    for target in targets:
+        try:
+            html = fetch_root_html(opener, target.uri, timeout=timeout)
+            dependencies = discover_dependencies(html, target.uri)
+            for dependency in dependencies:
+                product = to_installed_product(target, dependency)
+                if product["externalId"] in seen_external_ids:
+                    continue
+                seen_external_ids.add(product["externalId"])
+                products.append(product)
+        except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError, ValueError) as exc:
+            failures.append({"uri": target.uri, "assetName": target.asset_name, "error": str(exc)})
+    return products, failures
+
+
+def fetch_root_html(opener: Any, uri: str, *, timeout: float) -> str:
+    request = Request(uri, method="GET", headers={"Accept": "text/html,application/xhtml+xml"})
+    with opener.open(request, timeout=timeout) as response:
+        content_type = response.headers.get("Content-Type", "")
+        if "html" not in content_type.lower() and content_type:
+            raise ValueError(f"{uri} did not return HTML (Content-Type: {content_type})")
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def to_installed_product(target: ScanTarget, dependency: WebDependency) -> dict[str, Any]:
+    return {
+        "externalId": dependency.external_id(target.asset_name),
+        "hostname": target.asset_name,
+        "name": dependency.name,
+        "vendor": dependency.vendor,
+        "version": dependency.version,
+        "category": dependency.category,
+        "installationPath": dependency.url,
+    }
+
+
+def import_in_batches(client: SecManClient, products: list[dict[str, Any]], *, dry_run: bool, batch_size: int) -> list[dict[str, Any]]:
+    if batch_size < 1:
+        raise ValueError("--max-products-per-request must be at least 1")
+    responses: list[dict[str, Any]] = []
+    for start in range(0, len(products), batch_size):
+        responses.append(client.import_products(products[start : start + batch_size], dry_run=dry_run))
+    if not products:
+        responses.append(
+            {
+                "productsProcessed": 0,
+                "productsImported": 0,
+                "productsUpdated": 0,
+                "productsSkipped": 0,
+                "unknownSystems": 0,
+                "dryRun": dry_run,
+                "errors": [],
+            }
+        )
+    return responses
+
+
+def print_human_summary(summary: dict[str, Any]) -> None:
+    print(f"Targets scanned: {summary['targets']}")
+    print(f"Products discovered: {summary['productsDiscovered']}")
+    print(f"Dry run: {summary['dryRun']}")
+    print("Import responses:")
+    for response in summary["import"]:
+        print(f"  - {response}")
+    if summary["failures"]:
+        print("Failures:", file=sys.stderr)
+        for failure in summary["failures"]:
+            print(f"  - {failure['assetName']} {failure['uri']}: {failure['error']}", file=sys.stderr)
+
+
+def _asset_name_from_uri(uri: str) -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(uri)
+    return parsed.hostname or uri
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/webdep/webdep/discovery.py
+++ b/src/webdep/webdep/discovery.py
@@ -1,0 +1,210 @@
+"""HTML dependency discovery for SecMan web assets.
+
+The functions in this module intentionally use only the Python standard library
+so operators can run the helper from an administration workstation without
+installing additional runtime dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+import hashlib
+import posixpath
+import re
+from typing import Iterable
+from urllib.parse import parse_qs, unquote, urljoin, urlparse
+
+_LIBRARY_ALIASES = {
+    "bootstrap.bundle": "bootstrap",
+    "bootstrap.min": "bootstrap",
+    "jquery.min": "jquery",
+    "react-dom": "react-dom",
+    "vue.global": "vue",
+}
+
+_VENDOR_HINTS = {
+    "ajax.googleapis.com": "Google Hosted Libraries",
+    "cdnjs.cloudflare.com": "cdnjs",
+    "cdn.jsdelivr.net": "jsDelivr",
+    "unpkg.com": "unpkg",
+    "code.jquery.com": "jQuery CDN",
+    "stackpath.bootstrapcdn.com": "BootstrapCDN",
+    "maxcdn.bootstrapcdn.com": "BootstrapCDN",
+    "fonts.googleapis.com": "Google Fonts",
+}
+
+_VERSION_RE = re.compile(r"(?<![a-zA-Z])v?(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?)(?![a-zA-Z])")
+_NAME_VERSION_RE = re.compile(
+    r"^(?P<name>[A-Za-z][A-Za-z0-9_.@/-]*?)[-_.@]v?(?P<version>\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?)"
+)
+
+
+@dataclass(frozen=True)
+class WebDependency:
+    """A CSS or JavaScript dependency found on a web page."""
+
+    name: str
+    url: str
+    category: str
+    vendor: str | None = None
+    version: str | None = None
+
+    def external_id(self, asset_name: str) -> str:
+        """Return a stable SecMan external id for this asset/dependency pair."""
+
+        digest = hashlib.sha256(f"{asset_name}\0{self.category}\0{self.name}\0{self.url}".encode()).hexdigest()
+        return f"webdep:{digest[:32]}"
+
+
+class DependencyParser(HTMLParser):
+    """Collect dependency-bearing HTML tags from a document."""
+
+    def __init__(self, base_url: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.base_url = base_url
+        self.urls: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = {key.lower(): value for key, value in attrs if key}
+        if tag.lower() == "script":
+            src = values.get("src")
+            if src:
+                self.urls.append(("JavaScript library", urljoin(self.base_url, src)))
+            return
+
+        if tag.lower() == "link":
+            href = values.get("href")
+            rel = {part.lower() for part in (values.get("rel") or "").split()}
+            as_value = (values.get("as") or "").lower()
+            if href and ("stylesheet" in rel or as_value in {"style", "script"}):
+                category = "CSS library" if as_value != "script" else "JavaScript library"
+                self.urls.append((category, urljoin(self.base_url, href)))
+
+
+def discover_dependencies(html: str, base_url: str) -> list[WebDependency]:
+    """Extract unique CSS and JavaScript dependencies from *html*.
+
+    Dependencies are deduplicated by absolute URL and category while preserving
+    discovery order.
+    """
+
+    parser = DependencyParser(base_url)
+    parser.feed(html)
+
+    seen: set[tuple[str, str]] = set()
+    dependencies: list[WebDependency] = []
+    for category, dependency_url in parser.urls:
+        key = (category, dependency_url)
+        if key in seen:
+            continue
+        seen.add(key)
+        dependencies.append(describe_dependency(dependency_url, category))
+    return dependencies
+
+
+def describe_dependency(dependency_url: str, category: str) -> WebDependency:
+    """Derive a product-like name, vendor, and version from a dependency URL."""
+
+    parsed = urlparse(dependency_url)
+    host = parsed.netloc.lower()
+    path_parts = [unquote(part) for part in parsed.path.split("/") if part]
+    filename = path_parts[-1] if path_parts else host or dependency_url
+    stem = _strip_asset_suffix(filename)
+
+    name = _name_from_cdn_path(host, path_parts) or _name_from_filename(stem) or stem or filename
+    version = _version_from_path(path_parts) or _version_from_query(parsed.query)
+    vendor = _vendor_from_host(host)
+
+    return WebDependency(
+        name=name[:512],
+        vendor=vendor[:255] if vendor else None,
+        version=version[:255] if version else None,
+        category=category,
+        url=dependency_url,
+    )
+
+
+def normalize_uris(values: Iterable[str]) -> list[str]:
+    """Normalize user or SecMan supplied URI values for HTTP probing."""
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        value = raw.strip()
+        if not value or value.startswith("#"):
+            continue
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            value = f"https://{value}"
+            parsed = urlparse(value)
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+            continue
+        root = parsed._replace(path="/", params="", query="", fragment="").geturl()
+        if root not in seen:
+            seen.add(root)
+            normalized.append(root)
+    return normalized
+
+
+def _strip_asset_suffix(filename: str) -> str:
+    basename = posixpath.basename(filename)
+    basename = re.sub(r"\.(?:min|bundle|global|esm|umd|cjs|slim|all)$", "", posixpath.splitext(basename)[0], flags=re.I)
+    return basename
+
+
+def _name_from_filename(stem: str) -> str | None:
+    match = _NAME_VERSION_RE.match(stem)
+    name = match.group("name") if match else stem
+    name = re.sub(r"[._-](?:min|bundle|global|esm|umd|cjs|slim|all)$", "", name, flags=re.I)
+    name = _LIBRARY_ALIASES.get(name.lower(), name)
+    return name.replace("_", "-").strip(".-/") or None
+
+
+def _name_from_cdn_path(host: str, path_parts: list[str]) -> str | None:
+    if "cdn.jsdelivr.net" in host:
+        if len(path_parts) >= 2 and path_parts[0] == "npm":
+            package = path_parts[1].split("@")
+            if path_parts[1].startswith("@") and len(path_parts) >= 3:
+                return f"{path_parts[1]}/{path_parts[2].split('@')[0]}"
+            return package[0]
+        if len(path_parts) >= 2 and path_parts[0] == "gh":
+            return path_parts[1]
+    if "unpkg.com" in host and path_parts:
+        if path_parts[0].startswith("@") and len(path_parts) >= 2:
+            return f"{path_parts[0]}/{path_parts[1].split('@')[0]}"
+        return path_parts[0].split("@")[0]
+    if "cdnjs.cloudflare.com" in host and len(path_parts) >= 3 and path_parts[0] == "ajax" and path_parts[1] == "libs":
+        return path_parts[2]
+    if "ajax.googleapis.com" in host and len(path_parts) >= 2 and path_parts[0] == "ajax" and path_parts[1] == "libs" and len(path_parts) >= 3:
+        return path_parts[2]
+    return None
+
+
+def _version_from_path(path_parts: list[str]) -> str | None:
+    for part in path_parts:
+        if "@" in part and not part.startswith("@"):
+            maybe_version = part.rsplit("@", 1)[1]
+            if _VERSION_RE.search(maybe_version):
+                return maybe_version
+        match = _VERSION_RE.search(part)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _version_from_query(query: str) -> str | None:
+    values = parse_qs(query)
+    for key in ("v", "ver", "version"):
+        for value in values.get(key, []):
+            match = _VERSION_RE.search(value)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _vendor_from_host(host: str) -> str | None:
+    for suffix, vendor in _VENDOR_HINTS.items():
+        if host == suffix or host.endswith(f".{suffix}"):
+            return vendor
+    return host or None

--- a/src/webdep/webdep/secman.py
+++ b/src/webdep/webdep/secman.py
@@ -1,0 +1,99 @@
+"""Small SecMan HTTP client used by the web dependency importer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from http.cookiejar import CookieJar
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+import ssl
+from urllib.request import HTTPCookieProcessor, HTTPSHandler, Request, build_opener
+
+
+class SecManClientError(RuntimeError):
+    """Raised when the SecMan backend returns an error or cannot be reached."""
+
+
+@dataclass(frozen=True)
+class Asset:
+    """SecMan asset fields needed by the importer."""
+
+    id: int | None
+    name: str
+    uri: str | None
+
+
+class SecManClient:
+    """Cookie-authenticated client for the SecMan REST API."""
+
+    def __init__(self, backend_url: str, *, verify_tls: bool = True, timeout: float = 30.0) -> None:
+        self.backend_url = backend_url.rstrip("/") + "/"
+        self.timeout = timeout
+        context = ssl.create_default_context() if verify_tls else ssl._create_unverified_context()
+        self.cookie_jar = CookieJar()
+        self.opener = build_opener(HTTPCookieProcessor(self.cookie_jar), HTTPSHandlerWithContext(context))
+
+    def login(self, username: str, password: str) -> None:
+        """Authenticate against ``/api/auth/login`` and retain the session cookie."""
+
+        response = self._request(
+            "POST",
+            "api/auth/login",
+            {"username": username, "password": password},
+        )
+        if response.get("mfaRequired"):
+            raise SecManClientError("MFA is required for this account; use a non-MFA automation account.")
+
+    def assets(self) -> list[Asset]:
+        """Return assets visible to the authenticated user."""
+
+        data = self._request("GET", "api/assets")
+        if not isinstance(data, list):
+            raise SecManClientError("Unexpected /api/assets response shape")
+        assets: list[Asset] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            assets.append(
+                Asset(
+                    id=item.get("id"),
+                    name=str(item.get("name") or item.get("uri") or item.get("id") or "unknown"),
+                    uri=item.get("uri"),
+                )
+            )
+        return assets
+
+    def import_products(self, products: list[dict[str, Any]], *, dry_run: bool) -> dict[str, Any]:
+        """Import installed product DTOs through SecMan's existing endpoint."""
+
+        return self._request("POST", "api/installed-products/import", {"products": products, "dryRun": dry_run})
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        url = urljoin(self.backend_url, path)
+        payload = json.dumps(body).encode("utf-8") if body is not None else None
+        request = Request(url, data=payload, method=method)
+        request.add_header("Accept", "application/json")
+        if payload is not None:
+            request.add_header("Content-Type", "application/json")
+        try:
+            with self.opener.open(request, timeout=self.timeout) as response:
+                raw = response.read()
+                if not raw:
+                    return {}
+                return json.loads(raw.decode("utf-8"))
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise SecManClientError(f"{method} {url} failed with HTTP {exc.code}: {detail}") from exc
+        except URLError as exc:
+            raise SecManClientError(f"{method} {url} failed: {exc.reason}") from exc
+        except json.JSONDecodeError as exc:
+            raise SecManClientError(f"{method} {url} returned invalid JSON") from exc
+
+
+class HTTPSHandlerWithContext(HTTPSHandler):
+    """HTTPS handler that accepts an explicit SSL context."""
+
+    def __init__(self, context: ssl.SSLContext) -> None:
+        super().__init__(context=context)


### PR DESCRIPTION
### Motivation
- Provide a small, operator-friendly Python tool to scan SecMan asset URIs for frontend dependencies (CSS/JS) and populate SecMan's installed-products from the discovered libraries.
- Support safe operations via `--dry-run`, batch imports, optional file-based URI input, and runs against backends with self-signed certs for internal/dev usage.

### Description
- Added a new Python package under `src/webdep` with `pyproject.toml` and a console entry `secman-webdep` implemented in `webdep.cli:main` that exposes command-line switches like `--backend-url`, `--username`, `--password`, `--uri-file`, `--dry-run`, `--insecure`, `--timeout`, and `--max-products-per-request`.
- Implemented HTML dependency extraction in `webdep.discovery` that parses `<script>` and `<link>` tags, normalizes URIs, heuristically derives package `name`, `vendor`, and `version`, and produces stable `externalId` values for idempotent imports.
- Added a minimal standard-library SecMan HTTP client in `webdep.secman` that logs in (cookie session), lists assets via `GET /api/assets`, and imports discovered products via `POST /api/installed-products/import` while optionally allowing disabled TLS verification for self-signed certs.
- Added operator documentation `src/webdep/README.md` and unit tests `src/webdep/tests/test_discovery.py` covering discovery, CDN parsing, and URI normalization.

### Testing
- Ran unit tests with `python -m pytest src/webdep/tests` and `3` tests passed successfully.
- Verified package modules compile with `python -m compileall -q src/webdep/webdep` (succeeded).
- Verified CLI help invocation with `PYTHONPATH=src/webdep python -m webdep.cli --help` which returned expected usage text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ce58b70c83239485ab922aff0fa6)