### PR TITLE
Show similar past exception decisions in approval modal

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityExceptionRequestController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityExceptionRequestController.kt
@@ -288,6 +288,33 @@ open class VulnerabilityExceptionRequestController(
     }
 
     /**
+     * Get previously reviewed (APPROVED / REJECTED) requests similar to this one.
+     *
+     * GET /api/vulnerability-exception-requests/{id}/similar
+     * Auth: ADMIN or SECCHAMPION only
+     *
+     * Gives approvers historical context: how comparable exception requests
+     * (same CVE, product, or asset) were decided in the past.
+     *
+     * @param id Request ID
+     * @return 200 OK with list of similar reviewed requests, 404 if not found
+     */
+    @Get("/{id}/similar")
+    @Secured("ADMIN", "SECCHAMPION")
+    open fun getSimilarRequests(@PathVariable id: Long): HttpResponse<*> {
+        return try {
+            val similar = exceptionRequestService.getSimilarReviewedRequests(id)
+            HttpResponse.ok(similar)
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Request not found for similar lookup: id={}", id)
+            HttpResponse.notFound<List<VulnerabilityExceptionRequestDto>>()
+        } catch (e: Exception) {
+            logger.error("Failed to get similar requests: id={}", id, e)
+            HttpResponse.serverError<List<VulnerabilityExceptionRequestDto>>()
+        }
+    }
+
+    /**
      * TASK-020: Approve a pending exception request.
      *
      * POST /api/vulnerability-exception-requests/{id}/approve

--- a/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
@@ -1,6 +1,7 @@
 package com.secman.repository
 
 import com.secman.domain.ExceptionRequestStatus
+import com.secman.domain.VulnerabilityException
 import com.secman.domain.VulnerabilityExceptionRequest
 import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Repository
@@ -257,6 +258,46 @@ interface VulnerabilityExceptionRequestRepository : JpaRepository<VulnerabilityE
         status: ExceptionRequestStatus,
         createdAfter: LocalDateTime
     ): Long
+
+    /**
+     * Find previously reviewed (APPROVED / REJECTED) requests that are "similar" to a
+     * given request, to give approvers historical context for their decision.
+     *
+     * A request is considered similar if it matches on any of:
+     * - the same CVE id (denormalized, survives reimport), OR
+     * - the same subject + subjectValue (e.g. the same product), OR
+     * - the same asset.
+     *
+     * The request itself is excluded via [excludeId]. Results are ordered most
+     * recently reviewed first.
+     *
+     * @param excludeId ID of the request being reviewed (excluded from results)
+     * @param cveId Denormalized CVE id of the request (nullable)
+     * @param subject Subject axis of the request
+     * @param subjectValue Subject value of the request (nullable)
+     * @param assetId Denormalized asset id of the request (nullable)
+     * @param statuses Decision statuses to include (typically APPROVED, REJECTED)
+     * @return List of similar reviewed requests, newest decision first
+     */
+    @Query("""
+        SELECT r FROM VulnerabilityExceptionRequest r
+        WHERE r.id <> :excludeId
+          AND r.status IN (:statuses)
+          AND (
+                (:cveId IS NOT NULL AND r.cveId = :cveId)
+             OR (:subjectValue IS NOT NULL AND r.subject = :subject AND r.subjectValue = :subjectValue)
+             OR (:assetId IS NOT NULL AND r.assetId = :assetId)
+          )
+        ORDER BY r.reviewDate DESC
+    """)
+    fun findSimilarReviewedRequests(
+        excludeId: Long,
+        cveId: String?,
+        subject: VulnerabilityException.Subject,
+        subjectValue: String?,
+        assetId: Long?,
+        statuses: List<ExceptionRequestStatus>
+    ): List<VulnerabilityExceptionRequest>
 
     /**
      * Nullify the requestedByUser reference when a user is deleted.

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
@@ -52,6 +52,11 @@ open class VulnerabilityExceptionRequestService(
 ) {
     private val logger = LoggerFactory.getLogger(VulnerabilityExceptionRequestService::class.java)
 
+    companion object {
+        /** Max number of similar historical requests returned for approver context. */
+        private const val SIMILAR_REQUESTS_LIMIT = 50
+    }
+
     /**
      * Create a new exception request.
      *
@@ -515,6 +520,34 @@ open class VulnerabilityExceptionRequestService(
             IllegalArgumentException("Exception request with ID $requestId not found")
         }
         return toDto(request)
+    }
+
+    /**
+     * Get previously reviewed (APPROVED / REJECTED) requests similar to the given one.
+     *
+     * Gives approvers historical context — how comparable exception requests
+     * were decided in the past. Similarity is matched on CVE id, subject value
+     * (e.g. product), or asset. Results are newest decision first, capped to a
+     * reasonable number for display.
+     *
+     * @param requestId ID of the request being reviewed
+     * @return List of similar reviewed request DTOs
+     */
+    @Transactional
+    open fun getSimilarReviewedRequests(requestId: Long): List<VulnerabilityExceptionRequestDto> {
+        val request = requestRepository.findById(requestId).orElseThrow {
+            IllegalArgumentException("Exception request with ID $requestId not found")
+        }
+        val cveId = request.vulnerability?.vulnerabilityId ?: request.cveId
+        val similar = requestRepository.findSimilarReviewedRequests(
+            excludeId = request.id!!,
+            cveId = cveId,
+            subject = request.subject,
+            subjectValue = request.subjectValue,
+            assetId = request.assetId,
+            statuses = listOf(ExceptionRequestStatus.APPROVED, ExceptionRequestStatus.REJECTED)
+        )
+        return similar.take(SIMILAR_REQUESTS_LIMIT).map { toDto(it) }
     }
 
     /**

--- a/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityExceptionRequestServiceAwsAccountTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityExceptionRequestServiceAwsAccountTest.kt
@@ -211,6 +211,83 @@ class VulnerabilityExceptionRequestServiceAwsAccountTest {
         assertEquals(null, savedException.captured.assetId)
     }
 
+    @Test
+    fun `getSimilarReviewedRequests returns mapped APPROVED and REJECTED history`() {
+        val target = VulnerabilityExceptionRequest(
+            id = 200L,
+            requestedByUser = requester,
+            requestedByUsername = requester.username,
+            subject = VulnerabilityException.Subject.CVE,
+            scope = VulnerabilityException.Scope.ASSET,
+            subjectValue = "CVE-2026-9999",
+            scopeValue = null,
+            reason = requestReason,
+            expirationDate = LocalDateTime.now().plusDays(30),
+            status = ExceptionRequestStatus.PENDING,
+            autoApproved = false,
+            cveId = "CVE-2026-9999",
+            assetId = 3001L
+        ).apply {
+            createdAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now()
+        }
+
+        val approvedHistory = VulnerabilityExceptionRequest(
+            id = 201L,
+            requestedByUser = reviewer,
+            requestedByUsername = "alice",
+            subject = VulnerabilityException.Subject.CVE,
+            scope = VulnerabilityException.Scope.ASSET,
+            subjectValue = "CVE-2026-9999",
+            scopeValue = null,
+            reason = requestReason,
+            expirationDate = LocalDateTime.now().plusDays(30),
+            status = ExceptionRequestStatus.APPROVED,
+            autoApproved = false,
+            reviewedByUsername = "secchamp",
+            reviewComment = "Approved previously for the same CVE.",
+            cveId = "CVE-2026-9999",
+            assetId = 3001L
+        ).apply {
+            createdAt = LocalDateTime.now().minusDays(10)
+            updatedAt = LocalDateTime.now().minusDays(9)
+            reviewDate = LocalDateTime.now().minusDays(9)
+        }
+
+        val statuses = slot<List<ExceptionRequestStatus>>()
+        every { requestRepository.findById(200L) } returns Optional.of(target)
+        every {
+            requestRepository.findSimilarReviewedRequests(
+                excludeId = 200L,
+                cveId = "CVE-2026-9999",
+                subject = VulnerabilityException.Subject.CVE,
+                subjectValue = "CVE-2026-9999",
+                assetId = 3001L,
+                statuses = capture(statuses)
+            )
+        } returns listOf(approvedHistory)
+
+        val result = service.getSimilarReviewedRequests(200L)
+
+        assertEquals(1, result.size)
+        assertEquals(201L, result[0].id)
+        assertEquals(ExceptionRequestStatus.APPROVED, result[0].status)
+        assertEquals("secchamp", result[0].reviewedByUsername)
+        assertEquals(
+            listOf(ExceptionRequestStatus.APPROVED, ExceptionRequestStatus.REJECTED),
+            statuses.captured
+        )
+    }
+
+    @Test
+    fun `getSimilarReviewedRequests throws when request not found`() {
+        every { requestRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            service.getSimilarReviewedRequests(999L)
+        }
+    }
+
     private fun requestForAwsAccount(scopeValue: String): CreateExceptionRequestDto =
         CreateExceptionRequestDto(
             subject = VulnerabilityException.Subject.PRODUCT,

--- a/src/frontend/src/components/ApprovalDetailModal.tsx
+++ b/src/frontend/src/components/ApprovalDetailModal.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { getRequestById, approveRequest, rejectRequest, type VulnerabilityExceptionRequestDto } from '../services/exceptionRequestService';
+import { getRequestById, getSimilarRequests, approveRequest, rejectRequest, type VulnerabilityExceptionRequestDto } from '../services/exceptionRequestService';
 import ExceptionStatusBadge from './ExceptionStatusBadge';
 import ExceptionRequestScopeBadge from './ExceptionRequestScopeBadge';
 
@@ -40,6 +40,10 @@ const ApprovalDetailModal: React.FC<ApprovalDetailModalProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Similar past requests (historical approval/rejection context)
+  const [similarRequests, setSimilarRequests] = useState<VulnerabilityExceptionRequestDto[]>([]);
+  const [similarLoading, setSimilarLoading] = useState(false);
+
   // Action states
   const [approving, setApproving] = useState(false);
   const [rejecting, setRejecting] = useState(false);
@@ -54,6 +58,7 @@ const ApprovalDetailModal: React.FC<ApprovalDetailModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       fetchRequestDetails();
+      fetchSimilarRequests();
       // Reset states
       setApproveComment('');
       setRejectComment('');
@@ -74,6 +79,20 @@ const ApprovalDetailModal: React.FC<ApprovalDetailModalProps> = ({
       setError(errorMessage);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchSimilarRequests = async () => {
+    try {
+      setSimilarLoading(true);
+      setSimilarRequests([]);
+      const data = await getSimilarRequests(requestId);
+      setSimilarRequests(data);
+    } catch (err) {
+      // Non-fatal: historical context is supplementary, don't block the review.
+      setSimilarRequests([]);
+    } finally {
+      setSimilarLoading(false);
     }
   };
 
@@ -459,6 +478,90 @@ const ApprovalDetailModal: React.FC<ApprovalDetailModalProps> = ({
                         </div>
                       )}
                     </div>
+                  </div>
+
+                  {/* Similar Past Requests - historical approval/rejection context */}
+                  <div className="mt-4 pt-3 border-top">
+                    <h6 className="text-muted mb-3">
+                      <i className="bi bi-clock-history me-2"></i>
+                      Similar Past Requests
+                    </h6>
+
+                    {similarLoading && (
+                      <div className="text-muted small">
+                        <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                        Loading history...
+                      </div>
+                    )}
+
+                    {!similarLoading && similarRequests.length === 0 && (
+                      <p className="text-muted small mb-0" data-testid="similar-requests-empty">
+                        No similar requests (same CVE, product, or asset) have been approved or declined before.
+                      </p>
+                    )}
+
+                    {!similarLoading && similarRequests.length > 0 && (
+                      <>
+                        <p className="small mb-2" data-testid="similar-requests-summary">
+                          <span className="badge bg-success me-2">
+                            {similarRequests.filter((r) => r.status === 'APPROVED').length} approved
+                          </span>
+                          <span className="badge bg-danger me-2">
+                            {similarRequests.filter((r) => r.status === 'REJECTED').length} declined
+                          </span>
+                          <span className="text-muted">
+                            among comparable requests (same CVE, product, or asset).
+                          </span>
+                        </p>
+                        <div className="table-responsive" style={{ maxHeight: '260px', overflowY: 'auto' }}>
+                          <table className="table table-sm table-hover align-middle small mb-0" data-testid="similar-requests-table">
+                            <thead>
+                              <tr>
+                                <th>Decision</th>
+                                <th>CVE</th>
+                                <th>Scope</th>
+                                <th>Requested By</th>
+                                <th>Reviewed By</th>
+                                <th>Reviewed</th>
+                                <th>Comment</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {similarRequests.map((sr) => (
+                                <tr key={sr.id} data-testid={`similar-request-row-${sr.id}`}>
+                                  <td>
+                                    <ExceptionStatusBadge status={sr.status} autoApproved={sr.autoApproved} />
+                                  </td>
+                                  <td><code>{sr.vulnerabilityCve || '—'}</code></td>
+                                  <td>
+                                    <ExceptionRequestScopeBadge
+                                      scope={sr.scope}
+                                      scopeValue={sr.scopeValue}
+                                      assetId={sr.assetId}
+                                      assetName={sr.assetName}
+                                    />
+                                  </td>
+                                  <td>{sr.requestedByUsername}</td>
+                                  <td>{sr.reviewedByUsername || '—'}</td>
+                                  <td>{sr.reviewDate ? new Date(sr.reviewDate).toLocaleDateString() : '—'}</td>
+                                  <td>
+                                    {sr.reviewComment ? (
+                                      <span title={sr.reviewComment}>
+                                        {sr.reviewComment.length > 60
+                                          ? `${sr.reviewComment.slice(0, 60)}…`
+                                          : sr.reviewComment}
+                                      </span>
+                                    ) : (
+                                      <span className="text-muted">—</span>
+                                    )}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </>
+                    )}
                   </div>
                 </>
               )}

--- a/src/frontend/src/services/exceptionRequestService.ts
+++ b/src/frontend/src/services/exceptionRequestService.ts
@@ -396,6 +396,44 @@ export async function getPendingCount(): Promise<number> {
 }
 
 /**
+ * Get previously reviewed (APPROVED / REJECTED) requests similar to the given one
+ * (ADMIN/SECCHAMPION only).
+ *
+ * Provides historical context for approvers: how comparable exception requests
+ * (same CVE, product, or asset) were decided in the past.
+ *
+ * @param id Request ID being reviewed
+ * @returns List of similar reviewed requests, newest decision first
+ * @throws Error on 401 (unauthorized), 403 (forbidden), 404 (not found), 500 (server error)
+ */
+export async function getSimilarRequests(id: number): Promise<VulnerabilityExceptionRequestDto[]> {
+  const response = await authenticatedGet(`/api/vulnerability-exception-requests/${id}/similar`);
+
+  if (response.ok) {
+    return await response.json();
+  }
+
+  if (response.status === 401) {
+    throw new Error('Unauthorized. Please login again.');
+  }
+
+  if (response.status === 403) {
+    throw new Error('Access denied. This feature requires ADMIN or SECCHAMPION role.');
+  }
+
+  if (response.status === 404) {
+    throw new Error('Exception request not found.');
+  }
+
+  if (response.status === 500) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch similar exception requests.');
+  }
+
+  throw new Error(`Failed to fetch similar exception requests: ${response.status}`);
+}
+
+/**
  * Approve an exception request (ADMIN/SECCHAMPION only)
  *
  * @param id Request ID


### PR DESCRIPTION
When reviewing a pending vulnerability exception request, approvers now
see how comparable requests were decided in the past (approved/declined),
giving historical context for the decision.

Backend:
- New repository query findSimilarReviewedRequests matching on CVE id,
  subject value (e.g. product), or asset, restricted to APPROVED/REJECTED.
- Service getSimilarReviewedRequests (capped at 50, newest decision first).
- Endpoint GET /api/vulnerability-exception-requests/{id}/similar
  (ADMIN/SECCHAMPION).

Frontend:
- exceptionRequestService.getSimilarRequests().
- ApprovalDetailModal renders a "Similar Past Requests" section with an
  approved/declined summary and a table of prior decisions (status,
  reviewer, review date, comment). Non-fatal if the lookup fails.

Tests:
- Unit tests for getSimilarReviewedRequests (mapping + not-found).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nb4FQY13Gb2LBxLRQ275TP