### PR TITLE
Block exception requests for vulnerabilities younger than 5 days

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExceptionRequestService.kt
@@ -85,6 +85,19 @@ open class VulnerabilityExceptionRequestService(
             }
         }
 
+        // Individual-vulnerability exceptions require the vulnerability to be at least 5 days old.
+        // SLA anchor mirrors the overdue calculation: firstSeenAt when available, scanTimestamp otherwise.
+        if (vulnerability != null) {
+            val ageAnchor = vulnerability.firstSeenAt ?: vulnerability.scanTimestamp
+            val ageInDays = java.time.temporal.ChronoUnit.DAYS.between(ageAnchor, java.time.LocalDateTime.now())
+            if (ageInDays < 5) {
+                throw IllegalArgumentException(
+                    "Exception requests for individual vulnerabilities can only be submitted once the vulnerability is at least 5 days old. " +
+                    "This vulnerability was first seen ${ageInDays} day(s) ago."
+                )
+            }
+        }
+
         // Get requester user
         val requester = userRepository.findById(requesterUserId).orElseThrow {
             IllegalArgumentException("User with ID $requesterUserId not found")

--- a/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
+++ b/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
@@ -1232,6 +1232,7 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
           isOpen={showRequestModal}
           vulnerabilityId={selectedVulnerability.id}
           vulnerabilityCveId={selectedVulnerability.vulnerabilityId}
+          vulnerabilityFirstSeenAt={selectedVulnerability.firstSeenAt ?? selectedVulnerability.scanTimestamp}
           assetId={selectedVulnerability.assetId}
           assetIp={selectedVulnerability.assetIp}
           assetName={selectedVulnerability.assetName}

--- a/src/frontend/src/components/ExceptionRequestModal.tsx
+++ b/src/frontend/src/components/ExceptionRequestModal.tsx
@@ -30,6 +30,7 @@ interface ExceptionRequestModalProps {
     isOpen: boolean;
     vulnerabilityId: number;
     vulnerabilityCveId: string | null;
+    vulnerabilityFirstSeenAt: string | null;
     assetId?: number | null;
     assetIp?: string | null;
     assetCloudAccountId?: string | null;
@@ -45,10 +46,19 @@ const SCOPE_OPTIONS: ReadonlyArray<{ value: ExceptionScope; label: string; helpe
     { value: 'AWS_ACCOUNT', label: 'in a specific AWS account', helperKey: 'aws' }
 ];
 
+const MIN_VULNERABILITY_AGE_DAYS = 5;
+
+function getVulnerabilityAgeDays(firstSeenAt: string | null): number {
+    const anchor = firstSeenAt ? new Date(firstSeenAt) : null;
+    if (!anchor || isNaN(anchor.getTime())) return Number.MAX_SAFE_INTEGER;
+    return Math.floor((Date.now() - anchor.getTime()) / (1000 * 60 * 60 * 24));
+}
+
 const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
     isOpen,
     vulnerabilityId,
     vulnerabilityCveId,
+    vulnerabilityFirstSeenAt,
     assetId,
     assetIp,
     assetCloudAccountId,
@@ -56,6 +66,8 @@ const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
     onClose,
     onSuccess
 }) => {
+    const vulnerabilityAgeDays = getVulnerabilityAgeDays(vulnerabilityFirstSeenAt);
+    const isTooNew = vulnerabilityAgeDays < MIN_VULNERABILITY_AGE_DAYS;
     // Subject is always CVE in this modal (vulnerability-anchored flow).
     const [scope, setScope] = useState<ExceptionScope>('ASSET');
     const [scopeValue, setScopeValue] = useState<string>('');
@@ -289,6 +301,19 @@ const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
                         {/* Body */}
                         <form onSubmit={handleSubmit}>
                             <div className="modal-body">
+                                {/* Age guard — vulnerability must be at least 5 days old */}
+                                {isTooNew && (
+                                    <div className="alert alert-warning d-flex align-items-start" role="alert">
+                                        <i className="bi bi-clock-history me-2 mt-1 flex-shrink-0"></i>
+                                        <div>
+                                            <strong>Exception not available yet.</strong>
+                                            {' '}Exception requests can only be submitted once a vulnerability is at least {MIN_VULNERABILITY_AGE_DAYS} days old.
+                                            {' '}This vulnerability was first seen {vulnerabilityAgeDays} day{vulnerabilityAgeDays === 1 ? '' : 's'} ago.
+                                            {' '}Please try again in {MIN_VULNERABILITY_AGE_DAYS - vulnerabilityAgeDays} more day{MIN_VULNERABILITY_AGE_DAYS - vulnerabilityAgeDays === 1 ? '' : 's'}.
+                                        </div>
+                                    </div>
+                                )}
+
                                 {/* Error Alert */}
                                 {error && (
                                     <div className="alert alert-danger" role="alert">
@@ -499,7 +524,7 @@ const ExceptionRequestModal: React.FC<ExceptionRequestModalProps> = ({
                                 <button
                                     type="submit"
                                     className="btn btn-primary"
-                                    disabled={loading}
+                                    disabled={loading || isTooNew}
                                 >
                                     {loading ? (
                                         <>

--- a/src/frontend/src/services/vulnerabilityManagementService.ts
+++ b/src/frontend/src/services/vulnerabilityManagementService.ts
@@ -31,6 +31,7 @@ export interface CurrentVulnerability {
     vulnerableProductVersions: string | null;
     daysOpen: string | null;
     scanTimestamp: string;
+    firstSeenAt: string | null;
     hasException: boolean;
     exceptionReason: string | null;
     // Feature 021: Overdue status fields


### PR DESCRIPTION
Backend: validate in VulnerabilityExceptionRequestService.createRequest()
that finding-anchored requests use firstSeenAt (or scanTimestamp fallback)
and reject with IllegalArgumentException when age < 5 days.

Frontend: ExceptionRequestModal accepts vulnerabilityFirstSeenAt prop,
computes age client-side, shows a warning banner, and disables the submit
button when the vulnerability is too new. CurrentVulnerabilitiesTable
passes firstSeenAt ?? scanTimestamp. Added firstSeenAt to CurrentVulnerability
interface in vulnerabilityManagementService.ts.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hhtnq1hpwuqJS5CtiyPMW9