### PR TITLE
Block inactive users from creating exception requests; fix always-visible Account Inactive badge

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityExceptionRequestDto.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityExceptionRequestDto.kt
@@ -38,6 +38,11 @@ data class VulnerabilityExceptionRequestDto(
     val assetIp: String?,
 
     /**
+     * ID of the user who requested the exception. Null if the account has been deleted.
+     */
+    val requestedByUserId: Long?,
+
+    /**
      * Username of the person who requested the exception.
      */
     val requestedByUsername: String,
@@ -86,6 +91,11 @@ data class VulnerabilityExceptionRequestDto(
      * True if this request was auto-approved (requester has ADMIN/SECCHAMPION role).
      */
     val autoApproved: Boolean,
+
+    /**
+     * ID of the reviewer. Null if not yet reviewed or account has been deleted.
+     */
+    val reviewedByUserId: Long?,
 
     /**
      * Username of the reviewer who approved/rejected. Null if not yet reviewed.

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
@@ -90,6 +90,10 @@ open class VulnerabilityExceptionRequestService(
             IllegalArgumentException("User with ID $requesterUserId not found")
         }
 
+        if (requester.lastLogin == null) {
+            throw IllegalStateException("Inactive accounts cannot create exception requests")
+        }
+
         // Enforce the spec §4.2 invariants on the request shape *before* persisting anything.
         // This guarantees a non-ADMIN/VULN user submitting an ALL_VULNS × * request is rejected
         // with 403 before a PENDING row is created (spec §3 role-gating bullet 1).
@@ -935,6 +939,7 @@ open class VulnerabilityExceptionRequestService(
             vulnerabilityCve = request.vulnerability?.vulnerabilityId ?: request.cveId,
             assetName = request.vulnerability?.asset?.name,
             assetIp = request.vulnerability?.asset?.ip,
+            requestedByUserId = request.requestedByUser?.id,
             requestedByUsername = request.requestedByUsername,
             subject = request.subject,
             scope = request.scope,
@@ -945,6 +950,7 @@ open class VulnerabilityExceptionRequestService(
             expirationDate = request.expirationDate,
             status = request.status,
             autoApproved = request.autoApproved,
+            reviewedByUserId = request.reviewedByUser?.id,
             reviewedByUsername = request.reviewedByUsername,
             reviewDate = request.reviewDate,
             reviewComment = request.reviewComment,


### PR DESCRIPTION
- VulnerabilityExceptionRequestService.createRequest: reject requester
  whose lastLogin is null (never logged in = inactive account)
- VulnerabilityExceptionRequestDto: add requestedByUserId and
  reviewedByUserId fields so the frontend badge correctly shows
  "Account Inactive" only when the account was deleted, not on every row
- toDto(): populate both new fields from the entity FK (nullable when
  the user row has since been removed)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CGxb8uYMYt2effYwB8RyEj