### PR TITLE
test(crowdstrike): add vulnerability match skill and testcase

### DIFF
--- a/.agents/skills/crowdstrike-vuln-match/SKILL.md
+++ b/.agents/skills/crowdstrike-vuln-match/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: crowdstrike-vuln-match
+description: >
+  Select a stable sample of SecMan assets (200 by default) and compare each
+  asset's currently stored CrowdStrike vulnerability rows with a fresh ad-hoc
+  CrowdStrike Falcon query that does not save data. Use when the user says
+  "CrowdStrike vulnerability match", "compare SecMan to CrowdStrike", "check
+  200 assets", or similar.
+context: fork
+---
+# CrowdStrike Vulnerability Match Test
+
+This skill validates that SecMan's current CrowdStrike vulnerability state still
+matches Falcon for a bounded sample of assets. It is a **read-only** production
+check: the matcher authenticates to SecMan, reads assets and vulnerabilities,
+then runs `secman query --hostname ... --output ...` for every sampled host
+without `--save`.
+
+## Driver
+
+Use the wrapper from the repository root:
+
+```bash
+./scripts/test/test-crowdstrike-vulnerability-match.sh \
+  --sample-size 200 \
+  --asset-type SERVER \
+  --severity HIGH,CRITICAL
+```
+
+The wrapper resolves `secmanpp.env` through `pass-cli` when available and then
+executes `scripts/test/crowdstrike_vulnerability_match.py`.
+
+## Required environment
+
+Resolved through `pass-cli run --env-file ./secmanpp.env -- ...` or exported
+before running the wrapper:
+
+- `SECMAN_HOST` or `SECMAN_BACKEND_URL` — SecMan backend URL.
+- `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` — account that can read assets and
+  vulnerability rows.
+- `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` plus the configured Falcon region
+  or base URL used by `./scripts/secman query`.
+
+## What is compared
+
+For each sampled asset:
+
+1. Read SecMan vulnerabilities from `GET /api/assets/{assetId}/vulnerabilities`.
+2. Keep only rows with `source = CROWDSTRIKE` unless
+   `--include-non-crowdstrike` is explicitly passed.
+3. Run an ad-hoc Falcon query with the SecMan CLI for the asset hostname.
+4. Normalize both sides to the CrowdStrike import identity:
+   `(CVE ID uppercased, affected product normalized)`.
+5. Report rows missing from Falcon, rows missing from SecMan, and severity drift
+   for matching keys.
+
+This mirrors the backend import service's dedupe key (`CVE`, affected product),
+so duplicate CrowdStrike rows for the same product do not produce false
+positives.
+
+## Outputs and exit codes
+
+Default report files:
+
+- `crowdstrike-vulnerability-match-report.json` — machine-readable summary and
+  mismatch details.
+- `crowdstrike-vulnerability-match-report.md` — human-readable report for PRs,
+  incident notes, or operations handoff.
+
+Exit codes:
+
+- `0` — all sampled assets matched.
+- `1` — at least one asset had a mismatch or Falcon query error.
+- `2`/other shell failures — setup, authentication, or environment problem.
+
+## Recommended operation
+
+1. Build the CLI first if it is not already current:
+
+   ```bash
+   ./gradlew :cli:shadowJar
+   ```
+
+2. Run the matcher against a stable sample:
+
+   ```bash
+   ./scripts/test/test-crowdstrike-vulnerability-match.sh \
+     --sample-size 200 \
+     --asset-type SERVER \
+     --severity HIGH,CRITICAL
+   ```
+
+3. If the matcher fails, inspect the Markdown report first. Use the JSON report
+   for automation or to re-check exact `(CVE, product)` keys.
+
+4. Do **not** run a saving import from this skill. If Falcon is authoritative
+   and the mismatch is expected, run the normal operational import separately:
+
+   ```bash
+   ./scripts/secman query servers --save --severity HIGH,CRITICAL --device-type SERVER
+   ```

--- a/docs/CROWDSTRIKE_VULNERABILITY_MATCH.md
+++ b/docs/CROWDSTRIKE_VULNERABILITY_MATCH.md
@@ -1,0 +1,115 @@
+# CrowdStrike Vulnerability Match Test
+
+The CrowdStrike vulnerability match test is a read-only operations testcase that
+checks whether SecMan's currently stored CrowdStrike vulnerability rows still
+match a fresh, ad-hoc Falcon query for a bounded asset sample.
+
+## Purpose
+
+Use this check when you need confidence that the SecMan database reflects the
+current CrowdStrike state before relying on dashboards, exception workflows, or
+reports. The default sample size is **200 assets**.
+
+The test never imports or deletes data. It compares:
+
+- **SecMan side:** `GET /api/assets/{assetId}/vulnerabilities`, filtered to
+  `source = CROWDSTRIKE` by default.
+- **CrowdStrike side:** `./scripts/secman query --hostname <asset-name>` with a
+  JSON output file and without `--save`.
+
+## Comparison semantics
+
+The matcher normalizes both systems to the same identity used by
+`CrowdStrikeVulnerabilityImportService` during import:
+
+```text
+(CVE ID, affected product/version)
+```
+
+Normalization rules:
+
+- CVE IDs are trimmed and uppercased.
+- Products are whitespace-normalized and case-folded.
+- Rows without a CVE are ignored, matching the backend import rule that skips
+  CrowdStrike vulnerabilities without a CVE ID.
+- Duplicate `(CVE, product)` rows collapse to one comparison key, matching the
+  backend dedupe behavior.
+- Severity is compared for keys that exist on both sides.
+
+By default only SecMan rows with `source = CROWDSTRIKE` are compared. Pass
+`--include-non-crowdstrike` only when intentionally validating the full asset
+vulnerability set, including manual and spreadsheet imports.
+
+## Running the check
+
+From the repository root:
+
+```bash
+./gradlew :cli:shadowJar
+./scripts/test/test-crowdstrike-vulnerability-match.sh \
+  --sample-size 200 \
+  --asset-type SERVER \
+  --severity HIGH,CRITICAL
+```
+
+The wrapper resolves `secmanpp.env` via `pass-cli` when available. You can also
+run the Python driver directly if all environment variables are already set:
+
+```bash
+python3 scripts/test/crowdstrike_vulnerability_match.py \
+  --sample-size 200 \
+  --asset-type SERVER \
+  --severity HIGH,CRITICAL
+```
+
+## Required environment
+
+The script needs backend and CrowdStrike credentials, normally resolved through
+`pass-cli`:
+
+| Variable | Purpose |
+| --- | --- |
+| `SECMAN_HOST` or `SECMAN_BACKEND_URL` | Backend URL used for SecMan API reads. |
+| `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` | SecMan account used to read assets and vulnerability rows. |
+| `FALCON_CLIENT_ID` / `FALCON_CLIENT_SECRET` | CrowdStrike API credentials used by `./scripts/secman query`. |
+| `FALCON_BASE_URL` or `FALCON_CLOUD_REGION` | Falcon cloud/region selection used by the CLI. |
+
+## Useful options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--sample-size` | `200` | Number of SecMan assets selected for the comparison. |
+| `--seed` | `crowdstrike-vulnerability-match` | Stable sampling seed; change it to rotate the sample. |
+| `--asset-type` | unset | Optional pre-sampling asset type filter, e.g. `SERVER`. |
+| `--owner` | unset | Optional pre-sampling owner filter. |
+| `--severity` | unset | Comma-separated severity filter applied to both sides, e.g. `HIGH,CRITICAL`. |
+| `--include-non-crowdstrike` | `false` | Compare all SecMan vulnerability sources instead of only `CROWDSTRIKE`. |
+| `--json-report` | `crowdstrike-vulnerability-match-report.json` | Machine-readable report path. |
+| `--markdown-report` | `crowdstrike-vulnerability-match-report.md` | Human-readable report path. |
+| `--secman-cli` | `./scripts/secman` | CLI wrapper to use for ad-hoc Falcon queries. |
+| `--timeout` | `120` | Per-host CrowdStrike query timeout in seconds. |
+
+## Reports
+
+Every run writes both report formats:
+
+- JSON report for automation and exact mismatch keys.
+- Markdown report for humans and incident handoff.
+
+The summary contains selected asset count, match count, mismatch count, query
+error count, and total vulnerabilities compared on both sides. Each mismatch
+lists rows missing from CrowdStrike, rows missing from SecMan, and severity drift.
+
+## Exit codes
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | All sampled assets matched. |
+| `1` | At least one sampled asset had a mismatch or CrowdStrike query error. |
+| Other | Setup/authentication/environment failure. |
+
+## Skill
+
+Agents can run the same workflow through the local skill
+`.agents/skills/crowdstrike-vuln-match/SKILL.md` when asked to compare SecMan
+and CrowdStrike vulnerability state or to check a 200-asset sample.

--- a/scripts/test/crowdstrike_vulnerability_match.py
+++ b/scripts/test/crowdstrike_vulnerability_match.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Compare SecMan's current CrowdStrike vulnerability rows with ad-hoc Falcon queries.
+
+The script samples assets from SecMan, queries CrowdStrike for each sampled
+hostname without saving anything, normalizes both sides to the same import key
+(CVE + affected product), and exits non-zero if the two data sets drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_SAMPLE_SIZE = 200
+DEFAULT_TIMEOUT_SECONDS = 120
+DEFAULT_SECMAN_CLI = "./scripts/secman"
+CROWDSTRIKE_SOURCE = "CROWDSTRIKE"
+
+
+@dataclass(frozen=True, order=True)
+class VulnerabilityKey:
+    """Canonical comparison key used by the CrowdStrike import service."""
+
+    cve: str
+    product: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"cve": self.cve, "product": self.product}
+
+    def display(self) -> str:
+        return f"{self.cve} :: {self.product or '<no product>'}"
+
+
+@dataclass
+class NormalizedVulnerability:
+    key: VulnerabilityKey
+    severity: str = ""
+
+
+@dataclass
+class AssetComparison:
+    asset_id: int
+    hostname: str
+    secman_count: int = 0
+    crowdstrike_count: int = 0
+    missing_in_crowdstrike: list[VulnerabilityKey] = field(default_factory=list)
+    missing_in_secman: list[VulnerabilityKey] = field(default_factory=list)
+    severity_mismatches: list[dict[str, str]] = field(default_factory=list)
+    query_error: str | None = None
+
+    @property
+    def matched(self) -> bool:
+        return (
+            self.query_error is None
+            and not self.missing_in_crowdstrike
+            and not self.missing_in_secman
+            and not self.severity_mismatches
+        )
+
+
+def normalize_text(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def normalize_cve(value: Any) -> str:
+    return normalize_text(value).upper()
+
+
+def normalize_product(value: Any) -> str:
+    return normalize_text(value).casefold()
+
+
+def normalize_severity(value: Any) -> str:
+    return normalize_text(value).upper()
+
+
+def normalize_secman_vulnerabilities(
+    vulnerabilities: Iterable[dict[str, Any]],
+    *,
+    source: str | None = CROWDSTRIKE_SOURCE,
+    severities: set[str] | None = None,
+) -> dict[VulnerabilityKey, NormalizedVulnerability]:
+    normalized: dict[VulnerabilityKey, NormalizedVulnerability] = {}
+    for vuln in vulnerabilities:
+        if source is not None and normalize_severity(vuln.get("source")) != normalize_severity(source):
+            continue
+        cve = normalize_cve(vuln.get("vulnerabilityId"))
+        if not cve:
+            continue
+        severity = normalize_severity(vuln.get("cvssSeverity"))
+        if severities and severity not in severities:
+            continue
+        key = VulnerabilityKey(cve=cve, product=normalize_product(vuln.get("vulnerableProductVersions")))
+        normalized[key] = NormalizedVulnerability(key=key, severity=severity)
+    return normalized
+
+
+def normalize_crowdstrike_vulnerabilities(
+    vulnerabilities: Iterable[dict[str, Any]],
+    *,
+    severities: set[str] | None = None,
+) -> dict[VulnerabilityKey, NormalizedVulnerability]:
+    normalized: dict[VulnerabilityKey, NormalizedVulnerability] = {}
+    for vuln in vulnerabilities:
+        cve = normalize_cve(vuln.get("cveId"))
+        if not cve:
+            continue
+        severity = normalize_severity(vuln.get("severity"))
+        if severities and severity not in severities:
+            continue
+        key = VulnerabilityKey(cve=cve, product=normalize_product(vuln.get("affectedProduct")))
+        # Mirrors CrowdStrikeVulnerabilityImportService: duplicate (CVE, product)
+        # entries collapse to one row. For comparison, the last equivalent key is enough.
+        normalized[key] = NormalizedVulnerability(key=key, severity=severity)
+    return normalized
+
+
+def select_assets(
+    assets: list[dict[str, Any]],
+    *,
+    sample_size: int,
+    seed: str,
+    owner: str | None = None,
+    asset_type: str | None = None,
+) -> list[dict[str, Any]]:
+    candidates = [asset for asset in assets if normalize_text(asset.get("name"))]
+    if owner:
+        expected_owner = normalize_text(owner).casefold()
+        candidates = [asset for asset in candidates if normalize_text(asset.get("owner")).casefold() == expected_owner]
+    if asset_type:
+        expected_type = normalize_text(asset_type).casefold()
+        candidates = [asset for asset in candidates if normalize_text(asset.get("type")).casefold() == expected_type]
+
+    def stable_weight(asset: dict[str, Any]) -> str:
+        material = f"{seed}\0{asset.get('id')}\0{asset.get('name')}"
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    return sorted(candidates, key=stable_weight)[:sample_size]
+
+
+def resolve_backend_url(value: str | None) -> str:
+    raw = value or os.getenv("SECMAN_BACKEND_URL") or os.getenv("SECMAN_HOST")
+    if not raw:
+        raise SystemExit("SECMAN_BACKEND_URL or SECMAN_HOST is required")
+    raw = raw.strip().rstrip("/")
+    if raw.startswith("http://") or raw.startswith("https://"):
+        return raw
+    return f"https://{raw}"
+
+
+class SecManClient:
+    def __init__(self, base_url: str, token: str | None = None, timeout: int = 30) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+
+    def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        data = None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = urllib.request.Request(f"{self.base_url}{path}", data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as response:
+                payload = response.read().decode("utf-8")
+                return json.loads(payload) if payload else None
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"{method} {path} failed with HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"{method} {path} failed: {exc.reason}") from exc
+
+    def login(self, username: str, password: str) -> str:
+        payload = self.request("POST", "/api/auth/login", {"username": username, "password": password})
+        token = (payload or {}).get("token")
+        if not token:
+            raise RuntimeError("Login response did not contain a token")
+        self.token = token
+        return token
+
+    def assets(self) -> list[dict[str, Any]]:
+        payload = self.request("GET", "/api/assets")
+        if not isinstance(payload, list):
+            raise RuntimeError("/api/assets did not return a JSON list")
+        return payload
+
+    def vulnerabilities_for_asset(self, asset_id: int) -> list[dict[str, Any]]:
+        payload = self.request("GET", f"/api/assets/{asset_id}/vulnerabilities")
+        if not isinstance(payload, list):
+            raise RuntimeError(f"/api/assets/{asset_id}/vulnerabilities did not return a JSON list")
+        return payload
+
+
+def run_crowdstrike_query(
+    hostname: str,
+    *,
+    secman_cli: str,
+    severity: str | None,
+    timeout: int,
+) -> tuple[list[dict[str, Any]], str | None]:
+    with tempfile.TemporaryDirectory(prefix="secman-cs-match-") as tmpdir:
+        output_path = Path(tmpdir) / "crowdstrike.json"
+        command = [secman_cli, "query", "--hostname", hostname, "--format", "json", "--output", str(output_path)]
+        if severity:
+            command.extend(["--severity", severity])
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if completed.returncode != 0:
+            return [], (completed.stderr or completed.stdout or f"exit {completed.returncode}").strip()
+        if not output_path.exists():
+            # QueryCommand only exports non-empty result sets. A successful command
+            # without a file therefore means Falcon returned zero matching vulns.
+            return [], None
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        vulns = payload.get("vulnerabilities", [])
+        if not isinstance(vulns, list):
+            return [], f"CrowdStrike output for {hostname} did not contain a vulnerability list"
+        return vulns, None
+
+
+def compare_asset(
+    asset: dict[str, Any],
+    secman_vulns: dict[VulnerabilityKey, NormalizedVulnerability],
+    crowdstrike_vulns: dict[VulnerabilityKey, NormalizedVulnerability],
+    query_error: str | None,
+) -> AssetComparison:
+    asset_id = int(asset["id"])
+    hostname = normalize_text(asset.get("name"))
+    result = AssetComparison(
+        asset_id=asset_id,
+        hostname=hostname,
+        secman_count=len(secman_vulns),
+        crowdstrike_count=len(crowdstrike_vulns),
+        query_error=query_error,
+    )
+    if query_error:
+        return result
+
+    secman_keys = set(secman_vulns)
+    crowdstrike_keys = set(crowdstrike_vulns)
+    result.missing_in_crowdstrike = sorted(secman_keys - crowdstrike_keys)
+    result.missing_in_secman = sorted(crowdstrike_keys - secman_keys)
+    for key in sorted(secman_keys & crowdstrike_keys):
+        secman_sev = secman_vulns[key].severity
+        crowdstrike_sev = crowdstrike_vulns[key].severity
+        if secman_sev and crowdstrike_sev and secman_sev != crowdstrike_sev:
+            result.severity_mismatches.append(
+                {"key": key.display(), "secmanSeverity": secman_sev, "crowdstrikeSeverity": crowdstrike_sev}
+            )
+    return result
+
+
+def result_to_dict(result: AssetComparison, max_items: int) -> dict[str, Any]:
+    return {
+        "assetId": result.asset_id,
+        "hostname": result.hostname,
+        "matched": result.matched,
+        "secmanCount": result.secman_count,
+        "crowdstrikeCount": result.crowdstrike_count,
+        "queryError": result.query_error,
+        "missingInCrowdStrike": [key.as_dict() for key in result.missing_in_crowdstrike[:max_items]],
+        "missingInSecMan": [key.as_dict() for key in result.missing_in_secman[:max_items]],
+        "severityMismatches": result.severity_mismatches[:max_items],
+        "truncated": (
+            len(result.missing_in_crowdstrike) > max_items
+            or len(result.missing_in_secman) > max_items
+            or len(result.severity_mismatches) > max_items
+        ),
+    }
+
+
+def write_markdown_report(path: Path, summary: dict[str, Any], mismatches: list[dict[str, Any]]) -> None:
+    lines = [
+        "# CrowdStrike Vulnerability Match Report",
+        "",
+        "## Summary",
+        "",
+        f"- Backend URL: `{summary['backendUrl']}`",
+        f"- Requested sample size: `{summary['requestedSampleSize']}`",
+        f"- Selected assets: `{summary['selectedAssets']}`",
+        f"- Matched assets: `{summary['matchedAssets']}`",
+        f"- Assets with mismatches: `{summary['mismatchedAssets']}`",
+        f"- Assets with query errors: `{summary['queryErrorAssets']}`",
+        f"- SecMan vulnerabilities compared: `{summary['secmanVulnerabilities']}`",
+        f"- CrowdStrike vulnerabilities compared: `{summary['crowdstrikeVulnerabilities']}`",
+        "",
+    ]
+    if not mismatches:
+        lines.extend(["## Result", "", "All sampled assets matched.", ""])
+    else:
+        lines.extend(["## Mismatches", ""])
+        for item in mismatches:
+            lines.extend(
+                [
+                    f"### {item['hostname']} (asset `{item['assetId']}`)",
+                    "",
+                    f"- SecMan count: `{item['secmanCount']}`",
+                    f"- CrowdStrike count: `{item['crowdstrikeCount']}`",
+                ]
+            )
+            if item.get("queryError"):
+                lines.append(f"- Query error: `{item['queryError']}`")
+            if item.get("missingInCrowdStrike"):
+                lines.append("- Missing in CrowdStrike:")
+                lines.extend(f"  - `{entry['cve']}` / `{entry['product'] or '<no product>'}`" for entry in item["missingInCrowdStrike"])
+            if item.get("missingInSecMan"):
+                lines.append("- Missing in SecMan:")
+                lines.extend(f"  - `{entry['cve']}` / `{entry['product'] or '<no product>'}`" for entry in item["missingInSecMan"])
+            if item.get("severityMismatches"):
+                lines.append("- Severity mismatches:")
+                lines.extend(
+                    f"  - `{entry['key']}`: SecMan `{entry['secmanSeverity']}`, CrowdStrike `{entry['crowdstrikeSeverity']}`"
+                    for entry in item["severityMismatches"]
+                )
+            if item.get("truncated"):
+                lines.append("- Output truncated; see JSON report for complete counts.")
+            lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend-url", default=None, help="SecMan backend URL; defaults to SECMAN_BACKEND_URL or SECMAN_HOST")
+    parser.add_argument("--username", default=os.getenv("SECMAN_ADMIN_NAME"), help="SecMan username; defaults to SECMAN_ADMIN_NAME")
+    parser.add_argument("--password", default=os.getenv("SECMAN_ADMIN_PASS"), help="SecMan password; defaults to SECMAN_ADMIN_PASS")
+    parser.add_argument("--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE, help="Number of SecMan assets to sample (default: 200)")
+    parser.add_argument("--seed", default="crowdstrike-vulnerability-match", help="Stable sampling seed")
+    parser.add_argument("--owner", default=None, help="Optional asset owner filter before sampling")
+    parser.add_argument("--asset-type", default=None, help="Optional asset type filter before sampling, e.g. SERVER")
+    parser.add_argument("--severity", default=None, help="Optional comma-separated severity filter applied to both sides")
+    parser.add_argument("--include-non-crowdstrike", action="store_true", help="Compare every SecMan vulnerability source instead of source=CROWDSTRIKE only")
+    parser.add_argument("--secman-cli", default=DEFAULT_SECMAN_CLI, help="Path to the SecMan CLI wrapper")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-host CrowdStrike query timeout in seconds")
+    parser.add_argument("--json-report", default="crowdstrike-vulnerability-match-report.json", help="JSON report path")
+    parser.add_argument("--markdown-report", default="crowdstrike-vulnerability-match-report.md", help="Markdown report path")
+    parser.add_argument("--max-items", type=int, default=25, help="Maximum mismatch entries to include per asset in reports")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.sample_size <= 0:
+        raise SystemExit("--sample-size must be greater than zero")
+    if not args.username or not args.password:
+        raise SystemExit("SECMAN_ADMIN_NAME/SECMAN_ADMIN_PASS or --username/--password are required")
+
+    backend_url = resolve_backend_url(args.backend_url)
+    severities = {normalize_severity(part) for part in (args.severity or "").split(",") if normalize_severity(part)} or None
+    source = None if args.include_non_crowdstrike else CROWDSTRIKE_SOURCE
+
+    client = SecManClient(backend_url)
+    client.login(args.username, args.password)
+    assets = client.assets()
+    selected = select_assets(assets, sample_size=args.sample_size, seed=args.seed, owner=args.owner, asset_type=args.asset_type)
+    if not selected:
+        raise SystemExit("No assets matched the requested selection filters")
+
+    print(f"Selected {len(selected)} assets from {len(assets)} accessible SecMan assets", file=sys.stderr)
+    started = time.time()
+    comparisons: list[AssetComparison] = []
+    for index, asset in enumerate(selected, start=1):
+        hostname = normalize_text(asset.get("name"))
+        print(f"[{index}/{len(selected)}] Comparing {hostname}", file=sys.stderr)
+        secman_raw = client.vulnerabilities_for_asset(int(asset["id"]))
+        secman_normalized = normalize_secman_vulnerabilities(secman_raw, source=source, severities=severities)
+        crowdstrike_raw, query_error = run_crowdstrike_query(
+            hostname,
+            secman_cli=args.secman_cli,
+            severity=args.severity,
+            timeout=args.timeout,
+        )
+        crowdstrike_normalized = normalize_crowdstrike_vulnerabilities(crowdstrike_raw, severities=severities)
+        comparisons.append(compare_asset(asset, secman_normalized, crowdstrike_normalized, query_error))
+
+    mismatches = [result_to_dict(item, args.max_items) for item in comparisons if not item.matched]
+    summary = {
+        "backendUrl": backend_url,
+        "requestedSampleSize": args.sample_size,
+        "selectedAssets": len(selected),
+        "matchedAssets": sum(1 for item in comparisons if item.matched),
+        "mismatchedAssets": sum(1 for item in comparisons if not item.matched and item.query_error is None),
+        "queryErrorAssets": sum(1 for item in comparisons if item.query_error is not None),
+        "secmanVulnerabilities": sum(item.secman_count for item in comparisons),
+        "crowdstrikeVulnerabilities": sum(item.crowdstrike_count for item in comparisons),
+        "durationSeconds": round(time.time() - started, 3),
+        "severityFilter": sorted(severities) if severities else None,
+        "secmanSourceFilter": source,
+        "ownerFilter": args.owner,
+        "assetTypeFilter": args.asset_type,
+    }
+    report = {"summary": summary, "mismatches": mismatches}
+
+    json_path = Path(args.json_report)
+    markdown_path = Path(args.markdown_report)
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    write_markdown_report(markdown_path, summary, mismatches)
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print(f"JSON report: {json_path}")
+    print(f"Markdown report: {markdown_path}")
+    return 0 if not mismatches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test/test-crowdstrike-vulnerability-match.sh
+++ b/scripts/test/test-crowdstrike-vulnerability-match.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve SecMan/CrowdStrike secrets via pass-cli when secmanpp.env is present,
+# then run the Python matcher. Arguments are passed through unchanged.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -f "$REPO_ROOT/secmanpp.env" ]] && command -v pass-cli >/dev/null 2>&1; then
+  exec pass-cli run --env-file "$REPO_ROOT/secmanpp.env" -- \
+    python3 "$REPO_ROOT/scripts/test/crowdstrike_vulnerability_match.py" "$@"
+fi
+
+exec python3 "$REPO_ROOT/scripts/test/crowdstrike_vulnerability_match.py" "$@"

--- a/tests/test_crowdstrike_vulnerability_match.py
+++ b/tests/test_crowdstrike_vulnerability_match.py
@@ -1,0 +1,93 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "test" / "crowdstrike_vulnerability_match.py"
+spec = importlib.util.spec_from_file_location("crowdstrike_vulnerability_match", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class CrowdStrikeVulnerabilityMatchTest(unittest.TestCase):
+    def test_normalizes_secman_crowdstrike_rows_to_import_key(self):
+        rows = [
+            {
+                "source": "CROWDSTRIKE",
+                "vulnerabilityId": " cve-2026-0001 ",
+                "cvssSeverity": "High",
+                "vulnerableProductVersions": "  OpenSSL   3.0  ",
+            },
+            {
+                "source": "XLSX",
+                "vulnerabilityId": "CVE-2026-0002",
+                "cvssSeverity": "Critical",
+                "vulnerableProductVersions": "nginx",
+            },
+            {
+                "source": "CROWDSTRIKE",
+                "vulnerabilityId": "",
+                "cvssSeverity": "High",
+                "vulnerableProductVersions": "ignored",
+            },
+        ]
+
+        normalized = module.normalize_secman_vulnerabilities(rows, source="CROWDSTRIKE", severities={"HIGH"})
+
+        self.assertEqual(list(normalized.keys()), [module.VulnerabilityKey("CVE-2026-0001", "openssl 3.0")])
+        self.assertEqual(normalized[module.VulnerabilityKey("CVE-2026-0001", "openssl 3.0")].severity, "HIGH")
+
+    def test_normalizes_crowdstrike_rows_and_applies_severity_filter(self):
+        rows = [
+            {"cveId": "cve-2026-0001", "severity": "high", "affectedProduct": "OpenSSL 3.0"},
+            {"cveId": "CVE-2026-0002", "severity": "low", "affectedProduct": "curl"},
+            {"cveId": None, "severity": "critical", "affectedProduct": "ignored"},
+        ]
+
+        normalized = module.normalize_crowdstrike_vulnerabilities(rows, severities={"HIGH", "CRITICAL"})
+
+        self.assertEqual(set(normalized), {module.VulnerabilityKey("CVE-2026-0001", "openssl 3.0")})
+
+    def test_select_assets_is_stable_and_applies_filters(self):
+        assets = [
+            {"id": 1, "name": "asset-a", "type": "SERVER", "owner": "CrowdStrike Import"},
+            {"id": 2, "name": "asset-b", "type": "WORKSTATION", "owner": "CrowdStrike Import"},
+            {"id": 3, "name": "asset-c", "type": "SERVER", "owner": "manual"},
+            {"id": 4, "name": "asset-d", "type": "SERVER", "owner": "CrowdStrike Import"},
+        ]
+
+        first = module.select_assets(assets, sample_size=2, seed="fixed", owner="CrowdStrike Import", asset_type="SERVER")
+        second = module.select_assets(assets, sample_size=2, seed="fixed", owner="CrowdStrike Import", asset_type="SERVER")
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 2)
+        self.assertTrue(all(asset["type"] == "SERVER" for asset in first))
+        self.assertTrue(all(asset["owner"] == "CrowdStrike Import" for asset in first))
+
+    def test_compare_asset_reports_missing_and_severity_drift(self):
+        asset = {"id": 42, "name": "server-42"}
+        shared = module.VulnerabilityKey("CVE-2026-0001", "openssl")
+        only_secman = module.VulnerabilityKey("CVE-2026-0002", "curl")
+        only_crowdstrike = module.VulnerabilityKey("CVE-2026-0003", "nginx")
+        secman = {
+            shared: module.NormalizedVulnerability(shared, "HIGH"),
+            only_secman: module.NormalizedVulnerability(only_secman, "CRITICAL"),
+        }
+        crowdstrike = {
+            shared: module.NormalizedVulnerability(shared, "CRITICAL"),
+            only_crowdstrike: module.NormalizedVulnerability(only_crowdstrike, "HIGH"),
+        }
+
+        result = module.compare_asset(asset, secman, crowdstrike, None)
+
+        self.assertFalse(result.matched)
+        self.assertEqual(result.missing_in_crowdstrike, [only_secman])
+        self.assertEqual(result.missing_in_secman, [only_crowdstrike])
+        self.assertEqual(result.severity_mismatches[0]["secmanSeverity"], "HIGH")
+        self.assertEqual(result.severity_mismatches[0]["crowdstrikeSeverity"], "CRITICAL")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a read-only, reproducible check that samples SecMan assets (200 by default) and verifies the backend's CrowdStrike-imported vulnerabilities still match ad-hoc CrowdStrike (Falcon) queries so operators can detect drift before trusting reports or dashboards.

### Description

- Add a Python matcher `scripts/test/crowdstrike_vulnerability_match.py` that authenticates to SecMan, selects a stable sample, fetches SecMan vuln rows, runs `./scripts/secman query --hostname ... --format json` (no `--save`), normalizes both sides to the import key `(CVE, affected product)`, and writes JSON + Markdown reports of mismatches.
- Add a pass-cli-aware wrapper `scripts/test/test-crowdstrike-vulnerability-match.sh` that resolves `secmanpp.env` and runs the matcher for operational use.
- Add a local agent skill `.agents/skills/crowdstrike-vuln-match/SKILL.md` documenting usage so agents can invoke the workflow.
- Add operator documentation `docs/CROWDSTRIKE_VULNERABILITY_MATCH.md` describing semantics, options, environment, reports, and exit codes.
- Add unit tests `tests/test_crowdstrike_vulnerability_match.py` covering normalization, stable sampling, and mismatch/severity-drift detection.

### Testing

- Ran the Python unit suite with `python3 -m unittest tests/test_crowdstrike_vulnerability_match.py` and it passed (`OK`).
- Verified Python syntax/compilation with `python3 -m py_compile scripts/test/crowdstrike_vulnerability_match.py tests/test_crowdstrike_vulnerability_match.py` which succeeded.
- Verified the wrapper script syntax with `bash -n scripts/test/test-crowdstrike-vulnerability-match.sh` which succeeded.
- Ran the CLI test task `./gradlew :cli:test` and it completed successfully for the project test targets.
- Note: an operational 200-asset run against live CrowdStrike/SecMan was not executed in CI because it requires resolved production credentials; the wrapper is ready for that live run when credentials are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26c5070acc8323bcf2ceb26e4d7196)