### PR TITLE
feat(webdep): import vulnerable web components

### DIFF
--- a/src/webdep/README.md
+++ b/src/webdep/README.md
@@ -4,7 +4,10 @@
 web applications registered in SecMan. It reads asset URIs from SecMan's asset
 inventory (or from a plain text file), downloads each root page (`/`), extracts
 referenced CSS and JavaScript resources, and imports those resources into SecMan
-as installed products via `POST /api/installed-products/import`.
+as installed products via `POST /api/installed-products/import`. When enabled,
+it also fingerprints vulnerable JavaScript libraries, PHP Composer libraries,
+PHP runtimes, and web server banners, then stores matching CVEs in SecMan via
+`POST /api/vulnerabilities/cli-add`.
 
 The tool is intentionally implemented with the Python standard library only. It
 can be copied to an administration host and run without installing runtime HTTP
@@ -12,7 +15,7 @@ or HTML parsing packages.
 
 ## What gets discovered
 
-The scanner parses the returned HTML and records:
+The scanner parses the returned HTML and records installed products:
 
 - `<script src="...">` entries as `JavaScript library` products.
 - `<link rel="stylesheet" href="...">` entries as `CSS library` products.
@@ -137,6 +140,46 @@ python -m webdep.cli \
 `--insecure` disables certificate validation and should not be used for routine
 production automation unless certificate trust cannot be fixed.
 
+## Vulnerability matching and SecMan CVE import
+
+Add `--vulnerability-scan` to identify vulnerable components and write the
+matching CVEs to SecMan. The scanner combines four evidence sources:
+
+- JavaScript libraries discovered from `<script src>` and preloaded script URLs.
+- PHP libraries from a publicly exposed `/composer.lock`, if present. Missing or
+  inaccessible Composer lock files are ignored.
+- PHP runtime versions from `X-Powered-By: PHP/...` response headers.
+- Web server products and versions from the `Server` response header.
+
+Each versioned component is queried against NVD CVE API 2.0 with a keyword search
+containing the component name and version. Matching CVEs are upserted into
+SecMan through `/api/vulnerabilities/cli-add` using the scanned asset name as the
+hostname, NVD severity as the criticality, and `WEBDEP-IMPORT` as the owner for
+assets that need to be auto-created. The existing installed-product import still
+runs, so SecMan keeps both the component inventory and the CVE rows.
+
+Example dry run:
+
+```bash
+python -m webdep.cli \
+  --backend-url https://secman.covestro.net \
+  --username automation-webdep \
+  --vulnerability-scan \
+  --dry-run \
+  --json
+```
+
+Remove `--dry-run` to store the CVEs. Use `--max-vulns-per-component` to cap the
+number of NVD results imported for one component (default `10`). `--nvd-base-url`
+is available for tests, mirrors, or controlled gateways.
+
+Vulnerability matching is **off by default** because it performs outbound NVD
+lookups and because public Composer lock files may reveal development packages
+that should ideally not be exposed by the target application. Fixing such
+exposure is recommended independently of the import result. NVD lookup errors
+for one component are skipped and do not abort scanning or installed-product
+import.
+
 ## Validating dependencies against npm
 
 By default the tool only identifies dependencies by name and version from the
@@ -178,6 +221,8 @@ abort the run.
   not crawl deeper pages.
 - Discovery is based on static HTML. Dependencies injected only after JavaScript
   execution are not visible to this tool.
+- Vulnerability matching is evidence-based and best-effort. Review NVD keyword
+  matches for false positives, especially generic server banners or package names.
 - Import calls are batched with `--max-products-per-request` (default `1000`) to
   stay below the backend request limit.
 - Re-running the helper is safe: stable `externalId` values let SecMan update

--- a/src/webdep/tests/test_validation.py
+++ b/src/webdep/tests/test_validation.py
@@ -134,3 +134,19 @@ def test_parser_accepts_validate_flag():
 
     default_args = build_parser().parse_args(["--username", "u"])
     assert default_args.validate is False
+
+
+def test_parser_accepts_vulnerability_scan_flags():
+    args = build_parser().parse_args([
+        "--username",
+        "u",
+        "--vulnerability-scan",
+        "--nvd-base-url",
+        "https://nvd.test/cves",
+        "--max-vulns-per-component",
+        "3",
+    ])
+
+    assert args.vulnerability_scan is True
+    assert args.nvd_base_url == "https://nvd.test/cves"
+    assert args.max_vulns_per_component == 3

--- a/src/webdep/tests/test_vulnerabilities.py
+++ b/src/webdep/tests/test_vulnerabilities.py
@@ -1,0 +1,93 @@
+import json
+from email.message import Message
+
+from webdep.vulnerabilities import (
+    WebComponent,
+    components_from_composer_lock,
+    components_from_headers,
+    find_vulnerabilities,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _FakeOpener:
+    def __init__(self, payload: dict):
+        self.payload = payload
+        self.urls = []
+
+    def open(self, request, timeout=None):
+        self.urls.append(request.full_url)
+        return _FakeResponse(self.payload)
+
+
+def test_components_from_headers_identifies_web_server_and_php_runtime():
+    headers = Message()
+    headers["Server"] = "nginx/1.18.0"
+    headers["X-Powered-By"] = "PHP/8.1.2"
+
+    components = components_from_headers(headers)
+
+    assert WebComponent("nginx", "1.18.0", "Web server", "Server: nginx/1.18.0") in components
+    assert WebComponent("PHP", "8.1.2", "PHP runtime", "X-Powered-By: PHP/8.1.2") in components
+
+
+def test_components_from_composer_lock_identifies_php_libraries():
+    lock = json.dumps(
+        {
+            "packages": [{"name": "symfony/http-foundation", "version": "v6.4.1"}],
+            "packages-dev": [{"name": "phpunit/phpunit", "version": "10.0.0"}],
+        }
+    )
+
+    components = components_from_composer_lock(lock, "https://example.test/composer.lock")
+
+    assert components[0] == WebComponent(
+        "symfony/http-foundation",
+        "6.4.1",
+        "PHP library",
+        "https://example.test/composer.lock",
+        "symfony",
+    )
+    assert components[1].category == "PHP library"
+
+
+def test_find_vulnerabilities_maps_nvd_results_to_secman_findings():
+    payload = {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-1234",
+                    "descriptions": [{"lang": "en", "value": "test vuln"}],
+                    "metrics": {"cvssMetricV31": [{"cvssData": {"baseSeverity": "HIGH"}}]},
+                    "references": [{"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1234"}],
+                }
+            }
+        ]
+    }
+    opener = _FakeOpener(payload)
+
+    findings = find_vulnerabilities(
+        opener,
+        "portal.example.test",
+        [WebComponent("jquery", "1.12.4", "JavaScript library", "https://cdn/jquery.js")],
+        timeout=5,
+        nvd_base_url="https://nvd.test/cves",
+    )
+
+    assert findings[0].asset_name == "portal.example.test"
+    assert findings[0].cve == "CVE-2024-1234"
+    assert findings[0].severity == "HIGH"
+    assert "keywordSearch=jquery%201.12.4" in opener.urls[0]

--- a/src/webdep/webdep/cli.py
+++ b/src/webdep/webdep/cli.py
@@ -15,6 +15,12 @@ from urllib.request import HTTPSHandler, Request, build_opener
 from .discovery import WebDependency, discover_dependencies, normalize_uris
 from .secman import SecManClient, SecManClientError
 from .validation import validate_packages
+from .vulnerabilities import (
+    WebComponent,
+    components_from_headers,
+    fetch_exposed_composer_components,
+    find_vulnerabilities,
+)
 
 
 @dataclass(frozen=True)
@@ -62,6 +68,23 @@ def build_parser() -> argparse.ArgumentParser:
         "(registry.npmjs.org): confirm the package exists and report the latest known version. "
         "Off by default; makes outbound HTTPS calls only when set.",
     )
+    parser.add_argument(
+        "--vulnerability-scan",
+        action="store_true",
+        help="Look up discovered JavaScript libraries, exposed PHP Composer packages, PHP runtimes, "
+        "and web server banners in NVD and store matching CVEs in SecMan. Off by default.",
+    )
+    parser.add_argument(
+        "--nvd-base-url",
+        default="https://services.nvd.nist.gov/rest/json/cves/2.0",
+        help="NVD CVE API URL used by --vulnerability-scan (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--max-vulns-per-component",
+        type=int,
+        default=10,
+        help="Maximum NVD findings imported for one detected component (default: %(default)s).",
+    )
     parser.add_argument("--json", action="store_true", help="Print a machine-readable JSON summary instead of human-readable output.")
     return parser
 
@@ -75,8 +98,19 @@ def main(argv: list[str] | None = None) -> int:
     try:
         client.login(args.username, password)
         targets = load_targets(client, args.uri_file)
-        products, failures = scan_targets(targets, verify_tls=verify_tls, timeout=args.timeout)
+        products, failures, components_by_asset = scan_targets(targets, verify_tls=verify_tls, timeout=args.timeout)
         validation = validate_products(products, verify_tls=verify_tls, timeout=args.timeout) if args.validate else None
+        vulnerability_findings = []
+        vulnerability_import = []
+        if args.vulnerability_scan:
+            vulnerability_findings = scan_vulnerabilities(
+                components_by_asset,
+                verify_tls=verify_tls,
+                timeout=args.timeout,
+                nvd_base_url=args.nvd_base_url,
+                max_per_component=args.max_vulns_per_component,
+            )
+            vulnerability_import = import_vulnerabilities(client, vulnerability_findings, dry_run=args.dry_run)
         import_response = import_in_batches(
             client,
             products,
@@ -93,6 +127,9 @@ def main(argv: list[str] | None = None) -> int:
         "failures": failures,
         "dryRun": args.dry_run,
         "import": import_response,
+        "componentsIdentified": sum(len(v) for v in components_by_asset.values()),
+        "vulnerabilitiesDiscovered": len(vulnerability_findings),
+        "vulnerabilityImport": vulnerability_import,
     }
     if validation is not None:
         summary["validation"] = validation
@@ -122,16 +159,21 @@ def build_http_opener(verify_tls: bool) -> Any:
     return build_opener(HTTPSHandler(context=context))
 
 
-def scan_targets(targets: list[ScanTarget], *, verify_tls: bool, timeout: float) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+def scan_targets(targets: list[ScanTarget], *, verify_tls: bool, timeout: float) -> tuple[list[dict[str, Any]], list[dict[str, str]], dict[str, list[WebComponent]]]:
     opener = build_http_opener(verify_tls)
     products: list[dict[str, Any]] = []
     failures: list[dict[str, str]] = []
     seen_external_ids: set[str] = set()
+    components_by_asset: dict[str, list[WebComponent]] = {}
 
     for target in targets:
         try:
-            html = fetch_root_html(opener, target.uri, timeout=timeout)
+            html, headers = fetch_root_html(opener, target.uri, timeout=timeout)
             dependencies = discover_dependencies(html, target.uri)
+            components = [WebComponent.from_dependency(dependency) for dependency in dependencies]
+            components.extend(components_from_headers(headers))
+            components.extend(fetch_exposed_composer_components(opener, target.uri, timeout=timeout))
+            components_by_asset[target.asset_name] = _dedupe_components(components_by_asset.get(target.asset_name, []) + components)
             for dependency in dependencies:
                 product = to_installed_product(target, dependency)
                 if product["externalId"] in seen_external_ids:
@@ -140,17 +182,17 @@ def scan_targets(targets: list[ScanTarget], *, verify_tls: bool, timeout: float)
                 products.append(product)
         except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError, ValueError) as exc:
             failures.append({"uri": target.uri, "assetName": target.asset_name, "error": str(exc)})
-    return products, failures
+    return products, failures, components_by_asset
 
 
-def fetch_root_html(opener: Any, uri: str, *, timeout: float) -> str:
+def fetch_root_html(opener: Any, uri: str, *, timeout: float) -> tuple[str, Any]:
     request = Request(uri, method="GET", headers={"Accept": "text/html,application/xhtml+xml"})
     with opener.open(request, timeout=timeout) as response:
         content_type = response.headers.get("Content-Type", "")
         if "html" not in content_type.lower() and content_type:
             raise ValueError(f"{uri} did not return HTML (Content-Type: {content_type})")
         charset = response.headers.get_content_charset() or "utf-8"
-        return response.read().decode(charset, errors="replace")
+        return response.read().decode(charset, errors="replace"), response.headers
 
 
 def to_installed_product(target: ScanTarget, dependency: WebDependency) -> dict[str, Any]:
@@ -185,6 +227,61 @@ def validate_products(products: list[dict[str, Any]], *, verify_tls: bool, timeo
     }
 
 
+def scan_vulnerabilities(
+    components_by_asset: dict[str, list[WebComponent]],
+    *,
+    verify_tls: bool,
+    timeout: float,
+    nvd_base_url: str,
+    max_per_component: int,
+) -> list[dict[str, Any]]:
+    if max_per_component < 1:
+        raise ValueError("--max-vulns-per-component must be at least 1")
+    opener = build_http_opener(verify_tls)
+    findings = []
+    for asset_name, components in components_by_asset.items():
+        findings.extend(
+            finding.as_dict()
+            for finding in find_vulnerabilities(
+                opener,
+                asset_name,
+                components,
+                timeout=timeout,
+                nvd_base_url=nvd_base_url,
+                max_per_component=max_per_component,
+            )
+        )
+    return findings
+
+
+def import_vulnerabilities(client: SecManClient, findings: list[dict[str, Any]], *, dry_run: bool) -> list[dict[str, Any]]:
+    responses: list[dict[str, Any]] = []
+    for finding in findings:
+        if dry_run:
+            responses.append({"dryRun": True, "hostname": finding["asset_name"], "cve": finding["cve"], "criticality": finding["severity"]})
+            continue
+        responses.append(
+            client.add_vulnerability(
+                hostname=finding["asset_name"],
+                cve=finding["cve"],
+                criticality=finding["severity"],
+                owner="WEBDEP-IMPORT",
+            )
+        )
+    return responses
+
+
+def _dedupe_components(components: list[WebComponent]) -> list[WebComponent]:
+    seen: set[tuple[str, str | None, str]] = set()
+    result: list[WebComponent] = []
+    for component in components:
+        key = (component.name.lower(), component.version, component.category)
+        if key not in seen:
+            seen.add(key)
+            result.append(component)
+    return result
+
+
 def import_in_batches(client: SecManClient, products: list[dict[str, Any]], *, dry_run: bool, batch_size: int) -> list[dict[str, Any]]:
     if batch_size < 1:
         raise ValueError("--max-products-per-request must be at least 1")
@@ -209,6 +306,8 @@ def import_in_batches(client: SecManClient, products: list[dict[str, Any]], *, d
 def print_human_summary(summary: dict[str, Any]) -> None:
     print(f"Targets scanned: {summary['targets']}")
     print(f"Products discovered: {summary['productsDiscovered']}")
+    print(f"Components identified for vulnerability matching: {summary['componentsIdentified']}")
+    print(f"Vulnerabilities discovered: {summary['vulnerabilitiesDiscovered']}")
     print(f"Dry run: {summary['dryRun']}")
     validation = summary.get("validation")
     if validation is not None:

--- a/src/webdep/webdep/secman.py
+++ b/src/webdep/webdep/secman.py
@@ -70,6 +70,14 @@ class SecManClient:
 
         return self._request("POST", "api/installed-products/import", {"products": products, "dryRun": dry_run})
 
+    def add_vulnerability(self, *, hostname: str, cve: str, criticality: str, owner: str | None = None) -> dict[str, Any]:
+        """Store a web dependency CVE through SecMan's CLI vulnerability endpoint."""
+
+        body: dict[str, Any] = {"hostname": hostname, "cve": cve, "criticality": criticality, "daysOpen": 0}
+        if owner is not None:
+            body["owner"] = owner
+        return self._request("POST", "api/vulnerabilities/cli-add", body)
+
     def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
         url = urljoin(self.backend_url, path)
         payload = json.dumps(body).encode("utf-8") if body is not None else None

--- a/src/webdep/webdep/vulnerabilities.py
+++ b/src/webdep/webdep/vulnerabilities.py
@@ -1,0 +1,218 @@
+"""Best-effort vulnerability identification for web dependencies.
+
+The module deliberately stays on the Python standard library. It fingerprints
+JavaScript packages, exposed Composer/PHP packages, PHP runtimes, and HTTP
+server banners, then looks them up in NVD's CVE 2.0 API when enabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import re
+from typing import Any, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urljoin
+from urllib.request import Request
+
+from .discovery import WebDependency
+
+NVD_CVE_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_SEVERITY_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+_SERVER_TOKEN_RE = re.compile(r"(?P<name>[A-Za-z][A-Za-z0-9_.+-]*)(?:/(?P<version>\d+(?:\.\d+){0,3}[0-9A-Za-z.+-]*))?")
+_PHP_RE = re.compile(r"\bPHP/(?P<version>\d+(?:\.\d+){1,3}[0-9A-Za-z.+-]*)", re.I)
+
+
+@dataclass(frozen=True)
+class WebComponent:
+    """A versioned component that may have CVEs."""
+
+    name: str
+    version: str | None
+    category: str
+    evidence: str
+    vendor: str | None = None
+
+    @classmethod
+    def from_dependency(cls, dependency: WebDependency) -> "WebComponent":
+        return cls(
+            name=dependency.name,
+            version=dependency.version,
+            category=dependency.category,
+            vendor=dependency.vendor,
+            evidence=dependency.url,
+        )
+
+
+@dataclass(frozen=True)
+class VulnerabilityFinding:
+    """One CVE found for one component on one SecMan asset."""
+
+    asset_name: str
+    component: WebComponent
+    cve: str
+    severity: str
+    description: str | None = None
+    source_url: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["component"] = asdict(self.component)
+        return data
+
+
+def components_from_headers(headers: Any) -> list[WebComponent]:
+    """Fingerprint web servers and PHP runtimes from HTTP response headers."""
+
+    components: list[WebComponent] = []
+    server = _header_value(headers, "Server")
+    if server:
+        for token in _SERVER_TOKEN_RE.finditer(server):
+            name = token.group("name")
+            if name.lower() in {"", "http", "https"}:
+                continue
+            components.append(
+                WebComponent(
+                    name=_normalize_server_name(name),
+                    version=token.group("version"),
+                    category="Web server",
+                    evidence=f"Server: {server}",
+                )
+            )
+    powered_by = _header_value(headers, "X-Powered-By")
+    if powered_by:
+        match = _PHP_RE.search(powered_by)
+        if match:
+            components.append(
+                WebComponent(
+                    name="PHP",
+                    version=match.group("version"),
+                    category="PHP runtime",
+                    evidence=f"X-Powered-By: {powered_by}",
+                )
+            )
+    return _dedupe_components(components)
+
+
+def components_from_composer_lock(lock_json: str, evidence_url: str) -> list[WebComponent]:
+    """Parse an exposed composer.lock file into PHP library components."""
+
+    try:
+        data = json.loads(lock_json)
+    except json.JSONDecodeError:
+        return []
+
+    components: list[WebComponent] = []
+    for section in ("packages", "packages-dev"):
+        packages = data.get(section) or []
+        if not isinstance(packages, list):
+            continue
+        for package in packages:
+            if not isinstance(package, dict):
+                continue
+            name = package.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            version = package.get("version")
+            components.append(
+                WebComponent(
+                    name=name.strip(),
+                    version=_clean_php_version(version) if isinstance(version, str) else None,
+                    category="PHP library",
+                    evidence=evidence_url,
+                    vendor=name.split("/", 1)[0] if "/" in name else None,
+                )
+            )
+    return _dedupe_components(components)
+
+
+def fetch_exposed_composer_components(opener: Any, root_uri: str, *, timeout: float) -> list[WebComponent]:
+    """Fetch ``/composer.lock`` if it is publicly exposed; return no components otherwise."""
+
+    url = urljoin(root_uri, "/composer.lock")
+    request = Request(url, method="GET", headers={"Accept": "application/json,text/plain,*/*"})
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            raw = response.read(2_000_000)
+            return components_from_composer_lock(raw.decode("utf-8", errors="replace"), url)
+    except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError):
+        return []
+
+
+def find_vulnerabilities(
+    opener: Any,
+    asset_name: str,
+    components: Iterable[WebComponent],
+    *,
+    timeout: float,
+    nvd_base_url: str = NVD_CVE_API_URL,
+    max_per_component: int = 10,
+) -> list[VulnerabilityFinding]:
+    """Look up component CVEs in NVD and return findings suitable for SecMan."""
+
+    findings: list[VulnerabilityFinding] = []
+    seen: set[tuple[str, str]] = set()
+    for component in components:
+        if not component.version:
+            continue
+        query = f"{component.name} {component.version}"
+        url = f"{nvd_base_url}?keywordSearch={quote(query)}&noRejected"
+        request = Request(url, method="GET", headers={"Accept": "application/json"})
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+
+        count = 0
+        for item in payload.get("vulnerabilities") or []:
+            cve = (item.get("cve") or {}) if isinstance(item, dict) else {}
+            cve_id = cve.get("id")
+            if not isinstance(cve_id, str) or (asset_name, cve_id) in seen:
+                continue
+            severity = _severity(cve)
+            descriptions = cve.get("descriptions") or []
+            description = next((d.get("value") for d in descriptions if d.get("lang") == "en"), None)
+            references = cve.get("references") or []
+            source_url = next((r.get("url") for r in references if isinstance(r, dict) and r.get("url")), url)
+            findings.append(VulnerabilityFinding(asset_name, component, cve_id, severity, description, source_url))
+            seen.add((asset_name, cve_id))
+            count += 1
+            if count >= max_per_component:
+                break
+    return findings
+
+
+def _severity(cve: dict[str, Any]) -> str:
+    severities: list[str] = []
+    for metrics in (cve.get("metrics") or {}).values():
+        for metric in metrics or []:
+            severity = ((metric.get("cvssData") or {}).get("baseSeverity") or metric.get("baseSeverity"))
+            if isinstance(severity, str):
+                severities.append(severity.upper())
+    return max(severities, key=lambda s: _SEVERITY_ORDER.get(s, 0), default="LOW")
+
+
+def _header_value(headers: Any, name: str) -> str | None:
+    getter = getattr(headers, "get", None)
+    value = getter(name) if getter else None
+    return str(value).strip() if value else None
+
+
+def _normalize_server_name(name: str) -> str:
+    return {"nginx": "nginx", "apache": "Apache HTTP Server", "httpd": "Apache HTTP Server"}.get(name.lower(), name)
+
+
+def _clean_php_version(version: str) -> str:
+    return version.removeprefix("v").lstrip("=").strip()
+
+
+def _dedupe_components(components: Iterable[WebComponent]) -> list[WebComponent]:
+    seen: set[tuple[str, str | None, str]] = set()
+    result: list[WebComponent] = []
+    for component in components:
+        key = (component.name.lower(), component.version, component.category)
+        if key not in seen:
+            seen.add(key)
+            result.append(component)
+    return result


### PR DESCRIPTION
### Motivation

- Add best-effort vulnerability identification to the web dependency importer so discovered JavaScript libraries, exposed PHP Composer packages, PHP runtimes, and web server banners can be matched to CVEs and stored in SecMan.

### Description

- New module `src/webdep/webdep/vulnerabilities.py` implements `WebComponent`/`VulnerabilityFinding` and functions to fingerprint components from HTML dependencies, `Server`/`X-Powered-By` headers, and exposed `/composer.lock`, and to query NVD CVE API (`find_vulnerabilities`).
- CLI extended in `src/webdep/webdep/cli.py` with flags `--vulnerability-scan`, `--nvd-base-url`, and `--max-vulns-per-component`, and `scan_targets` now collects components per asset and optionally runs NVD lookups; found CVEs are imported via a new `import_vulnerabilities` flow that respects `--dry-run`.
- `src/webdep/webdep/secman.py` adds `SecManClient.add_vulnerability` to call the backend `POST /api/vulnerabilities/cli-add` endpoint for storing matched CVEs.
- Documentation updated (`src/webdep/README.md`) to describe evidence sources, NVD lookup behavior, dry-run usage, and false-positive caution; unit tests added/extended under `src/webdep/tests/` for header parsing, composer lock parsing, NVD mapping, and CLI flags.

### Testing

- Ran the webdep unit test suite with `python -m pytest src/webdep/tests`, all tests passed (`16 passed`).
- Compiled the package modules with `python -m compileall src/webdep/webdep` to verify syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e77c746c88323b375328472414b09)