### PR TITLE
feat(products): show AWS Account ID in installed products list

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/dto/InstalledProductDtos.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/InstalledProductDtos.kt
@@ -28,6 +28,7 @@ data class InstalledProductResponse(
     val id: Long,
     val assetId: Long,
     val hostname: String,
+    val cloudAccountId: String?,
     val name: String,
     val vendor: String?,
     val version: String?,

--- a/src/backendng/src/main/kotlin/com/secman/service/InstalledProductListService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/InstalledProductListService.kt
@@ -78,6 +78,7 @@ open class InstalledProductListService(
                     id = requireNotNull(product.id),
                     assetId = requireNotNull(product.asset.id),
                     hostname = product.asset.name,
+                    cloudAccountId = product.asset.cloudAccountId,
                     name = product.name,
                     vendor = product.vendor,
                     version = product.version,

--- a/src/frontend/src/components/InstalledProducts.tsx
+++ b/src/frontend/src/components/InstalledProducts.tsx
@@ -166,18 +166,20 @@ const InstalledProducts: React.FC = () => {
                 <th>Product</th>
                 <th>Version</th>
                 <th>System</th>
+                <th>AWS Account ID</th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
-                <tr><td colSpan={3} className="text-center py-4">Loading installed products...</td></tr>
+                <tr><td colSpan={4} className="text-center py-4">Loading installed products...</td></tr>
               ) : products.length === 0 ? (
-                <tr><td colSpan={3} className="text-center py-4 text-muted">No installed products found.</td></tr>
+                <tr><td colSpan={4} className="text-center py-4 text-muted">No installed products found.</td></tr>
               ) : products.map((product) => (
                 <tr key={product.id}>
                   <td className="fw-semibold">{product.name}</td>
                   <td><code>{product.version || '—'}</code></td>
                   <td><a href={`/assets/${product.assetId}`}>{product.hostname}</a></td>
+                  <td><code>{product.cloudAccountId || '—'}</code></td>
                 </tr>
               ))}
             </tbody>

--- a/src/frontend/src/components/ProductsOverview.test.ts
+++ b/src/frontend/src/components/ProductsOverview.test.ts
@@ -52,7 +52,7 @@ test('installed products supports server-specific product lookup', () => {
     assert.match(serviceSource, /\/api\/installed-products\/by-server/);
 });
 
-test('installed products renders only product, version, and system columns', () => {
+test('installed products renders product, version, system, and AWS account columns', () => {
     const source = readFileSync(new URL('./InstalledProducts.tsx', import.meta.url), 'utf8');
 
     assert.doesNotMatch(source, /<th>Vendor<\/th>/);
@@ -61,7 +61,9 @@ test('installed products renders only product, version, and system columns', () 
     assert.doesNotMatch(source, /product\.vendor/);
     assert.doesNotMatch(source, /product\.category/);
     assert.doesNotMatch(source, /product\.importedAt/);
-    assert.match(source, /colSpan=\{3\}/);
+    assert.match(source, /<th>AWS Account ID<\/th>/);
+    assert.match(source, /product\.cloudAccountId/);
+    assert.match(source, /colSpan=\{4\}/);
 });
 
 test('admin email broadcast preview sanitizes html before rendering', () => {

--- a/src/frontend/src/services/installedProductService.ts
+++ b/src/frontend/src/services/installedProductService.ts
@@ -4,6 +4,7 @@ export interface InstalledProductResponse {
   id: number;
   assetId: number;
   hostname: string;
+  cloudAccountId?: string | null;
   name: string;
   vendor?: string | null;
   version?: string | null;


### PR DESCRIPTION
### Motivation
- Display the AWS Account ID in installed-products list rows when the backing asset already has a `cloudAccountId`, to match the vulnerable-products systems view which already shows the account.
- Improve operator visibility for cloud-scoped findings and make product/system lists consistent across views.

### Description
- Added `cloudAccountId` to the installed product API response DTO (`InstalledProductResponse`).
- Populated `InstalledProductResponse.cloudAccountId` from the linked asset in `InstalledProductListService.listMatchingProducts`.
- Updated the installed-products frontend component to render an "AWS Account ID" column and show a dash when absent (`InstalledProducts.tsx`).
- Extended the frontend installed-product response type (`installedProductService.ts`) and updated the component smoke test to assert the new column (`ProductsOverview.test.ts`).

### Testing
- Ran the component unit tests with `node --test src/frontend/src/components/ProductsOverview.test.ts`, all tests passed.
- Ran frontend install and build with `cd src/frontend && npm install` and `cd src/frontend && npm run build`, the build completed successfully.
- Attempted `./gradlew :backendng:compileKotlin` but the run stalled in `:backendng:kspKotlin` (no compiler error emitted) and was manually stopped, so the full backend compile and the mandatory E2E gates (`/e2ejs`, `/e2evulnexception`) were not executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3038de412483239bcfdffd94009167)