### PR TITLE
Display AWS Account scope in approval request details

### DIFF
--- a/src/frontend/src/components/ApprovalDetailModal.tsx
+++ b/src/frontend/src/components/ApprovalDetailModal.tsx
@@ -259,6 +259,12 @@ const ApprovalDetailModal: React.FC<ApprovalDetailModalProps> = ({
                             assetId={request.assetId}
                             assetName={request.assetName}
                           />
+                          {request.scope === 'AWS_ACCOUNT' && request.scopeValue && (
+                            <div className="mt-1 small text-muted">
+                              <i className="bi bi-cloud me-1"></i>
+                              <strong>AWS Account:</strong> {request.scopeValue}
+                            </div>
+                          )}
                         </div>
                         <div className="mb-2">
                           <strong>Expiration Date:</strong><br />


### PR DESCRIPTION
## Summary
Added UI display of AWS Account scope information in the ApprovalDetailModal component when viewing approval request details.

## Changes
- Display AWS Account ID/name when `scope === 'AWS_ACCOUNT'` and `scopeValue` is present
- Added a new info section below the asset details showing the AWS Account with a cloud icon
- Uses Bootstrap styling (`small text-muted`) and icon (`bi-cloud`) consistent with existing UI patterns

## Implementation Details
- Conditional rendering checks both scope type and scopeValue existence before displaying
- Placed logically after asset information and before expiration date
- Uses semantic HTML with icon and bold label for clarity
- Minimal styling overhead using existing Bootstrap classes

https://claude.ai/code/session_01RMenCeGSTCqwHjD5M8bxM4