### PR TITLE
Pool exception-request notifications into scheduled digest emails

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -37,6 +37,14 @@ Resolution order (Micronaut): system properties → env vars → `application.ym
 
 Gmail requires an [App Password](https://support.google.com/accounts/answer/185833), not the account password.
 
+### Exception-request reviewer notifications
+| Var | Default | Notes |
+|---|---|---|
+| `EXCEPTION_NOTIFICATIONS_MODE` | `digest` | `digest`: pool new pending requests into one scheduled email per ADMIN/SECCHAMPION reviewer. `immediate`: legacy one-email-per-request blast (rollback). |
+| `EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL` | `1h` | Digest job interval (Micronaut duration: `15m`, `1h`, `24h`). Ignored in `immediate` mode. |
+
+In `digest` mode a burst of N exception requests produces a single digest per reviewer instead of N emails. Quiet intervals send nothing. Approval/rejection/expiration emails (single recipient) remain immediate.
+
 ### OAuth retry (race tolerance for fast Microsoft SSO)
 | Var | Default |
 |---|---|
@@ -179,6 +187,8 @@ SECMAN_AUTH_COOKIE_SECURE=true
 # MEMORY_LAZY_LOADING=true
 # MEMORY_BATCH_SIZE=1000
 # MEMORY_STREAMING_EXPORTS=true
+# EXCEPTION_NOTIFICATIONS_MODE=digest
+# EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL=1h
 # OAUTH_STATE_RETRY_MAX_ATTEMPTS=5
 # OAUTH_STATE_RETRY_INITIAL_DELAY=100
 # OAUTH_STATE_RETRY_MAX_DELAY=500

--- a/src/backendng/src/main/kotlin/com/secman/config/ExceptionNotificationConfig.kt
+++ b/src/backendng/src/main/kotlin/com/secman/config/ExceptionNotificationConfig.kt
@@ -1,0 +1,32 @@
+package com.secman.config
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Configuration for admin/secchampion notifications about new pending exception requests.
+ *
+ * Replaces the per-request email blast (one email per reviewer, per request) with a
+ * pooled, scheduled digest. When a user creates 100 exception requests in an hour, each
+ * reviewer receives a single consolidated digest instead of 100 emails.
+ *
+ * Environment variables:
+ * - EXCEPTION_NOTIFICATIONS_MODE (default: "digest"; "immediate" = legacy per-request)
+ * - EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL (default: "1h"; Micronaut duration, e.g. "15m", "24h")
+ *
+ * The interval is also referenced directly by the scheduler's @Scheduled(fixedDelay)
+ * annotation via property placeholder, since annotation values must be constants.
+ */
+@ConfigurationProperties("secman.exception-notifications")
+@Serdeable
+data class ExceptionNotificationConfig(
+    /**
+     * Delivery mode for new-pending-request notifications:
+     * - "digest"    (default): pool into a scheduled per-reviewer digest.
+     * - "immediate"          : legacy behaviour — one email per reviewer, per request.
+     *                          Retained as a rollback path.
+     */
+    var mode: String = "digest"
+) {
+    fun isDigestMode(): Boolean = !mode.equals("immediate", ignoreCase = true)
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/VulnerabilityExceptionRequest.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/VulnerabilityExceptionRequest.kt
@@ -64,7 +64,8 @@ import java.time.LocalDateTime
         Index(name = "idx_vuln_req_created", columnList = "created_at"),
         Index(name = "idx_vuln_req_expiration", columnList = "expiration_date"),
         Index(name = "idx_vuln_req_identity", columnList = "cve_id, asset_id, superseded"),
-        Index(name = "idx_vuln_req_subject_scope", columnList = "subject, scope")
+        Index(name = "idx_vuln_req_subject_scope", columnList = "subject, scope"),
+        Index(name = "idx_excreq_status_notified", columnList = "status, admin_notified_at")
     ]
 )
 @Serdeable
@@ -207,6 +208,15 @@ data class VulnerabilityExceptionRequest(
 
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime? = null,
+
+    /**
+     * When this request was included in an admin/secchampion digest email.
+     * NULL means a PENDING request has not yet been announced to reviewers.
+     * Set by ExceptionRequestDigestScheduler after the hourly digest is dispatched,
+     * so the same request is never re-announced. Replaces per-request email blasts.
+     */
+    @Column(name = "admin_notified_at")
+    var adminNotifiedAt: LocalDateTime? = null,
 
     /**
      * Denormalized CVE ID — copied from vulnerability.vulnerabilityId at creation time.

--- a/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
@@ -259,6 +259,20 @@ interface VulnerabilityExceptionRequestRepository : JpaRepository<VulnerabilityE
     ): Long
 
     /**
+     * Find requests with the given status that have not yet been announced to
+     * admins/secchampions (admin_notified_at IS NULL).
+     *
+     * Used by the hourly digest scheduler to collect newly-created PENDING requests
+     * for a single consolidated notification email, replacing per-request blasts.
+     *
+     * @param status Request status filter (PENDING)
+     * @return List of un-notified requests in creation order
+     */
+    fun findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(
+        status: ExceptionRequestStatus
+    ): List<VulnerabilityExceptionRequest>
+
+    /**
      * Nullify the requestedByUser reference when a user is deleted.
      * Preserves the request record without blocking user deletion via the
      * vulnerability_exception_request.requested_by_user_id → users.id FK.

--- a/src/backendng/src/main/kotlin/com/secman/scheduler/ExceptionRequestDigestScheduler.kt
+++ b/src/backendng/src/main/kotlin/com/secman/scheduler/ExceptionRequestDigestScheduler.kt
@@ -1,0 +1,95 @@
+package com.secman.scheduler
+
+import com.secman.config.ExceptionNotificationConfig
+import com.secman.domain.ExceptionRequestStatus
+import com.secman.repository.VulnerabilityExceptionRequestRepository
+import com.secman.service.ExceptionRequestNotificationService
+import io.micronaut.scheduling.annotation.Scheduled
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+
+/**
+ * Scheduled job that pools new pending exception requests into a single digest email
+ * per ADMIN/SECCHAMPION reviewer.
+ *
+ * **Problem**: previously every PENDING exception request triggered one email per reviewer
+ * (via ExceptionRequestNotificationListener.onCreatedPending). 100 requests => 100 emails
+ * per reviewer.
+ *
+ * **Fix**: in digest mode (the default), the listener no longer sends on creation. New
+ * requests stay with `admin_notified_at = NULL`. This job runs on a fixed interval
+ * (default hourly, EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL), collects all un-notified
+ * PENDING requests, sends one consolidated digest per reviewer, then stamps
+ * `admin_notified_at` so they are never re-announced. When there is nothing pending it
+ * sends nothing.
+ *
+ * Mirrors the structure of ExceptionExpirationScheduler.
+ */
+@Singleton
+open class ExceptionRequestDigestScheduler(
+    @Inject private val requestRepository: VulnerabilityExceptionRequestRepository,
+    @Inject private val notificationService: ExceptionRequestNotificationService,
+    @Inject private val notificationConfig: ExceptionNotificationConfig
+) {
+    private val logger = LoggerFactory.getLogger(ExceptionRequestDigestScheduler::class.java)
+
+    /**
+     * Collect un-notified PENDING requests and send one digest email per reviewer.
+     *
+     * **Schedule**: fixed delay, default 1h (EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL).
+     * The first run is delayed so the application finishes starting up first.
+     *
+     * **Idempotency**: requests are stamped with `admin_notified_at` once a send has been
+     * attempted with at least one success, matching the `successCount > 0` contract of the
+     * notification service. This avoids both re-announcing and tight resend loops on a
+     * transient SMTP failure (a fully-failed batch is retried on the next run).
+     */
+    @Scheduled(fixedDelay = "\${secman.exception-notifications.digest.interval:1h}", initialDelay = "2m")
+    @Transactional
+    open fun sendPendingDigest() {
+        if (!notificationConfig.isDigestMode()) {
+            logger.debug("Exception-notification mode is 'immediate'; skipping digest run")
+            return
+        }
+
+        try {
+            val pending = requestRepository.findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(
+                ExceptionRequestStatus.PENDING
+            )
+
+            if (pending.isEmpty()) {
+                logger.debug("No un-notified pending exception requests; no digest sent")
+                return
+            }
+
+            logger.info("Sending exception-request digest for {} pending request(s)", pending.size)
+
+            val sent = notificationService.notifyAdminsOfPendingDigest(pending).get()
+
+            if (sent) {
+                val now = LocalDateTime.now()
+                var stamped = 0
+                for (request in pending) {
+                    try {
+                        request.adminNotifiedAt = now
+                        requestRepository.update(request)
+                        stamped++
+                    } catch (e: Exception) {
+                        logger.error("Failed to stamp admin_notified_at for request {}: {}",
+                            request.id, e.message)
+                    }
+                }
+                logger.info("Exception-request digest sent; stamped {} request(s) as notified", stamped)
+            } else {
+                logger.warn("Exception-request digest send reported no successful deliveries; " +
+                    "leaving {} request(s) un-notified for retry on next run", pending.size)
+            }
+
+        } catch (e: Exception) {
+            logger.error("Failed to process exception-request digest", e)
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationListener.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationListener.kt
@@ -1,5 +1,6 @@
 package com.secman.service
 
+import com.secman.config.ExceptionNotificationConfig
 import com.secman.domain.ExceptionRequestApprovedEvent
 import com.secman.domain.ExceptionRequestCreatedPendingEvent
 import com.secman.domain.ExceptionRequestRejectedEvent
@@ -15,7 +16,8 @@ import org.slf4j.LoggerFactory
  */
 @Singleton
 open class ExceptionRequestNotificationListener(
-    private val notificationService: ExceptionRequestNotificationService
+    private val notificationService: ExceptionRequestNotificationService,
+    private val notificationConfig: ExceptionNotificationConfig
 ) {
     private val log = LoggerFactory.getLogger(ExceptionRequestNotificationListener::class.java)
 
@@ -41,6 +43,16 @@ open class ExceptionRequestNotificationListener(
 
     @TransactionalEventListener(TransactionPhase.AFTER_COMMIT)
     open fun onCreatedPending(event: ExceptionRequestCreatedPendingEvent) {
+        // Default (digest) mode: do nothing here — the request stays admin_notified_at=NULL
+        // and is picked up by ExceptionRequestDigestScheduler, which pools all new pending
+        // requests into a single per-reviewer email. This prevents the 100-requests =>
+        // 100-emails-per-reviewer flood. "immediate" mode preserves the legacy per-request
+        // blast as a rollback path.
+        if (notificationConfig.isDigestMode()) {
+            log.debug("Digest mode: deferring new-request notification for requestId={}",
+                event.request.id)
+            return
+        }
         try {
             notificationService.notifyAdminsOfNewRequest(event.request)
         } catch (e: Exception) {

--- a/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationService.kt
@@ -141,6 +141,103 @@ open class ExceptionRequestNotificationService(
     )
 
     /**
+     * Immutable snapshot of one request's display fields, resolved on the caller's
+     * transactional thread so the async send lambda never touches LAZY proxies.
+     */
+    private data class DigestRow(
+        val cveId: String,
+        val assetName: String,
+        val requester: String,
+        val submitted: String,
+        val expires: String
+    )
+
+    /**
+     * Send a single consolidated digest email to every ADMIN/SECCHAMPION user summarizing
+     * a batch of new pending exception requests.
+     *
+     * Called by ExceptionRequestDigestScheduler instead of the per-request blast, so that
+     * N new requests in a digest window collapse to one email per reviewer.
+     *
+     * @param requests The un-notified PENDING requests to announce (must be non-empty)
+     * @return CompletableFuture indicating if at least one email was sent successfully
+     */
+    open fun notifyAdminsOfPendingDigest(
+        requests: List<VulnerabilityExceptionRequest>
+    ): CompletableFuture<Boolean> {
+        // Resolve all Hibernate-backed fields on the caller's (transactional) thread so the
+        // async lambda never dereferences LAZY proxies from another thread. See the same
+        // guard in notifyAdminsOfNewRequest.
+        val rows: List<DigestRow> = requests.map { request ->
+            DigestRow(
+                cveId = request.vulnerability?.vulnerabilityId ?: request.cveId ?: "Unknown CVE",
+                assetName = request.vulnerability?.asset?.name ?: "Unknown Asset",
+                requester = request.requestedByUsername,
+                submitted = request.createdAt?.format(DATE_FORMATTER) ?: "Unknown",
+                expires = request.expirationDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+            )
+        }
+        val count = rows.size
+        val subject = "SecMan: $count new exception request${if (count == 1) "" else "s"} awaiting review"
+        val adminRecipients: List<AdminRecipient> = userRepository.findAll()
+            .filter { it.hasRole(User.Role.ADMIN) || it.hasRole(User.Role.SECCHAMPION) }
+            .map { user ->
+                AdminRecipient(
+                    email = user.email,
+                    username = user.username,
+                    htmlContent = generatePendingDigestEmail(rows, user.username),
+                    textContent = generatePendingDigestTextEmail(rows, user.username)
+                )
+            }
+        val inlineImages = loadLogoInlineImage()
+
+        return CompletableFuture.supplyAsync {
+            try {
+                logger.info("Sending pending-request digest for {} request(s) to {} reviewer(s)",
+                    count, adminRecipients.size)
+
+                if (adminRecipients.isEmpty()) {
+                    logger.warn("No ADMIN or SECCHAMPION users found to notify about {} pending request(s)", count)
+                    return@supplyAsync false
+                }
+
+                var successCount = 0
+                var failureCount = 0
+
+                for (recipient in adminRecipients) {
+                    try {
+                        val sent = emailService.sendEmailWithInlineImages(
+                            to = recipient.email,
+                            subject = subject,
+                            textContent = recipient.textContent,
+                            htmlContent = recipient.htmlContent,
+                            inlineImages = inlineImages
+                        ).get() // Block to ensure delivery attempt
+
+                        if (sent) {
+                            successCount++
+                            logger.debug("Sent pending-request digest to {}", recipient.email)
+                        } else {
+                            failureCount++
+                            logger.warn("Failed to send pending-request digest to {}", recipient.email)
+                        }
+                    } catch (e: Exception) {
+                        failureCount++
+                        logger.error("Error sending pending-request digest to {}: {}", recipient.email, e.message)
+                    }
+                }
+
+                logger.info("Pending-request digest sent: {} success, {} failures", successCount, failureCount)
+                return@supplyAsync successCount > 0
+
+            } catch (e: Exception) {
+                logger.error("Failed to send pending-request digest", e)
+                return@supplyAsync false
+            }
+        }
+    }
+
+    /**
      * Notify requester of request approval.
      *
      * Called after approveRequest() completes successfully.
@@ -426,6 +523,136 @@ open class ExceptionRequestNotificationService(
             |
             |--
             |This is an automated notification from SecMan. Please do not reply.
+        """.trimMargin()
+    }
+
+    /** Minimal HTML escaping for dynamic values rendered into the digest table cells. */
+    private fun escapeHtml(value: String): String =
+        value.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+
+    /**
+     * Generate the HTML digest email summarizing all new pending requests for one reviewer.
+     * One row per request in a compact table, with a single CTA to the approvals dashboard.
+     */
+    private fun generatePendingDigestEmail(rows: List<DigestRow>, recipientName: String): String {
+        val count = rows.size
+        val tableRows = rows.joinToString("\n") { row ->
+            """
+                                <tr>
+                                    <td style="padding:10px 12px;border:1px solid #e2e8f0;font-size:13px;font-family:'SF Mono','Consolas',monospace;color:#1f2933;">${escapeHtml(row.cveId)}</td>
+                                    <td style="padding:10px 12px;border:1px solid #e2e8f0;font-size:13px;color:#1f2933;">${escapeHtml(row.assetName)}</td>
+                                    <td style="padding:10px 12px;border:1px solid #e2e8f0;font-size:13px;color:#1f2933;">${escapeHtml(row.requester)}</td>
+                                    <td style="padding:10px 12px;border:1px solid #e2e8f0;font-size:13px;color:#475569;">${escapeHtml(row.submitted)}</td>
+                                    <td style="padding:10px 12px;border:1px solid #e2e8f0;font-size:13px;color:#475569;">${escapeHtml(row.expires)}</td>
+                                </tr>
+            """.trimIndent()
+        }
+        val plural = if (count == 1) "request" else "requests"
+
+        return """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>New Exception Requests</title>
+</head>
+<body style="margin:0;padding:0;background-color:#eef2f7;font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#1f2933;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#eef2f7;padding:32px 12px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="680" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff;border-radius:10px;overflow:hidden;box-shadow:0 4px 14px rgba(15,23,42,0.08);max-width:680px;">
+                    <tr>
+                        <td style="background-color:#1a3a6c;background-image:linear-gradient(135deg,#0f2447 0%,#1a3a6c 45%,#b1273a 100%);padding:28px 32px;">
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                                <tr>
+                                    <td valign="middle" style="width:72px;">
+                                        <img src="cid:secman-logo" alt="SecMan" width="60" height="60" style="display:block;border:0;background-color:#ffffff;border-radius:10px;padding:6px;">
+                                    </td>
+                                    <td valign="middle" style="padding-left:18px;">
+                                        <div style="color:#dbe5f5;font-size:12px;letter-spacing:1.4px;text-transform:uppercase;font-weight:600;">SecMan Risk Assessment</div>
+                                        <div style="color:#ffffff;font-size:22px;font-weight:600;margin-top:6px;line-height:1.25;">$count New Exception $plural Awaiting Review</div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="height:4px;line-height:4px;background-color:#dc3545;">&nbsp;</td>
+                    </tr>
+                    <tr>
+                        <td style="padding:28px 32px 8px 32px;">
+                            <p style="margin:0 0 14px 0;font-size:15px;line-height:1.5;">Hello <strong>$recipientName</strong>,</p>
+                            <p style="margin:0 0 22px 0;font-size:15px;line-height:1.5;color:#475569;">The following <strong>$count</strong> vulnerability exception $plural have been submitted and are awaiting your review.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:0 32px 8px 32px;">
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+                                <tr>
+                                    <th align="left" style="padding:10px 12px;background-color:#f7f9fc;border:1px solid #e2e8f0;font-size:11px;text-transform:uppercase;letter-spacing:0.6px;color:#475569;">CVE</th>
+                                    <th align="left" style="padding:10px 12px;background-color:#f7f9fc;border:1px solid #e2e8f0;font-size:11px;text-transform:uppercase;letter-spacing:0.6px;color:#475569;">Asset</th>
+                                    <th align="left" style="padding:10px 12px;background-color:#f7f9fc;border:1px solid #e2e8f0;font-size:11px;text-transform:uppercase;letter-spacing:0.6px;color:#475569;">Requested By</th>
+                                    <th align="left" style="padding:10px 12px;background-color:#f7f9fc;border:1px solid #e2e8f0;font-size:11px;text-transform:uppercase;letter-spacing:0.6px;color:#475569;">Submitted</th>
+                                    <th align="left" style="padding:10px 12px;background-color:#f7f9fc;border:1px solid #e2e8f0;font-size:11px;text-transform:uppercase;letter-spacing:0.6px;color:#475569;">Expires</th>
+                                </tr>
+$tableRows
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center" style="padding:28px 32px 32px 32px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                                <tr>
+                                    <td style="background-color:#1a3a6c;background-image:linear-gradient(135deg,#1a3a6c 0%,#2c5282 100%);border-radius:6px;">
+                                        <a href="${dashboardUrl()}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;letter-spacing:0.3px;">Review Requests &rarr;</a>
+                                    </td>
+                                </tr>
+                            </table>
+                            <p style="margin:14px 0 0 0;font-size:12px;color:#94a3b8;">Or open: <a href="${dashboardUrl()}" style="color:#1a3a6c;text-decoration:underline;">${dashboardUrl()}</a></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="background-color:#f7f9fc;padding:18px 32px;text-align:center;border-top:1px solid #e2e8f0;">
+                            <p style="margin:0;font-size:12px;color:#64748b;">This is an automated digest from <strong style="color:#475569;">SecMan</strong>. Please do not reply to this email.</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>
+        """.trimIndent()
+    }
+
+    /**
+     * Plain-text alternative for the pending-request digest (multipart/alternative MIME).
+     */
+    private fun generatePendingDigestTextEmail(rows: List<DigestRow>, recipientName: String): String {
+        val count = rows.size
+        val plural = if (count == 1) "request" else "requests"
+        val lines = rows.joinToString("\n") { row ->
+            "  - ${row.cveId} | ${row.assetName} | by ${row.requester} | submitted ${row.submitted} | expires ${row.expires}"
+        }
+        return """
+            |SecMan — $count New Exception $plural Awaiting Review
+            |====================================================
+            |
+            |Hello $recipientName,
+            |
+            |The following $count vulnerability exception $plural have been submitted and are awaiting your review:
+            |
+            |$lines
+            |
+            |Review the requests:
+            |  ${dashboardUrl()}
+            |
+            |--
+            |This is an automated digest from SecMan. Please do not reply.
         """.trimMargin()
     }
 

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -275,6 +275,14 @@ secman:
   # Cache is refreshed during materialized view refresh (after CLI import)
   statistics-cache:
     enabled: ${STATISTICS_CACHE_ENABLED:true}
+  # Admin/secchampion notifications about new pending exception requests.
+  # "digest" (default) pools new requests into one scheduled email per reviewer so a
+  # burst of N requests does not produce N emails. "immediate" restores the legacy
+  # per-request blast (rollback path). The interval accepts Micronaut durations (15m, 1h, 24h).
+  exception-notifications:
+    mode: ${EXCEPTION_NOTIFICATIONS_MODE:digest}
+    digest:
+      interval: ${EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL:1h}
   vulnerability:
     # Use patch publication date for calculating days open
     # When true: days_open = scan_timestamp - patch_publication_date

--- a/src/backendng/src/main/resources/db/migration/V234__exception_request_admin_notified_at.sql
+++ b/src/backendng/src/main/resources/db/migration/V234__exception_request_admin_notified_at.sql
@@ -1,0 +1,16 @@
+-- Pool & schedule admin/secchampion exception-request emails.
+-- admin_notified_at tracks whether a PENDING request has already been included in a
+-- digest email. NULL = not yet announced; the hourly digest scheduler picks those up,
+-- sends one consolidated email per reviewer, then stamps this column.
+ALTER TABLE vulnerability_exception_request
+    ADD COLUMN admin_notified_at DATETIME NULL AFTER updated_at;
+
+-- Backfill: treat every pre-existing request as already announced so the first digest
+-- run does not dump the entire historical backlog onto reviewers.
+UPDATE vulnerability_exception_request
+    SET admin_notified_at = COALESCE(created_at, NOW())
+    WHERE admin_notified_at IS NULL;
+
+-- Index supporting the digest query: find PENDING requests that are not yet notified.
+CREATE INDEX idx_excreq_status_notified
+    ON vulnerability_exception_request (status, admin_notified_at);

--- a/src/backendng/src/test/kotlin/com/secman/scheduler/ExceptionRequestDigestSchedulerTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/scheduler/ExceptionRequestDigestSchedulerTest.kt
@@ -1,0 +1,104 @@
+package com.secman.scheduler
+
+import com.secman.config.ExceptionNotificationConfig
+import com.secman.domain.ExceptionRequestStatus
+import com.secman.domain.VulnerabilityException
+import com.secman.domain.VulnerabilityExceptionRequest
+import com.secman.repository.VulnerabilityExceptionRequestRepository
+import com.secman.service.ExceptionRequestNotificationService
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+class ExceptionRequestDigestSchedulerTest {
+
+    private lateinit var repository: VulnerabilityExceptionRequestRepository
+    private lateinit var notificationService: ExceptionRequestNotificationService
+    private lateinit var scheduler: ExceptionRequestDigestScheduler
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        notificationService = mockk()
+    }
+
+    private fun newScheduler(mode: String) {
+        scheduler = ExceptionRequestDigestScheduler(
+            repository, notificationService, ExceptionNotificationConfig(mode = mode)
+        )
+    }
+
+    private fun request(cve: String): VulnerabilityExceptionRequest =
+        VulnerabilityExceptionRequest(
+            requestedByUsername = "alice",
+            subject = VulnerabilityException.Subject.CVE,
+            scope = VulnerabilityException.Scope.ASSET,
+            reason = "A sufficiently long business justification that satisfies the minimum length rule.",
+            expirationDate = LocalDateTime.now().plusDays(30),
+            status = ExceptionRequestStatus.PENDING,
+            cveId = cve,
+            assetId = 1L
+        ).apply { createdAt = LocalDateTime.of(2026, 6, 18, 9, 0) }
+
+    @Test
+    fun `stamps adminNotifiedAt and dispatches digest when pending requests exist`() {
+        newScheduler("digest")
+        val pending = listOf(request("CVE-1"), request("CVE-2"))
+        every {
+            repository.findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(ExceptionRequestStatus.PENDING)
+        } returns pending
+        every { notificationService.notifyAdminsOfPendingDigest(pending) } returns
+            CompletableFuture.completedFuture(true)
+
+        scheduler.sendPendingDigest()
+
+        verify(exactly = 1) { notificationService.notifyAdminsOfPendingDigest(pending) }
+        pending.forEach { assertNotNull(it.adminNotifiedAt) }
+        verify(exactly = 2) { repository.update(any<VulnerabilityExceptionRequest>()) }
+    }
+
+    @Test
+    fun `does nothing when there are no un-notified pending requests`() {
+        newScheduler("digest")
+        every {
+            repository.findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(ExceptionRequestStatus.PENDING)
+        } returns emptyList()
+
+        scheduler.sendPendingDigest()
+
+        verify(exactly = 0) { notificationService.notifyAdminsOfPendingDigest(any()) }
+        verify(exactly = 0) { repository.update(any<VulnerabilityExceptionRequest>()) }
+    }
+
+    @Test
+    fun `leaves requests un-notified for retry when digest send fails`() {
+        newScheduler("digest")
+        val pending = listOf(request("CVE-1"))
+        every {
+            repository.findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(ExceptionRequestStatus.PENDING)
+        } returns pending
+        every { notificationService.notifyAdminsOfPendingDigest(pending) } returns
+            CompletableFuture.completedFuture(false)
+
+        scheduler.sendPendingDigest()
+
+        assertNull(pending[0].adminNotifiedAt)
+        verify(exactly = 0) { repository.update(any<VulnerabilityExceptionRequest>()) }
+    }
+
+    @Test
+    fun `skips entirely in immediate mode`() {
+        newScheduler("immediate")
+
+        scheduler.sendPendingDigest()
+
+        verify(exactly = 0) {
+            repository.findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt(any())
+        }
+        verify(exactly = 0) { notificationService.notifyAdminsOfPendingDigest(any()) }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/ExceptionRequestNotificationDigestTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/ExceptionRequestNotificationDigestTest.kt
@@ -1,0 +1,139 @@
+package com.secman.service
+
+import com.secman.config.AppConfig
+import com.secman.config.BackendConfig
+import com.secman.domain.Asset
+import com.secman.domain.ExceptionRequestStatus
+import com.secman.domain.User
+import com.secman.domain.Vulnerability
+import com.secman.domain.VulnerabilityException
+import com.secman.domain.VulnerabilityExceptionRequest
+import com.secman.repository.UserRepository
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Unit tests for the pooled digest path: ExceptionRequestNotificationService.notifyAdminsOfPendingDigest.
+ *
+ * Verifies the core anti-flood property: N pending requests collapse to ONE email per
+ * ADMIN/SECCHAMPION reviewer (not N).
+ */
+class ExceptionRequestNotificationDigestTest {
+
+    private lateinit var emailService: EmailService
+    private lateinit var userRepository: UserRepository
+    private lateinit var appConfig: AppConfig
+    private lateinit var service: ExceptionRequestNotificationService
+
+    @BeforeEach
+    fun setUp() {
+        emailService = mockk(relaxed = false)
+        userRepository = mockk()
+        appConfig = mockk()
+        val backendCfg = mockk<BackendConfig>()
+        every { backendCfg.baseUrl } returns "https://secman.example.com/"
+        every { appConfig.backend } returns backendCfg
+        service = ExceptionRequestNotificationService(emailService, userRepository, appConfig)
+    }
+
+    private fun user(name: String, role: User.Role) = User(
+        username = name,
+        email = "$name@example.com",
+        passwordHash = "x",
+        roles = mutableSetOf(role)
+    )
+
+    private fun request(cve: String, asset: String, requester: String): VulnerabilityExceptionRequest {
+        val assetEntity = Asset(name = asset, type = "SERVER", owner = "owner")
+        val vuln = Vulnerability(
+            asset = assetEntity,
+            vulnerabilityId = cve,
+            scanTimestamp = LocalDateTime.of(2026, 6, 18, 8, 0)
+        )
+        return VulnerabilityExceptionRequest(
+            requestedByUsername = requester,
+            subject = VulnerabilityException.Subject.CVE,
+            scope = VulnerabilityException.Scope.ASSET,
+            reason = "A sufficiently long business justification that satisfies the minimum length rule.",
+            expirationDate = LocalDateTime.now().plusDays(30),
+            status = ExceptionRequestStatus.PENDING,
+            cveId = cve,
+            assetId = 1L,
+            vulnerability = vuln
+        ).apply { createdAt = LocalDateTime.of(2026, 6, 18, 9, 0) }
+    }
+
+    @Test
+    fun `sends exactly one digest email per reviewer regardless of request count`() {
+        every { userRepository.findAll() } returns listOf(
+            user("admin", User.Role.ADMIN),
+            user("champ", User.Role.SECCHAMPION),
+            user("regular", User.Role.USER) // must be excluded
+        )
+        every {
+            emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any())
+        } returns CompletableFuture.completedFuture(true)
+
+        val requests = (1..100).map { request("CVE-2026-$it", "asset-$it", "alice") }
+
+        val result = service.notifyAdminsOfPendingDigest(requests).get()
+
+        assertTrue(result)
+        // 100 requests -> exactly 2 emails (one per ADMIN + SECCHAMPION), NOT 200.
+        verify(exactly = 2) { emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `digest body lists every request and a correct count`() {
+        every { userRepository.findAll() } returns listOf(user("admin", User.Role.ADMIN))
+        val subjectSlot = slot<String>()
+        val textSlot = slot<String>()
+        val htmlSlot = slot<String>()
+        every {
+            emailService.sendEmailWithInlineImages(any(), capture(subjectSlot), capture(textSlot), capture(htmlSlot), any())
+        } returns CompletableFuture.completedFuture(true)
+
+        val requests = listOf(
+            request("CVE-2026-1", "web-01", "alice"),
+            request("CVE-2026-2", "db-02", "bob")
+        )
+
+        service.notifyAdminsOfPendingDigest(requests).get()
+
+        assertTrue(subjectSlot.captured.contains("2 new exception requests"))
+        for (body in listOf(textSlot.captured, htmlSlot.captured)) {
+            assertTrue(body.contains("CVE-2026-1")) { "missing CVE-2026-1 in: $body" }
+            assertTrue(body.contains("CVE-2026-2")) { "missing CVE-2026-2 in: $body" }
+            assertTrue(body.contains("web-01")) { "missing web-01 in: $body" }
+            assertTrue(body.contains("db-02")) { "missing db-02 in: $body" }
+        }
+    }
+
+    @Test
+    fun `single request uses singular subject wording`() {
+        every { userRepository.findAll() } returns listOf(user("admin", User.Role.ADMIN))
+        val subjectSlot = slot<String>()
+        every {
+            emailService.sendEmailWithInlineImages(any(), capture(subjectSlot), any(), any(), any())
+        } returns CompletableFuture.completedFuture(true)
+
+        service.notifyAdminsOfPendingDigest(listOf(request("CVE-2026-9", "host", "carol"))).get()
+
+        assertTrue(subjectSlot.captured.contains("1 new exception request awaiting"))
+    }
+
+    @Test
+    fun `returns false and sends nothing when no admins or secchampions exist`() {
+        every { userRepository.findAll() } returns listOf(user("regular", User.Role.USER))
+
+        val result = service.notifyAdminsOfPendingDigest(listOf(request("CVE-1", "a", "x"))).get()
+
+        assertFalse(result)
+        verify(exactly = 0) { emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the per-request email blast for new pending exception requests with a pooled, scheduled digest. Previously, each new PENDING request triggered one email per ADMIN/SECCHAMPION reviewer. Now, a burst of N requests in a digest window (default 1 hour) collapses to a single consolidated email per reviewer, dramatically reducing notification spam.

## Key Changes

- **New `ExceptionRequestDigestScheduler`**: scheduled job (default hourly) that collects un-notified PENDING requests and sends one consolidated digest email per ADMIN/SECCHAMPION reviewer via the new `notifyAdminsOfPendingDigest()` method.

- **New `ExceptionNotificationConfig`**: configuration class supporting two modes:
  - `digest` (default): pooled, scheduled delivery
  - `immediate`: legacy per-request blast (rollback path)
  
  Configurable via `EXCEPTION_NOTIFICATIONS_MODE` and `EXCEPTION_NOTIFICATIONS_DIGEST_INTERVAL` environment variables.

- **Database schema**: added `admin_notified_at` column to `vulnerability_exception_request` to track whether a request has been included in a digest. Backfilled with creation timestamp to avoid dumping historical backlog on first run. Added supporting index `idx_excreq_status_notified`.

- **Notification service enhancements**:
  - New `notifyAdminsOfPendingDigest(requests)` method that resolves all Hibernate-backed fields on the caller's transactional thread (preventing lazy-proxy dereference in async lambda).
  - New `DigestRow` immutable snapshot class for safe async serialization.
  - New `generatePendingDigestEmail()` and `generatePendingDigestTextEmail()` methods with styled HTML table and plain-text alternatives.
  - New `escapeHtml()` utility for safe dynamic content rendering.

- **Event listener update**: `ExceptionRequestNotificationListener.onCreatedPending()` now respects the notification mode—in digest mode, it skips the immediate per-request email and lets the scheduler handle it.

- **Repository query**: new `findByStatusAndAdminNotifiedAtIsNullOrderByCreatedAt()` method to fetch un-notified PENDING requests in creation order.

- **Comprehensive test coverage**:
  - `ExceptionRequestNotificationDigestTest`: verifies N requests collapse to one email per reviewer, correct subject/body content, singular/plural wording, and no-op when no admins exist.
  - `ExceptionRequestDigestSchedulerTest`: verifies stamping of `admin_notified_at`, idempotency on send failure, and mode-aware skipping.

- **Documentation**: updated `ENVIRONMENT.md` and `application.yml` with new configuration options and digest mode explanation.

## Implementation Details

- **Thread safety**: all Hibernate-backed fields (CVE ID, asset name, requester, timestamps) are resolved on the transactional thread before the async send lambda runs, preventing lazy-proxy dereference errors.
- **Idempotency**: requests are stamped with `admin_notified_at` only after at least one successful email delivery (`successCount > 0`), matching the service contract. Fully-failed batches are retried on the next scheduler run.
- **Backfill strategy**: pre-existing requests are backfilled with `admin_notified_at = created_at` to prevent the first digest run from re-announcing the entire historical backlog.
- **Rollback path**: `immediate` mode restores legacy per-request behavior for quick rollback if needed.

https://claude.ai/code/session_01Sk7yVU41pzTE5dpFMug2Z7