### PR TITLE
Add frontend build verification to development completion checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ CrowdStrike monitoring: `src/clinotify/check_crowdstrike_checkin.py` polls `/api
 3. Schema = Flyway migrations + Hibernate auto-update.
 4. Always write tests. Source of truth for credentials and URLs is `pass-cli`.
 5. **A change is complete only when** `./gradlew build` is clean **AND** `./scripts/startbackenddev.sh` starts cleanly. Compile-clean ≠ runtime-clean (Micronaut bean wiring, Flyway, SessionFactory only check at startup). Stop the backend after verifying.
+5a. **Frontend changes are complete only when** `cd src/frontend && npm ci && npm run build` exits 0. TypeScript errors, missing imports, and broken Astro/React components are caught here — do not skip this step for any frontend file edit.
 6. Tests route HTTP through `SECMAN_HOST` (from `pass-cli`). No hardcoded localhost URLs.
 7. **Mandatory post-change E2E gates** (in addition to build + startup):
    - **`/e2ejs`** must report **0 JS errors** for both admin and normal-user runs against `SECMAN_HOST`. RBAC 403s on role-gated endpoints and documented 404s (e.g., `/api/wg-vulns`, `/api/domain-vulns` for users without mappings) are NOT JS errors. A page that throws or logs `console.error` IS — fix before merge.


### PR DESCRIPTION
## Summary
Updated the development completion checklist in CLAUDE.md to explicitly require frontend build verification as a mandatory gate before marking changes complete.

## Changes
- Added principle **5a** to the hard principles section, establishing that frontend changes must pass `cd src/frontend && npm ci && npm run build` with exit code 0
- Clarified that TypeScript errors, missing imports, and broken Astro/React components are caught during the frontend build step and must be fixed before merge
- Emphasized that this step is non-negotiable for any frontend file edit, bringing frontend parity with the existing backend build + startup verification requirement

## Rationale
This formalizes the frontend build as a mandatory completion gate alongside the existing backend verification (principle 5: `./gradlew build` + `./scripts/startbackenddev.sh`). Frontend changes can compile cleanly in isolation but fail at build time due to TypeScript, module resolution, or component issues that only surface during the full build pipeline. This ensures runtime-clean frontend code before merge, consistent with the backend's compile-clean ≠ runtime-clean principle.

https://claude.ai/code/session_01VWiX5osYFbZvda4CxxKR6w