### PR TITLE
Add MCP tools for all CLI-only functions

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolRegistry.kt
@@ -101,7 +101,15 @@ class McpToolRegistry(
     @Inject private val removeWorkgroupAdDomainTool: RemoveWorkgroupAdDomainTool,
     // CrowdStrike import status
     @Inject private val getCrowdStrikeLastImportTool: GetCrowdStrikeLastImportTool,
-    @Inject private val applicationRegisterTool: ApplicationRegisterTool
+    @Inject private val applicationRegisterTool: ApplicationRegisterTool,
+    // CLI parity tools
+    @Inject private val deduplicateVulnerabilitiesTool: DeduplicateVulnerabilitiesTool,
+    @Inject private val deleteAssetNotSeenTool: DeleteAssetNotSeenTool,
+    @Inject private val notifyNewAccountsTool: NotifyNewAccountsTool,
+    @Inject private val sendOutdatedNotificationsTool: SendOutdatedNotificationsTool,
+    @Inject private val sendVulnerabilityNotificationsTool: SendVulnerabilityNotificationsTool,
+    @Inject private val sendApplicationRegisterRemindersTool: SendApplicationRegisterRemindersTool,
+    @Inject private val assetMatchClearTool: AssetMatchClearTool
 ) {
     private val logger = LoggerFactory.getLogger(McpToolRegistry::class.java)
 
@@ -199,7 +207,15 @@ class McpToolRegistry(
             removeWorkgroupAdDomainTool,
             // CrowdStrike import status
             getCrowdStrikeLastImportTool,
-            applicationRegisterTool
+            applicationRegisterTool,
+            // CLI parity tools
+            deduplicateVulnerabilitiesTool,
+            deleteAssetNotSeenTool,
+            notifyNewAccountsTool,
+            sendOutdatedNotificationsTool,
+            sendVulnerabilityNotificationsTool,
+            sendApplicationRegisterRemindersTool,
+            assetMatchClearTool
         ).forEach { tool ->
             toolMap[tool.name] = tool
             logger.debug("Registered MCP tool: {}", tool.name)
@@ -482,6 +498,29 @@ class McpToolRegistry(
             // CrowdStrike import status (ADMIN/VULN role checked in tool execute())
             "get_crowdstrike_last_import" -> {
                 permissions.contains(McpPermission.VULNERABILITIES_READ)
+            }
+
+            // CLI parity tools (ADMIN only via User Delegation)
+            "deduplicate_vulnerabilities" -> {
+                permissions.contains(McpPermission.VULNERABILITIES_READ) // ADMIN role checked in tool execute()
+            }
+            "delete_asset_not_seen" -> {
+                permissions.contains(McpPermission.ASSETS_READ) // ADMIN role checked in tool execute()
+            }
+            "notify_new_accounts" -> {
+                permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
+            }
+            "send_outdated_notifications" -> {
+                permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
+            }
+            "send_vulnerability_notifications" -> {
+                permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
+            }
+            "send_application_register_reminders" -> {
+                permissions.contains(McpPermission.NOTIFICATIONS_SEND) // ADMIN role checked in tool execute()
+            }
+            "asset_match_clear" -> {
+                permissions.contains(McpPermission.ASSETS_READ) // ADMIN role checked in tool execute()
             }
 
             else -> false

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssetMatchClearTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AssetMatchClearTool.kt
@@ -1,0 +1,134 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.AssetMatchClearService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that reconciles AWS assets in secman against an authoritative resource snapshot.
+ *
+ * Mirrors the core delete path of the CLI command `asset-match-clear` (without S3 download).
+ * The caller supplies the list of known account IDs and resource IDs directly; the backend
+ * deletes every secman asset whose cloudAccountId is in accountIds and whose cloudInstanceId
+ * is NOT in resourceIds.
+ *
+ * ADMIN role is required via User Delegation.
+ */
+@Singleton
+class AssetMatchClearTool(
+    @Inject private val assetMatchClearService: AssetMatchClearService
+) : McpTool {
+
+    override val name = "asset_match_clear"
+    override val description = "Delete AWS assets in secman whose cloudInstanceId is missing from a supplied resource snapshot (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "accountIds" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "string"),
+                "description" to "AWS account IDs covered by the snapshot. Only assets in these accounts are considered for deletion."
+            ),
+            "resourceIds" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "string"),
+                "description" to "Currently existing AWS resource/instance IDs from the snapshot. Assets NOT in this list will be deleted."
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview matching assets without deleting them. Default: false"
+            ),
+            "maxDeletePercent" to mapOf(
+                "type" to "number",
+                "description" to "Abort if proposed deletions exceed N% of scoped assets. Default: 25. Set 0 to disable.",
+                "minimum" to 0,
+                "maximum" to 100
+            ),
+            "strict" to mapOf(
+                "type" to "boolean",
+                "description" to "Treat the snapshot as globally authoritative across all secman AWS assets (not just snapshot-covered accounts). Default: false"
+            )
+        ),
+        "required" to listOf("accountIds", "resourceIds")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to run asset match-clear")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val accountIds = (arguments["accountIds"] as? List<*>)?.filterIsInstance<String>()
+            ?: return McpToolResult.error("INVALID_ARGUMENT", "accountIds is required and must be a list of strings")
+        @Suppress("UNCHECKED_CAST")
+        val resourceIds = (arguments["resourceIds"] as? List<*>)?.filterIsInstance<String>()
+            ?: return McpToolResult.error("INVALID_ARGUMENT", "resourceIds is required and must be a list of strings")
+
+        if (accountIds.isEmpty()) {
+            return McpToolResult.error("INVALID_ARGUMENT", "accountIds must not be empty")
+        }
+
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+        val maxDeletePercent = (arguments["maxDeletePercent"] as? Number)?.toInt() ?: 25
+        val strict = arguments["strict"] as? Boolean ?: false
+
+        return try {
+            val result = assetMatchClearService.clear(
+                accountIds = accountIds,
+                resourceIds = resourceIds,
+                dryRun = dryRun,
+                username = context.delegatedUserEmail ?: "mcp",
+                maxDeletePercent = if (maxDeletePercent == 0) null else maxDeletePercent,
+                strict = strict
+            )
+
+            val response = mapOf(
+                "success" to true,
+                "dryRun" to result.dryRun,
+                "scopeMode" to result.scopeMode,
+                "snapshotAccountCount" to result.snapshotAccountCount,
+                "snapshotResourceCount" to result.snapshotResourceCount,
+                "scopedAssetCount" to result.scopedAssetCount,
+                "uncoveredAccountCount" to result.uncoveredAccountCount,
+                "uncoveredAssetCount" to result.uncoveredAssetCount,
+                "candidateCount" to result.candidateCount,
+                "deletedCount" to result.deletedCount,
+                "skippedCount" to result.skippedCount,
+                "status" to result.status,
+                "safetyBrakeTripped" to result.safetyBrakeTripped,
+                "safetyBrakePercent" to result.safetyBrakePercent,
+                "candidates" to result.candidates.map { c ->
+                    mapOf(
+                        "assetId" to c.assetId,
+                        "name" to c.name,
+                        "cloudAccountId" to c.cloudAccountId,
+                        "cloudInstanceId" to c.cloudInstanceId
+                    )
+                },
+                "errors" to result.errors.map { e ->
+                    mapOf("assetId" to e.assetId, "assetName" to e.assetName, "message" to e.message)
+                },
+                "message" to when {
+                    result.safetyBrakeTripped -> "Safety brake tripped — no assets deleted (proposed deletions exceeded ${result.safetyBrakePercent}% limit)"
+                    dryRun -> "Dry run: ${result.candidateCount} asset(s) would be deleted"
+                    else -> "Deleted ${result.deletedCount} asset(s) not in the resource snapshot" +
+                        if (result.skippedCount > 0) " (${result.skippedCount} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: AssetMatchClearService.EmptySnapshotException) {
+            McpToolResult.error("EMPTY_SNAPSHOT", e.message ?: "Empty snapshot rejected")
+        } catch (e: IllegalArgumentException) {
+            McpToolResult.error("INVALID_ARGUMENT", e.message ?: "Invalid argument")
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Asset match-clear failed: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeduplicateVulnerabilitiesTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeduplicateVulnerabilitiesTool.kt
@@ -1,0 +1,67 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.VulnerabilityDeduplicationService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that removes duplicate vulnerability records from the database.
+ *
+ * Mirrors the CLI command `deduplicate-vulnerabilities`.
+ * ADMIN role is required via User Delegation.
+ *
+ * For each asset, keeps the oldest record (lowest primary key) when the same
+ * (CVE ID, product) combination appears more than once.
+ */
+@Singleton
+class DeduplicateVulnerabilitiesTool(
+    @Inject private val vulnerabilityDeduplicationService: VulnerabilityDeduplicationService
+) : McpTool {
+
+    override val name = "deduplicate_vulnerabilities"
+    override val description = "Remove duplicate vulnerability records from the database, keeping the oldest entry per (CVE ID, product) per asset (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to emptyMap<String, Any>(),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to deduplicate vulnerabilities")
+        }
+
+        return try {
+            val result = vulnerabilityDeduplicationService.deduplicateAll()
+
+            val response = mapOf(
+                "success" to true,
+                "totalDuplicatesRemoved" to result.totalDuplicatesRemoved,
+                "assetsAffected" to result.assetsAffected,
+                "details" to result.details.map { d ->
+                    mapOf(
+                        "assetId" to d.assetId,
+                        "assetName" to (d.assetName ?: ""),
+                        "duplicatesRemoved" to d.duplicatesRemoved,
+                        "duplicateKeys" to d.duplicateKeys
+                    )
+                },
+                "message" to if (result.totalDuplicatesRemoved == 0) {
+                    "No duplicate vulnerabilities found. Database is clean."
+                } else {
+                    "Removed ${result.totalDuplicatesRemoved} duplicate vulnerability record(s) across ${result.assetsAffected} asset(s)"
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Deduplication failed: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAssetNotSeenTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAssetNotSeenTool.kt
@@ -1,0 +1,106 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.CrowdStrikeCleanupAuditService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that deletes CrowdStrike-imported assets not seen in CrowdStrike for N days.
+ *
+ * Mirrors the CLI command `delete-asset-not-seen`.
+ * ADMIN role is required via User Delegation.
+ */
+@Singleton
+class DeleteAssetNotSeenTool(
+    @Inject private val crowdStrikeCleanupAuditService: CrowdStrikeCleanupAuditService
+) : McpTool {
+
+    override val name = "delete_asset_not_seen"
+    override val description = "Delete CrowdStrike-imported assets not seen in CrowdStrike for more than N days (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "days" to mapOf(
+                "type" to "number",
+                "description" to "Days since last CrowdStrike import. Assets with no import in this window are deleted.",
+                "minimum" to 1
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview matching assets without deleting them. Default: false"
+            ),
+            "includeLegacy" to mapOf(
+                "type" to "boolean",
+                "description" to "Also clean up legacy CrowdStrike assets with no import timestamp (rule B, Feature 087). Default: uses server-configured default"
+            )
+        ),
+        "required" to listOf("days")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to delete stale assets")
+        }
+
+        val days = (arguments["days"] as? Number)?.toInt()
+            ?: return McpToolResult.error("INVALID_ARGUMENT", "days is required and must be >= 1")
+        if (days < 1) {
+            return McpToolResult.error("INVALID_ARGUMENT", "days must be >= 1")
+        }
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+        val includeLegacy = arguments["includeLegacy"] as? Boolean
+
+        return try {
+            val result = crowdStrikeCleanupAuditService.run(
+                days = days,
+                dryRun = dryRun,
+                triggeredBy = context.delegatedUserEmail ?: "mcp",
+                maxDeletePercent = null,
+                includeLegacy = includeLegacy
+            )
+
+            val response = mapOf(
+                "success" to true,
+                "days" to result.days,
+                "cutoff" to result.cutoff.toString(),
+                "dryRun" to result.dryRun,
+                "candidateCount" to result.candidateCount,
+                "deletedCount" to result.deletedCount,
+                "skippedCount" to result.skippedCount,
+                "legacyCandidateCount" to result.legacyCandidateCount,
+                "legacyDeletedCount" to result.legacyDeletedCount,
+                "status" to (result.status ?: if (dryRun) "DRY_RUN" else "SUCCESS"),
+                "runId" to result.runId,
+                "candidates" to result.candidates.map { c ->
+                    mapOf(
+                        "assetId" to c.assetId,
+                        "name" to c.name,
+                        "crowdStrikeLastImportedAt" to c.crowdStrikeLastImportedAt?.toString(),
+                        "reason" to c.reason.name
+                    )
+                },
+                "errors" to result.errors.map { e ->
+                    mapOf("assetId" to e.assetId, "assetName" to e.assetName, "message" to e.message)
+                },
+                "message" to if (dryRun) {
+                    "Dry run: ${result.candidateCount} asset(s) would be deleted (not seen in $days days)"
+                } else {
+                    "Deleted ${result.deletedCount} asset(s) not seen in $days days" +
+                        if (result.skippedCount > 0) " (${result.skippedCount} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: IllegalArgumentException) {
+            McpToolResult.error("INVALID_ARGUMENT", e.message ?: "Invalid argument")
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Cleanup failed: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/NotifyNewAccountsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/NotifyNewAccountsTool.kt
@@ -1,0 +1,96 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.NewAccountNotificationService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that notifies users about new AWS account mappings created in the last N hours.
+ *
+ * Mirrors the CLI command `notify-new-accounts`.
+ * ADMIN role is required via User Delegation.
+ *
+ * The CLI reads notification body text from a local file; this MCP tool accepts the
+ * text directly as a parameter so MCP callers can customise it per invocation.
+ */
+@Singleton
+class NotifyNewAccountsTool(
+    @Inject private val newAccountNotificationService: NewAccountNotificationService
+) : McpTool {
+
+    override val name = "notify_new_accounts"
+    override val description = "Notify users about new AWS account mappings created in the last N hours (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "notificationText" to mapOf(
+                "type" to "string",
+                "description" to "Body text of the notification email. The list of new account IDs is appended below this text automatically."
+            ),
+            "hours" to mapOf(
+                "type" to "number",
+                "description" to "Look-back window in hours: notify about mappings created within this period. Default: 24",
+                "minimum" to 1
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview planned notifications without sending emails. Default: false"
+            )
+        ),
+        "required" to listOf("notificationText")
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to send new-account notifications")
+        }
+
+        val notificationText = (arguments["notificationText"] as? String)?.trim()
+        if (notificationText.isNullOrBlank()) {
+            return McpToolResult.error("INVALID_ARGUMENT", "notificationText is required and must not be blank")
+        }
+
+        val hours = (arguments["hours"] as? Number)?.toInt() ?: 24
+        if (hours < 1) {
+            return McpToolResult.error("INVALID_ARGUMENT", "hours must be >= 1")
+        }
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+
+        return try {
+            val result = newAccountNotificationService.sendNewAccountNotifications(
+                hours = hours,
+                dryRun = dryRun,
+                verbose = false,
+                notificationText = notificationText
+            )
+
+            val response = mapOf(
+                "success" to true,
+                "status" to result.status.name,
+                "hours" to hours,
+                "accountMappingsFound" to result.accountMappingsFound,
+                "usersNotified" to result.usersNotified,
+                "emailsSent" to result.emailsSent,
+                "emailsFailed" to result.emailsFailed,
+                "recipients" to result.recipients,
+                "failedRecipients" to result.failedRecipients,
+                "message" to if (dryRun) {
+                    "Dry run: would notify ${result.usersNotified} user(s) about ${result.accountMappingsFound} new AWS account mapping(s)"
+                } else {
+                    "Notified ${result.emailsSent} user(s) about new AWS account mappings in the last $hours hour(s)" +
+                        if (result.emailsFailed > 0) " (${result.emailsFailed} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to send new-account notifications: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendApplicationRegisterRemindersTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendApplicationRegisterRemindersTool.kt
@@ -1,0 +1,79 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.ApplicationRegisterReminderService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that sends reminder emails for application register entries not reviewed recently.
+ *
+ * Mirrors the CLI command `send-application-register-reminders`.
+ * ADMIN role is required via User Delegation.
+ */
+@Singleton
+class SendApplicationRegisterRemindersTool(
+    @Inject private val applicationRegisterReminderService: ApplicationRegisterReminderService
+) : McpTool {
+
+    override val name = "send_application_register_reminders"
+    override val description = "Send reminder emails for application register entries not checked within the threshold period (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "days" to mapOf(
+                "type" to "number",
+                "description" to "Threshold in days: entries not reviewed within this period trigger a reminder. Default: 365",
+                "minimum" to 1
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview planned reminders without sending emails. Default: false"
+            )
+        ),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to send application register reminders")
+        }
+
+        val days = (arguments["days"] as? Number)?.toInt() ?: 365
+        if (days < 1) {
+            return McpToolResult.error("INVALID_ARGUMENT", "days must be >= 1")
+        }
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+
+        return try {
+            val result = applicationRegisterReminderService.sendReminderEmails(days, dryRun, verbose = false)
+
+            val response = mapOf(
+                "success" to true,
+                "status" to result.status.name,
+                "thresholdDays" to result.thresholdDays,
+                "entriesOverdue" to result.entriesOverdue,
+                "recipientCount" to result.recipientCount,
+                "emailsSent" to result.emailsSent,
+                "emailsFailed" to result.emailsFailed,
+                "recipients" to result.recipients,
+                "failedRecipients" to result.failedRecipients,
+                "message" to if (dryRun) {
+                    "Dry run: ${result.entriesOverdue} overdue application register entry/entries, would notify ${result.recipientCount} recipient(s)"
+                } else {
+                    "Sent ${result.emailsSent} application register reminder(s)" +
+                        if (result.emailsFailed > 0) " (${result.emailsFailed} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to send application register reminders: ${e.message}")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendOutdatedNotificationsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendOutdatedNotificationsTool.kt
@@ -1,0 +1,117 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.AssetRepository
+import com.secman.repository.OutdatedAssetMaterializedViewRepository
+import com.secman.repository.UserMappingRepository
+import com.secman.service.NotificationService
+import io.micronaut.data.model.Pageable
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that sends outdated asset reminder emails.
+ *
+ * Mirrors the CLI command `send-notifications`.
+ * ADMIN role is required via User Delegation.
+ *
+ * Queries the outdated-asset materialized view, resolves owner emails, and sends
+ * one consolidated reminder email per owner.
+ */
+@Singleton
+class SendOutdatedNotificationsTool(
+    @Inject private val notificationService: NotificationService,
+    @Inject private val outdatedAssetRepository: OutdatedAssetMaterializedViewRepository,
+    @Inject private val assetRepository: AssetRepository,
+    @Inject private val userMappingRepository: UserMappingRepository
+) : McpTool {
+
+    override val name = "send_outdated_notifications"
+    override val description = "Send outdated-asset reminder emails to owners with overdue vulnerabilities (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview planned notifications without sending emails. Default: false"
+            )
+        ),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to send outdated asset notifications")
+        }
+
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+
+        return try {
+            val outdatedAssets = buildOutdatedAssetList()
+            val result = notificationService.processOutdatedAssets(outdatedAssets, dryRun)
+
+            val response = mapOf(
+                "success" to true,
+                "assetsProcessed" to result.assetsProcessed,
+                "emailsSent" to result.emailsSent,
+                "failures" to result.failures,
+                "skipped" to result.skipped,
+                "message" to if (dryRun) {
+                    "Dry run: would process ${outdatedAssets.size} outdated asset(s)"
+                } else {
+                    "Processed ${result.assetsProcessed} outdated asset(s), sent ${result.emailsSent} email(s)" +
+                        if (result.failures > 0) " (${result.failures} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to send outdated notifications: ${e.message}")
+        }
+    }
+
+    private fun buildOutdatedAssetList(): List<NotificationService.OutdatedAssetData> {
+        val page = outdatedAssetRepository.findOutdatedAssets(
+            workgroupId = null,
+            searchTerm = null,
+            minSeverity = null,
+            adDomain = null,
+            pageable = Pageable.unpaged()
+        )
+
+        val results = mutableListOf<NotificationService.OutdatedAssetData>()
+        for (view in page.content) {
+            val asset = assetRepository.findById(view.assetId).orElse(null) ?: continue
+            val mappings = userMappingRepository.findByAwsAccountId(asset.owner)
+            if (mappings.isEmpty()) continue
+            val ownerEmail = mappings.first().email
+
+            val severity = when {
+                view.criticalCount > 0 -> "CRITICAL"
+                view.highCount > 0 -> "HIGH"
+                view.mediumCount > 0 -> "MEDIUM"
+                else -> "LOW"
+            }
+
+            results.add(
+                NotificationService.OutdatedAssetData(
+                    assetId = view.assetId,
+                    assetName = view.assetName,
+                    assetType = view.assetType,
+                    ownerEmail = ownerEmail,
+                    vulnerabilityCount = view.totalOverdueCount,
+                    oldestVulnDays = view.oldestVulnDays,
+                    oldestVulnId = view.oldestVulnId ?: "unknown",
+                    severity = severity,
+                    criticality = asset.getEffectiveCriticality().name
+                )
+            )
+        }
+        return results
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendVulnerabilityNotificationsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendVulnerabilityNotificationsTool.kt
@@ -1,0 +1,102 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.McpOperation
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.UserVulnerabilityNotificationService
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+/**
+ * MCP tool that sends vulnerability notification emails to users with affected AWS accounts.
+ *
+ * Mirrors the CLI command `send-notification-users`. Sends to all users with overdue
+ * vulnerabilities, with an optional filter to notify only a single specific user.
+ *
+ * For batch-by-email-prefix behaviour, use `send_patch_notifications` instead.
+ * ADMIN role is required via User Delegation.
+ */
+@Singleton
+class SendVulnerabilityNotificationsTool(
+    @Inject private val userVulnerabilityNotificationService: UserVulnerabilityNotificationService
+) : McpTool {
+
+    override val name = "send_vulnerability_notifications"
+    override val description = "Send overdue-vulnerability notification emails to users with affected AWS accounts (ADMIN only, requires User Delegation)"
+    override val operation = McpOperation.WRITE
+
+    override val inputSchema = mapOf(
+        "type" to "object",
+        "properties" to mapOf(
+            "days" to mapOf(
+                "type" to "number",
+                "description" to "Vulnerability age threshold in days — assets with vulnerabilities open longer than this are included. Default: 30",
+                "minimum" to 1
+            ),
+            "notificationUser" to mapOf(
+                "type" to "string",
+                "description" to "Only notify this specific user (login email). When omitted, all users with affected accounts are notified."
+            ),
+            "dryRun" to mapOf(
+                "type" to "boolean",
+                "description" to "Preview planned notifications without sending emails. Default: false"
+            )
+        ),
+        "required" to emptyList<String>()
+    )
+
+    override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        if (!context.hasDelegation()) {
+            return McpToolResult.error("DELEGATION_REQUIRED", "User Delegation must be enabled to use this tool")
+        }
+        if (!context.isAdmin) {
+            return McpToolResult.error("ADMIN_REQUIRED", "ADMIN role required to send vulnerability notifications")
+        }
+
+        val days = (arguments["days"] as? Number)?.toInt() ?: 30
+        if (days < 1) {
+            return McpToolResult.error("INVALID_ARGUMENT", "days must be >= 1")
+        }
+        val notificationUser = (arguments["notificationUser"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+        val dryRun = arguments["dryRun"] as? Boolean ?: false
+
+        return try {
+            val result = userVulnerabilityNotificationService.sendUserVulnerabilityNotifications(
+                thresholdDays = days,
+                dryRun = dryRun,
+                verbose = false,
+                notificationUser = notificationUser,
+                emailPrefix = null
+            )
+
+            if (notificationUser != null && result.notificationUserExists == false) {
+                return McpToolResult.error(
+                    "USER_NOT_FOUND",
+                    "No user account found with email '$notificationUser'. Verify the login email address."
+                )
+            }
+
+            val response = mapOf(
+                "success" to true,
+                "status" to result.status.name,
+                "notificationScope" to result.notificationScope.name,
+                "thresholdDays" to result.thresholdDays,
+                "awsAccountsAffected" to result.awsAccountsAffected,
+                "usersNotified" to result.usersNotified,
+                "emailsSent" to result.emailsSent,
+                "emailsFailed" to result.emailsFailed,
+                "recipients" to result.recipients,
+                "failedRecipients" to result.failedRecipients,
+                "unmappedAccounts" to result.unmappedAccounts,
+                "message" to if (dryRun) {
+                    "Dry run: would notify ${result.usersNotified} user(s) about vulnerabilities older than $days days"
+                } else {
+                    "Notified ${result.emailsSent} user(s) about overdue vulnerabilities" +
+                        if (result.emailsFailed > 0) " (${result.emailsFailed} failed)" else ""
+                }
+            )
+            McpToolResult.success(response)
+        } catch (e: Exception) {
+            McpToolResult.error("EXECUTION_ERROR", "Failed to send vulnerability notifications: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
Adds 7 new MCP tools so every CLI command that calls a backend API also has an MCP equivalent, usable via User Delegation (ADMIN role required for all):

- deduplicate_vulnerabilities  → VulnerabilityDeduplicationService.deduplicateAll()
- delete_asset_not_seen        → CrowdStrikeCleanupAuditService.run() (days, dryRun, includeLegacy)
- notify_new_accounts          → NewAccountNotificationService (hours, notificationText, dryRun)
- send_outdated_notifications  → NotificationService.processOutdatedAssets() + outdated-asset repos
- send_vulnerability_notifications → UserVulnerabilityNotificationService (days, notificationUser, dryRun)
- send_application_register_reminders → ApplicationRegisterReminderService (days, dryRun)
- asset_match_clear            → AssetMatchClearService.clear() (accountIds, resourceIds, dryRun, strict)

All tools are registered in McpToolRegistry with NOTIFICATIONS_SEND or ASSETS_READ permission gates (matching the existing pattern for similar tools).


Claude-Session: https://claude.ai/code/session_01GZDq1k9rWXKtr2obsFQmDk