### PR TITLE
Fan out outdated-asset notifications to all account recipients

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -143,6 +143,22 @@ Existing assets start with `crowdstrike_last_imported_at = NULL` after the schem
 | `--verbose` | false | per-asset detail |
 | `--outdated-only` | false | skip new-vuln notifications |
 
+For each outdated asset (an asset with overdue vulnerabilities), the recipients are
+the deduplicated, case-insensitive union of — keyed on the asset's AWS account
+(`cloud_account_id`):
+
+1. **AWS account owner(s)** — every `UserMapping` row whose `aws_account_id` matches
+   the account (plus, for backward compatibility, the legacy `asset.owner` lookup).
+2. **Workgroup members** — every member of any workgroup that contains an asset in
+   the account (asset → workgroup → users).
+3. **Sharing recipients** — every user granted access to the account via the AWS
+   Account Sharing feature (directional, honoring per-rule account selection).
+
+This mirrors the `send-notification-users` recipient fan-out. Each recipient receives
+one consolidated email covering all outdated assets they can access; an asset is
+notified at most once per day regardless of how many recipients it reaches. An asset
+with no recipients in any category is skipped (logged with `--verbose`).
+
 ### `send-notification-users` — per-AWS-account vulnerability emails
 
 Finds AWS accounts whose EC2 assets have vulnerabilities open longer than

--- a/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
@@ -4,6 +4,7 @@ import com.secman.repository.AssetRepository
 import com.secman.repository.OutdatedAssetMaterializedViewRepository
 import com.secman.repository.UserMappingRepository
 import com.secman.service.AdminSummaryService
+import com.secman.service.AwsAccountRecipientResolver
 import com.secman.service.NewAccountNotificationService
 import com.secman.service.NotificationService
 import com.secman.service.UserMappingStatisticsService
@@ -41,7 +42,8 @@ class CliController(
     private val userVulnerabilityNotificationService: UserVulnerabilityNotificationService,
     private val userMappingStatisticsService: UserMappingStatisticsService,
     private val applicationRegisterReminderService: ApplicationRegisterReminderService,
-    private val newAccountNotificationService: NewAccountNotificationService
+    private val newAccountNotificationService: NewAccountNotificationService,
+    private val recipientResolver: AwsAccountRecipientResolver
 ) {
     private val logger = LoggerFactory.getLogger(CliController::class.java)
 
@@ -116,13 +118,23 @@ class CliController(
                 return@forEach
             }
 
-            val userMappings = userMappingRepository.findByAwsAccountId(asset.owner)
-            if (userMappings.isEmpty()) {
-                if (verbose) logger.warn("No email found for AWS account {}, skipping asset {}", asset.owner, asset.name)
-                return@forEach
+            // Resolve the full recipient set for this asset (deduped, case-insensitive):
+            //  - workgroup members + AWS-account-sharing targets + owner mapping, keyed on
+            //    the canonical cloudAccountId (also covers CrowdStrike-imported assets), and
+            //  - the legacy owner-mapping lookup (asset.owner) for backward compatibility.
+            val recipients = mutableSetOf<String>()
+            recipients.addAll(recipientResolver.resolveAwsAccountRecipients(asset.cloudAccountId ?: ""))
+            userMappingRepository.findByAwsAccountId(asset.owner).forEach { mapping ->
+                recipients.add(mapping.email.lowercase())
             }
 
-            val ownerEmail = userMappings.first().email
+            if (recipients.isEmpty()) {
+                if (verbose) logger.warn(
+                    "No recipients found for asset {} (account={}, owner={}), skipping",
+                    asset.name, asset.cloudAccountId, asset.owner
+                )
+                return@forEach
+            }
 
             val severity = when {
                 view.criticalCount > 0 -> "CRITICAL"
@@ -133,22 +145,26 @@ class CliController(
 
             val criticality = asset.getEffectiveCriticality().name
 
-            results.add(
-                NotificationService.OutdatedAssetData(
-                    assetId = view.assetId,
-                    assetName = view.assetName,
-                    assetType = view.assetType,
-                    ownerEmail = ownerEmail,
-                    vulnerabilityCount = view.totalOverdueCount,
-                    oldestVulnDays = view.oldestVulnDays,
-                    oldestVulnId = view.oldestVulnId ?: "unknown",
-                    severity = severity,
-                    criticality = criticality
+            // Emit one row per (recipient, asset). NotificationService groups by recipient
+            // email and sends each recipient a single consolidated email.
+            recipients.forEach { recipientEmail ->
+                results.add(
+                    NotificationService.OutdatedAssetData(
+                        assetId = view.assetId,
+                        assetName = view.assetName,
+                        assetType = view.assetType,
+                        ownerEmail = recipientEmail,
+                        vulnerabilityCount = view.totalOverdueCount,
+                        oldestVulnDays = view.oldestVulnDays,
+                        oldestVulnId = view.oldestVulnId ?: "unknown",
+                        severity = severity,
+                        criticality = criticality
+                    )
                 )
-            )
+            }
         }
 
-        logger.info("Mapped {} outdated assets with owner emails", results.size)
+        logger.info("Mapped {} outdated-asset notifications across recipients", results.size)
         return results
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/AwsAccountRecipientResolver.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AwsAccountRecipientResolver.kt
@@ -1,0 +1,55 @@
+package com.secman.service
+
+import com.secman.repository.AssetRepository
+import com.secman.repository.UserMappingRepository
+import jakarta.inject.Singleton
+
+/**
+ * Resolves the full set of recipient emails who should be notified about
+ * vulnerabilities/outdated assets belonging to a given AWS account.
+ *
+ * Single source of truth for vulnerability-notification recipient fan-out,
+ * shared by both notification flows:
+ *  - overdue vulnerabilities (UserVulnerabilityNotificationService)
+ *  - outdated assets (NotificationService via CliController)
+ *
+ * Recipients are the deduplicated, case-insensitive union of:
+ *  1. The AWS account owner(s) — direct UserMapping rows for the account.
+ *  2. Members of any workgroup that contains an asset in the account
+ *     (asset → workgroup → users).
+ *  3. Users granted access to the account via the AWS sharing feature
+ *     (directional, honoring per-rule account selection).
+ */
+@Singleton
+open class AwsAccountRecipientResolver(
+    private val userMappingRepository: UserMappingRepository,
+    private val assetRepository: AssetRepository,
+    private val awsAccountSharingService: AwsAccountSharingService
+) {
+    /**
+     * @param awsAccountId the AWS account id (asset.cloudAccountId). Blank input
+     *   yields an empty set — no recipients can be resolved without an account.
+     */
+    open fun resolveAwsAccountRecipients(awsAccountId: String): Set<String> {
+        if (awsAccountId.isBlank()) return emptySet()
+
+        val recipients = mutableSetOf<String>()
+
+        // 1. AWS account owner(s) via direct UserMapping
+        userMappingRepository.findByAwsAccountId(awsAccountId).forEach { mapping ->
+            recipients.add(mapping.email.lowercase())
+        }
+
+        // 2. Members of workgroups that contain an asset in this account
+        assetRepository.findDistinctWorkgroupMemberEmailsByCloudAccountId(awsAccountId).forEach { email ->
+            recipients.add(email.lowercase())
+        }
+
+        // 3. Users with access to the account via the sharing feature
+        awsAccountSharingService.getTargetUserEmailsForAwsAccount(awsAccountId).forEach { email ->
+            recipients.add(email.lowercase())
+        }
+
+        return recipients
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/NotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/NotificationService.kt
@@ -43,36 +43,50 @@ class NotificationService(
         logger.info("Processing ${outdatedAssets.size} outdated assets (dry-run: $dryRun)")
 
         val assetsByOwner = aggregateByOwner(outdatedAssets)
-        logger.info("Aggregated into ${assetsByOwner.size} owners")
+        logger.info("Aggregated into ${assetsByOwner.size} recipients")
+
+        // Duplicate-prevention and reminder-level progression are tracked PER ASSET, but a
+        // single asset can now fan out to multiple recipients (owner mapping + workgroup
+        // members + AWS-account-sharing targets). Evaluate "already sent today" and the
+        // reminder level ONCE per distinct asset, up front, before any send updates the
+        // per-asset lastSentAt — otherwise notifying the first recipient would silently
+        // suppress the same asset for every other recipient who shares it.
+        val distinctAssetIds = outdatedAssets.map { it.assetId }.toSet()
+        val levelByAssetId = mutableMapOf<Long, Int>()
+        val eligibleAssetIds = mutableSetOf<Long>()
+        distinctAssetIds.forEach { assetId ->
+            val state = reminderStateService.getOrCreateReminderState(assetId, true)
+            levelByAssetId[assetId] = state?.level ?: 1
+            if (reminderStateService.shouldSendToday(assetId)) {
+                eligibleAssetIds.add(assetId)
+            }
+        }
 
         var emailsSent = 0
         var failures = 0
         val skipped = mutableListOf<String>()
+        // Assets successfully delivered to at least one recipient — marked sent-today once,
+        // after all recipients are processed.
+        val sentAssetIds = mutableSetOf<Long>()
 
         assetsByOwner.forEach { (ownerEmail, assets) ->
             if (ownerEmail.isBlank()) {
-                logger.warn("Skipping assets with blank owner email")
+                logger.warn("Skipping assets with blank recipient email")
                 skipped.add("blank email")
                 return@forEach
             }
 
+            // Only assets not already notified today (across all recipients) are sent.
+            val eligibleAssets = assets.filter { eligibleAssetIds.contains(it.assetId) }
+            if (eligibleAssets.isEmpty()) {
+                logger.info("Skipping $ownerEmail - no assets eligible to send today")
+                skipped.add(ownerEmail)
+                return@forEach
+            }
+
             try {
-                // Determine reminder level for each asset
-                val assetsWithLevels = assets.map { asset ->
-                    val state = reminderStateService.getOrCreateReminderState(asset.assetId, true)
-                    asset to (state?.level ?: 1)
-                }
-
-                // Check if we should send today (duplicate prevention)
-                val firstAsset = assets.first()
-                if (!reminderStateService.shouldSendToday(firstAsset.assetId)) {
-                    logger.info("Skipping $ownerEmail - already notified today")
-                    skipped.add(ownerEmail)
-                    return@forEach
-                }
-
                 // Determine which reminder level to use (use highest level)
-                val maxLevel = assetsWithLevels.maxOf { it.second }
+                val maxLevel = eligibleAssets.maxOf { levelByAssetId[it.assetId] ?: 1 }
                 val notificationType = if (maxLevel == 2) {
                     NotificationType.OUTDATED_LEVEL2
                 } else {
@@ -80,12 +94,10 @@ class NotificationService(
                 }
 
                 if (dryRun) {
-                    logger.info("[DRY-RUN] Would send $notificationType to $ownerEmail for ${assets.size} assets")
+                    logger.info("[DRY-RUN] Would send $notificationType to $ownerEmail for ${eligibleAssets.size} assets")
                 } else {
-                    sendOutdatedReminder(ownerEmail, assets, notificationType)
-                    assets.forEach { asset ->
-                        reminderStateService.updateLastSent(asset.assetId)
-                    }
+                    sendOutdatedReminder(ownerEmail, eligibleAssets, notificationType)
+                    sentAssetIds.addAll(eligibleAssets.map { it.assetId })
                 }
 
                 emailsSent++
@@ -96,14 +108,20 @@ class NotificationService(
                 if (!dryRun) {
                     // Log failure for first asset (representative)
                     notificationLogService.logFailure(
-                        assetId = assets.first().assetId,
-                        assetName = assets.first().assetName,
+                        assetId = eligibleAssets.first().assetId,
+                        assetName = eligibleAssets.first().assetName,
                         ownerEmail = ownerEmail,
                         notificationType = NotificationType.OUTDATED_LEVEL1,
                         errorMessage = e.message ?: "Unknown error"
                     )
                 }
             }
+        }
+
+        // Mark each delivered asset as sent exactly once, regardless of how many
+        // recipients it fanned out to.
+        if (!dryRun) {
+            sentAssetIds.forEach { reminderStateService.updateLastSent(it) }
         }
 
         // Send notifications to users with REPORT role

--- a/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
@@ -3,7 +3,6 @@ package com.secman.service
 import com.secman.config.AppConfig
 import com.secman.domain.ExecutionStatus
 import com.secman.domain.User
-import com.secman.repository.AssetRepository
 import com.secman.repository.ExceptionMatchSql
 import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
@@ -29,7 +28,7 @@ open class UserVulnerabilityNotificationService(
     private val userRepository: UserRepository,
     private val emailService: EmailService,
     private val awsAccountSharingService: AwsAccountSharingService,
-    private val assetRepository: AssetRepository,
+    private val recipientResolver: AwsAccountRecipientResolver,
     private val appConfig: AppConfig
 ) {
     private val logger = LoggerFactory.getLogger(UserVulnerabilityNotificationService::class.java)
@@ -357,26 +356,8 @@ open class UserVulnerabilityNotificationService(
      * 3. Users granted access to the account via the AWS sharing feature
      *    (directional, honoring per-rule account selection).
      */
-    private fun resolveAccountRecipients(awsAccountId: String): Set<String> {
-        val recipients = mutableSetOf<String>()
-
-        // 1. AWS account owner(s) via direct UserMapping
-        userMappingRepository.findByAwsAccountId(awsAccountId).forEach { mapping ->
-            recipients.add(mapping.email.lowercase())
-        }
-
-        // 2. Members of workgroups that contain an EC2 asset in this account
-        assetRepository.findDistinctWorkgroupMemberEmailsByCloudAccountId(awsAccountId).forEach { email ->
-            recipients.add(email.lowercase())
-        }
-
-        // 3. Users with access to the account via the sharing feature
-        awsAccountSharingService.getTargetUserEmailsForAwsAccount(awsAccountId).forEach { email ->
-            recipients.add(email.lowercase())
-        }
-
-        return recipients
-    }
+    private fun resolveAccountRecipients(awsAccountId: String): Set<String> =
+        recipientResolver.resolveAwsAccountRecipients(awsAccountId)
 
     private fun resolveScope(notificationUser: String?): NotificationScope {
         if (notificationUser.isNullOrBlank()) {

--- a/src/backendng/src/test/kotlin/com/secman/service/AwsAccountRecipientResolverTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AwsAccountRecipientResolverTest.kt
@@ -1,0 +1,61 @@
+package com.secman.service
+
+import com.secman.domain.UserMapping
+import com.secman.repository.AssetRepository
+import com.secman.repository.UserMappingRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AwsAccountRecipientResolverTest {
+
+    private val userMappingRepository = mockk<UserMappingRepository>(relaxed = true)
+    private val assetRepository = mockk<AssetRepository>(relaxed = true)
+    private val awsAccountSharingService = mockk<AwsAccountSharingService>(relaxed = true)
+    private val resolver = AwsAccountRecipientResolver(
+        userMappingRepository = userMappingRepository,
+        assetRepository = assetRepository,
+        awsAccountSharingService = awsAccountSharingService
+    )
+
+    @Test
+    fun `unions owners, workgroup members and sharing targets, deduped case-insensitively`() {
+        every { userMappingRepository.findByAwsAccountId("123456789012") } returns listOf(
+            UserMapping(email = "Owner@example.com", awsAccountId = "123456789012", domain = null)
+        )
+        every { assetRepository.findDistinctWorkgroupMemberEmailsByCloudAccountId("123456789012") } returns
+            listOf("wg-member@example.com", "OWNER@example.com")
+        every { awsAccountSharingService.getTargetUserEmailsForAwsAccount("123456789012") } returns
+            listOf("Shared-User@example.com")
+
+        val recipients = resolver.resolveAwsAccountRecipients("123456789012")
+
+        assertThat(recipients).containsExactlyInAnyOrder(
+            "owner@example.com", "wg-member@example.com", "shared-user@example.com"
+        )
+    }
+
+    @Test
+    fun `returns workgroup members even without an owner mapping`() {
+        every { userMappingRepository.findByAwsAccountId("444444444444") } returns emptyList()
+        every { assetRepository.findDistinctWorkgroupMemberEmailsByCloudAccountId("444444444444") } returns
+            listOf("wg-only@example.com")
+        every { awsAccountSharingService.getTargetUserEmailsForAwsAccount("444444444444") } returns emptyList()
+
+        val recipients = resolver.resolveAwsAccountRecipients("444444444444")
+
+        assertThat(recipients).containsExactly("wg-only@example.com")
+    }
+
+    @Test
+    fun `blank account id yields no recipients and skips all lookups`() {
+        val recipients = resolver.resolveAwsAccountRecipients("")
+
+        assertThat(recipients).isEmpty()
+        verify(exactly = 0) { userMappingRepository.findByAwsAccountId(any()) }
+        verify(exactly = 0) { assetRepository.findDistinctWorkgroupMemberEmailsByCloudAccountId(any()) }
+        verify(exactly = 0) { awsAccountSharingService.getTargetUserEmailsForAwsAccount(any()) }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/NotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/NotificationServiceTest.kt
@@ -1,0 +1,120 @@
+package com.secman.service
+
+import com.secman.domain.AssetReminderState
+import com.secman.domain.User
+import com.secman.repository.AssetReminderStateRepository
+import com.secman.repository.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Covers the outdated-asset fan-out: a single asset can now notify multiple recipients
+ * (owner mapping + workgroup members + AWS-account-sharing targets), and the per-asset
+ * "already sent today" gate must not let one recipient's send suppress the same asset
+ * for another recipient.
+ */
+class NotificationServiceTest {
+
+    private val emailTemplateService = mockk<EmailTemplateService>(relaxed = true)
+    private val reminderStateService = mockk<ReminderStateService>(relaxed = true)
+    private val notificationLogService = mockk<NotificationLogService>(relaxed = true)
+    private val emailSender = mockk<EmailSender>(relaxed = true)
+    private val assetReminderStateRepository = mockk<AssetReminderStateRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+
+    private val service = NotificationService(
+        emailTemplateService = emailTemplateService,
+        reminderStateService = reminderStateService,
+        notificationLogService = notificationLogService,
+        emailSender = emailSender,
+        assetReminderStateRepository = assetReminderStateRepository,
+        userRepository = userRepository
+    )
+
+    @BeforeEach
+    fun setUp() {
+        every { reminderStateService.getOrCreateReminderState(any(), any()) } answers {
+            AssetReminderState(
+                assetId = firstArg<Long>(),
+                level = 1,
+                lastSentAt = Instant.EPOCH,
+                outdatedSince = Instant.now()
+            )
+        }
+        every { reminderStateService.shouldSendToday(any()) } returns true
+        every { emailSender.sendEmail(any()) } returns EmailSender.SendResult(success = true, attemptCount = 1)
+        // Keep the REPORT-role fan-out out of these assertions.
+        every { userRepository.findByRolesContaining(User.Role.REPORT) } returns emptyList()
+    }
+
+    private fun outdated(assetId: Long, recipient: String) = NotificationService.OutdatedAssetData(
+        assetId = assetId,
+        assetName = "asset-$assetId",
+        assetType = "EC2",
+        ownerEmail = recipient,
+        vulnerabilityCount = 1,
+        oldestVulnDays = 45,
+        oldestVulnId = "CVE-2026-0001",
+        severity = "CRITICAL",
+        criticality = "HIGH"
+    )
+
+    @Test
+    fun `shared asset notifies every recipient and is not suppressed for the second recipient`() {
+        val sent = mutableListOf<EmailSender.EmailMessage>()
+        every { emailSender.sendEmail(capture(sent)) } returns EmailSender.SendResult(success = true, attemptCount = 1)
+
+        // Asset 1 fans out to both recipients; recipient a also owns asset 2.
+        val data = listOf(
+            outdated(1, "a@example.com"),
+            outdated(1, "b@example.com"),
+            outdated(2, "a@example.com")
+        )
+
+        val result = service.processOutdatedAssets(data, dryRun = false)
+
+        assertThat(result.emailsSent).isEqualTo(2)
+        assertThat(result.failures).isEqualTo(0)
+        assertThat(sent.map { it.to }).containsExactlyInAnyOrder("a@example.com", "b@example.com")
+        // Duplicate-prevention is per-asset-once: updateLastSent fires once per asset, not per recipient.
+        verify(exactly = 1) { reminderStateService.updateLastSent(1) }
+        verify(exactly = 1) { reminderStateService.updateLastSent(2) }
+    }
+
+    @Test
+    fun `dry run reports every recipient and never sends or marks sent`() {
+        val data = listOf(
+            outdated(1, "a@example.com"),
+            outdated(1, "b@example.com")
+        )
+
+        val result = service.processOutdatedAssets(data, dryRun = true)
+
+        assertThat(result.emailsSent).isEqualTo(2)
+        verify(exactly = 0) { emailSender.sendEmail(any()) }
+        verify(exactly = 0) { reminderStateService.updateLastSent(any()) }
+    }
+
+    @Test
+    fun `asset already sent today is skipped for all of its recipients`() {
+        every { reminderStateService.shouldSendToday(1) } returns false
+
+        val data = listOf(
+            outdated(1, "a@example.com"),
+            outdated(1, "b@example.com")
+        )
+
+        val result = service.processOutdatedAssets(data, dryRun = false)
+
+        assertThat(result.emailsSent).isEqualTo(0)
+        assertThat(result.skipped).containsExactlyInAnyOrder("a@example.com", "b@example.com")
+        verify(exactly = 0) { emailSender.sendEmail(any()) }
+        verify(exactly = 0) { reminderStateService.updateLastSent(any()) }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
@@ -24,13 +24,18 @@ class UserVulnerabilityNotificationServiceTest {
     private val emailService = mockk<EmailService>(relaxed = true)
     private val awsAccountSharingService = mockk<AwsAccountSharingService>(relaxed = true)
     private val assetRepository = mockk<AssetRepository>(relaxed = true)
+    private val recipientResolver = AwsAccountRecipientResolver(
+        userMappingRepository = userMappingRepository,
+        assetRepository = assetRepository,
+        awsAccountSharingService = awsAccountSharingService
+    )
     private val service = UserVulnerabilityNotificationService(
         entityManager = entityManager,
         userMappingRepository = userMappingRepository,
         userRepository = userRepository,
         emailService = emailService,
         awsAccountSharingService = awsAccountSharingService,
-        assetRepository = assetRepository,
+        recipientResolver = recipientResolver,
         appConfig = AppConfig()
     )
 


### PR DESCRIPTION
## Summary

Refactor outdated-asset notification delivery to support multiple recipients per asset (workgroup members, AWS-account-sharing targets, and owner mappings), while ensuring per-asset duplicate-prevention gates are evaluated once upfront rather than per-recipient.

## Key Changes

- **New `AwsAccountRecipientResolver` service**: Centralizes recipient resolution logic (owners, workgroup members, sharing targets) as a single source of truth, shared by both `NotificationService` (outdated assets) and `UserVulnerabilityNotificationService` (overdue vulnerabilities). Recipients are deduplicated and normalized to lowercase.

- **`NotificationService` refactoring**:
  - Pre-compute per-asset eligibility (reminder level, "already sent today" gate) once upfront, keyed by asset ID, before any send updates `lastSentAt`.
  - Emit one `OutdatedAssetData` row per (recipient, asset) pair from `CliController`, allowing a single asset to fan out to multiple recipients.
  - Group by recipient email and send each recipient one consolidated email covering all eligible assets.
  - Mark each delivered asset as sent exactly once (via `updateLastSent`), regardless of recipient count — prevents the first recipient's send from silently suppressing the same asset for other recipients.

- **`CliController` updates**:
  - Resolve full recipient set per asset using `AwsAccountRecipientResolver` (keyed on `cloudAccountId`) plus legacy `asset.owner` lookup for backward compatibility.
  - Emit one notification row per (recipient, asset) pair instead of one per asset.
  - Skip assets with no recipients across all categories (logged with `--verbose`).

- **`UserVulnerabilityNotificationService` simplification**:
  - Replace inline `resolveAccountRecipients()` with delegated call to `AwsAccountRecipientResolver`.

- **Comprehensive test coverage**:
  - `NotificationServiceTest`: validates fan-out to multiple recipients, per-asset duplicate-prevention gates, and dry-run behavior.
  - `AwsAccountRecipientResolverTest`: validates union of owners, workgroup members, and sharing targets with case-insensitive deduplication.

- **Documentation**: Updated `CLI.md` to describe the new multi-recipient fan-out and per-asset duplicate-prevention semantics.

## Implementation Details

- Recipient deduplication is case-insensitive (all emails normalized to lowercase).
- Blank AWS account IDs yield no recipients and skip all lookups.
- Dry-run mode reports all recipients but never sends or marks assets as sent.
- Assets already notified today (per asset, not per recipient) are skipped for all recipients.

https://claude.ai/code/session_012AYGwsLbEVSFASNDhT8TQi