### PR TITLE
Add --notall flag to send-notification-users for admin/secchampion scope restriction

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -242,10 +242,18 @@ than one path is notified only once. An account with no recipients in any of the
 three categories is reported under "Unmapped accounts". A non-ADMIN
 `--notification-user` is scoped to only the accounts that user can access.
 
+`--notall` forces a `--notification-user` run into a restricted scope regardless of
+role: instead of the ADMIN global-bypass view (or the narrower UserMapping+sharing
+view every other role, including SECCHAMPION, gets by default), the run is limited
+to only the AWS accounts backing assets the user directly owns (manual creator,
+scan uploader, or `owner` field), belongs to via workgroup membership, or has been
+granted via AWS account sharing. Has no effect without `--notification-user`.
+
 ```bash
 ./scripts/secman send-notification-users --dry-run --verbose
 ./scripts/secman send-notification-users --days 60
 ./scripts/secman send-notification-users --notification-user user@example.com
+./scripts/secman send-notification-users --notification-user admin@example.com --notall
 ```
 
 | Option | Default | Notes |
@@ -254,6 +262,7 @@ three categories is reported under "Unmapped accounts". A non-ADMIN
 | `--dry-run` | false | print planned recipients only |
 | `--verbose` | false | per-recipient delivery status |
 | `--notification-user <email>` | — | only notify this user (ADMIN ⇒ global, otherwise self-scoped) |
+| `--notall` | false | with `--notification-user`, force the owned/workgroup/shared-only restriction regardless of role (chiefly for ADMIN/SECCHAMPION) |
 | `--username` / `--password` | env | `SECMAN_ADMIN_NAME` / `SECMAN_ADMIN_PASS` |
 | `--backend-url` | env | `SECMAN_HOST` / `SECMAN_BACKEND_URL` |
 

--- a/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/CliController.kt
@@ -396,7 +396,8 @@ class CliController(
         val verbose: Boolean = false,
         val thresholdDays: Int = 30,
         val notificationUser: String? = null,
-        val emailPrefix: String? = null
+        val emailPrefix: String? = null,
+        val notAll: Boolean = false
     )
 
     @Serdeable
@@ -437,7 +438,8 @@ class CliController(
                 dryRun = request.dryRun,
                 verbose = request.verbose,
                 notificationUser = request.notificationUser,
-                emailPrefix = request.emailPrefix
+                emailPrefix = request.emailPrefix,
+                notAll = request.notAll
             )
 
             HttpResponse.ok(UserVulnNotificationResultDto(

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendVulnerabilityNotificationsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/SendVulnerabilityNotificationsTool.kt
@@ -36,6 +36,10 @@ class SendVulnerabilityNotificationsTool(
                 "type" to "string",
                 "description" to "Only notify this specific user (login email). When omitted, all users with affected accounts are notified."
             ),
+            "notAll" to mapOf(
+                "type" to "boolean",
+                "description" to "With notificationUser for an ADMIN/SECCHAMPION: restrict to AWS accounts backing assets the user owns (manual creator, scan uploader, or owner), belongs to via workgroup, or has via AWS account sharing — instead of the full global view those roles get by default. Default: false"
+            ),
             "dryRun" to mapOf(
                 "type" to "boolean",
                 "description" to "Preview planned notifications without sending emails. Default: false"
@@ -58,6 +62,7 @@ class SendVulnerabilityNotificationsTool(
         }
         val notificationUser = (arguments["notificationUser"] as? String)?.trim()?.takeIf { it.isNotEmpty() }
         val dryRun = arguments["dryRun"] as? Boolean ?: false
+        val notAll = arguments["notAll"] as? Boolean ?: false
 
         return try {
             val result = userVulnerabilityNotificationService.sendUserVulnerabilityNotifications(
@@ -65,7 +70,8 @@ class SendVulnerabilityNotificationsTool(
                 dryRun = dryRun,
                 verbose = false,
                 notificationUser = notificationUser,
-                emailPrefix = null
+                emailPrefix = null,
+                notAll = notAll
             )
 
             if (notificationUser != null && result.notificationUserExists == false) {

--- a/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AssetRepository.kt
@@ -52,6 +52,39 @@ interface AssetRepository : JpaRepository<Asset, Long> {
     fun findDistinctWorkgroupMemberEmailsByCloudAccountId(cloudAccountId: String): List<String>
 
     /**
+     * Find the distinct AWS cloud account IDs of assets the given user owns directly —
+     * via workgroup membership, manual creation, scan upload, or the asset's `owner` field.
+     * Deliberately narrower than [findAccessibleAssets]: it excludes direct AWS/AD
+     * UserMapping and workgroup-assigned-account/domain access, since it backs the
+     * `--notall` restriction on the vulnerability-notification fan-out, which limits
+     * an ADMIN/SECCHAMPION `--notification-user` run to accounts the user is directly
+     * tied to (ownership, workgroup, or AWS account sharing — sharing is applied
+     * separately at the call site).
+     *
+     * @param userId The user's ID (for workgroup, creator, uploader checks)
+     * @param username The user's username (for owner-based access)
+     * @return Distinct non-blank cloud account IDs
+     */
+    @io.micronaut.data.annotation.Query(
+        value = """
+            SELECT DISTINCT a.cloud_account_id FROM asset a
+            WHERE a.cloud_account_id IS NOT NULL AND a.cloud_account_id != ''
+              AND (
+                  a.id IN (
+                      SELECT aw.asset_id FROM asset_workgroups aw
+                      JOIN user_workgroups uw ON aw.workgroup_id = uw.workgroup_id
+                      WHERE uw.user_id = :userId
+                  )
+                  OR a.manual_creator_id = :userId
+                  OR a.scan_uploader_id = :userId
+                  OR a.owner = :username
+              )
+        """,
+        nativeQuery = true
+    )
+    fun findDistinctCloudAccountIdsByOwnershipOrWorkgroup(userId: Long, username: String): List<String>
+
+    /**
      * Find all assets accessible to a user using unified access control query
      * Combines all access criteria in a single database round trip:
      * 1. Assets in user's workgroups

--- a/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/UserVulnerabilityNotificationService.kt
@@ -3,6 +3,7 @@ package com.secman.service
 import com.secman.config.AppConfig
 import com.secman.domain.ExecutionStatus
 import com.secman.domain.User
+import com.secman.repository.AssetRepository
 import com.secman.repository.ExceptionMatchSql
 import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
@@ -29,6 +30,7 @@ open class UserVulnerabilityNotificationService(
     private val emailService: EmailService,
     private val awsAccountSharingService: AwsAccountSharingService,
     private val recipientResolver: AwsAccountRecipientResolver,
+    private val assetRepository: AssetRepository,
     private val appConfig: AppConfig
 ) {
     private val logger = LoggerFactory.getLogger(UserVulnerabilityNotificationService::class.java)
@@ -88,7 +90,8 @@ open class UserVulnerabilityNotificationService(
 
     enum class NotificationScope {
         GLOBAL_AWS_OVERDUE,
-        USER_SCOPED_AWS_OVERDUE
+        USER_SCOPED_AWS_OVERDUE,
+        RESTRICTED_AWS_OVERDUE
     }
 
     /**
@@ -100,10 +103,11 @@ open class UserVulnerabilityNotificationService(
         dryRun: Boolean = false,
         verbose: Boolean = false,
         notificationUser: String? = null,
-        emailPrefix: String? = null
+        emailPrefix: String? = null,
+        notAll: Boolean = false
     ): UserNotificationResult {
         val thresholdDate = LocalDateTime.now().minusDays(thresholdDays.toLong())
-        val scope = resolveScope(notificationUser)
+        val scope = resolveScope(notificationUser, notAll)
 
         // Guardrail: a user-scoped run whose --notification-user matches no user account is
         // almost always a mistyped email. Without this, the run silently reports zero affected
@@ -136,6 +140,7 @@ open class UserVulnerabilityNotificationService(
         val accountSummaries = when (scope) {
             NotificationScope.GLOBAL_AWS_OVERDUE -> findAffectedAwsAccounts(thresholdDate)
             NotificationScope.USER_SCOPED_AWS_OVERDUE -> findAffectedAwsAccountsForUser(thresholdDate, notificationUser!!)
+            NotificationScope.RESTRICTED_AWS_OVERDUE -> findAffectedAwsAccountsForRestrictedUser(thresholdDate, notificationUser!!)
         }
 
         if (accountSummaries.isEmpty()) {
@@ -164,6 +169,7 @@ open class UserVulnerabilityNotificationService(
             when (scope) {
                 NotificationScope.GLOBAL_AWS_OVERDUE -> findAffectedAwsAccountDetails(thresholdDate)
                 NotificationScope.USER_SCOPED_AWS_OVERDUE -> findAffectedAwsAccountDetailsForUser(thresholdDate, notificationUser!!)
+                NotificationScope.RESTRICTED_AWS_OVERDUE -> findAffectedAwsAccountDetailsForRestrictedUser(thresholdDate, notificationUser!!)
             }
         } else {
             emptyList()
@@ -175,7 +181,7 @@ open class UserVulnerabilityNotificationService(
         val userAccountMap = mutableMapOf<String, MutableList<AwsAccountVulnSummary>>()
         val unmappedAccounts = mutableListOf<String>()
 
-        if (scope == NotificationScope.USER_SCOPED_AWS_OVERDUE && notificationUser != null) {
+        if ((scope == NotificationScope.USER_SCOPED_AWS_OVERDUE || scope == NotificationScope.RESTRICTED_AWS_OVERDUE) && notificationUser != null) {
             userAccountMap[notificationUser.lowercase()] = accountSummaries.toMutableList()
         } else {
             accountSummaries.forEach { summary ->
@@ -216,7 +222,7 @@ open class UserVulnerabilityNotificationService(
         // Step 2b: Filter to specific user if --notification-user was provided
         if (notificationUser != null) {
             val targetEmail = notificationUser.lowercase()
-            val targetAccounts = userAccountMap[targetEmail] ?: if (scope == NotificationScope.USER_SCOPED_AWS_OVERDUE) {
+            val targetAccounts = userAccountMap[targetEmail] ?: if (scope == NotificationScope.USER_SCOPED_AWS_OVERDUE || scope == NotificationScope.RESTRICTED_AWS_OVERDUE) {
                 accountSummaries.toMutableList()
             } else {
                 null
@@ -367,9 +373,25 @@ open class UserVulnerabilityNotificationService(
     private fun resolveAccountRecipients(awsAccountId: String): Set<String> =
         recipientResolver.resolveAwsAccountRecipients(awsAccountId)
 
-    private fun resolveScope(notificationUser: String?): NotificationScope {
+    /**
+     * Resolve which accounts a `--notification-user` run should cover.
+     *
+     * Without `--notall`, an ADMIN/SECCHAMPION `--notification-user` gets the full
+     * GLOBAL view (their role already grants unrestricted asset access elsewhere in
+     * the app), while any other user is restricted to their own directly-mapped/shared
+     * AWS accounts (USER_SCOPED_AWS_OVERDUE).
+     *
+     * `--notall` overrides that admin/secchampion bypass: the run is restricted to
+     * only the AWS accounts backing assets the user directly owns (manual creator,
+     * scan uploader, or `owner` field), belongs to via workgroup membership, or has
+     * been granted via AWS account sharing (RESTRICTED_AWS_OVERDUE) — regardless of role.
+     */
+    private fun resolveScope(notificationUser: String?, notAll: Boolean = false): NotificationScope {
         if (notificationUser.isNullOrBlank()) {
             return NotificationScope.GLOBAL_AWS_OVERDUE
+        }
+        if (notAll) {
+            return NotificationScope.RESTRICTED_AWS_OVERDUE
         }
         val user = userRepository.findByEmail(notificationUser.lowercase()).orElse(null)
         val isAdmin = user?.roles?.contains(User.Role.ADMIN) == true
@@ -495,6 +517,38 @@ open class UserVulnerabilityNotificationService(
         val sharedAccounts = awsAccountSharingService.getSharedAwsAccountIdsByEmail(normalizedEmail)
             .map { it.trim() }
         return (directAccounts + sharedAccounts)
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+
+    private fun findAffectedAwsAccountsForRestrictedUser(thresholdDate: LocalDateTime, userEmail: String): List<AwsAccountVulnSummary> {
+        val restrictedAccounts = getRestrictedAwsAccountIds(userEmail)
+        if (restrictedAccounts.isEmpty()) return emptyList()
+        return findAffectedAwsAccounts(thresholdDate).filter { it.awsAccountId in restrictedAccounts }
+    }
+
+    private fun findAffectedAwsAccountDetailsForRestrictedUser(thresholdDate: LocalDateTime, userEmail: String): List<AwsAccountNotificationDetail> {
+        val restrictedAccounts = getRestrictedAwsAccountIds(userEmail)
+        if (restrictedAccounts.isEmpty()) return emptyList()
+        return findAffectedAwsAccountDetails(thresholdDate).filter { it.awsAccountId in restrictedAccounts }
+    }
+
+    /**
+     * AWS account IDs a `--notall` run may cover for the given user: accounts backing
+     * assets they directly own (manual creator, scan uploader, or `owner` field) or
+     * belong to via workgroup membership, plus accounts shared to them via the AWS
+     * account sharing feature. Deliberately excludes direct AWS UserMapping and
+     * workgroup-assigned-account access — see [resolveScope].
+     */
+    private fun getRestrictedAwsAccountIds(userEmail: String): Set<String> {
+        val normalizedEmail = userEmail.lowercase()
+        val user = userRepository.findByEmail(normalizedEmail).orElse(null) ?: return emptySet()
+        val ownedOrWorkgroupAccounts = assetRepository
+            .findDistinctCloudAccountIdsByOwnershipOrWorkgroup(user.id!!, user.username)
+            .map { it.trim() }
+        val sharedAccounts = awsAccountSharingService.getSharedAwsAccountIdsByEmail(normalizedEmail)
+            .map { it.trim() }
+        return (ownedOrWorkgroupAccounts + sharedAccounts)
             .filter { it.isNotEmpty() }
             .toSet()
     }

--- a/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/UserVulnerabilityNotificationServiceTest.kt
@@ -36,6 +36,7 @@ class UserVulnerabilityNotificationServiceTest {
         emailService = emailService,
         awsAccountSharingService = awsAccountSharingService,
         recipientResolver = recipientResolver,
+        assetRepository = assetRepository,
         appConfig = AppConfig()
     )
 
@@ -320,6 +321,45 @@ class UserVulnerabilityNotificationServiceTest {
         assertThat(result.usersNotified).isEqualTo(0)
         assertThat(result.recipients).isEmpty()
         assertThat(result.status.name).isEqualTo("DRY_RUN")
+    }
+
+    @Test
+    fun `notall restricts an ADMIN notification user to owned workgroup and shared accounts`() {
+        val accountQuery = mockk<Query>()
+        val detailQuery = mockk<Query>()
+        every { userRepository.findByEmail("admin@example.com") } returns Optional.of(
+            User(id = 5, username = "admin", email = "admin@example.com", passwordHash = "x", roles = mutableSetOf(User.Role.ADMIN))
+        )
+        every { entityManager.createNativeQuery(match { it.contains("GROUP BY a.cloud_account_id") }) } returns accountQuery
+        every { entityManager.createNativeQuery(match { it.contains("ORDER BY a.cloud_account_id, a.name") }) } returns detailQuery
+        every { accountQuery.setParameter("thresholdDate", any()) } returns accountQuery
+        every { detailQuery.setParameter("thresholdDate", any()) } returns detailQuery
+        every { accountQuery.resultList } returns listOf(
+            arrayOf<Any?>("111111111111", 1, 1, 1, 0, 0, 0, 45),
+            arrayOf<Any?>("222222222222", 1, 1, 1, 0, 0, 0, 45),
+            arrayOf<Any?>("333333333333", 1, 1, 1, 0, 0, 0, 45)
+        )
+        every { detailQuery.resultList } returns emptyList<Array<Any?>>()
+        // Owned/workgroup account
+        every { assetRepository.findDistinctCloudAccountIdsByOwnershipOrWorkgroup(5, "admin") } returns
+            listOf("111111111111")
+        // Shared account
+        every { awsAccountSharingService.getSharedAwsAccountIdsByEmail("admin@example.com") } returns
+            listOf("222222222222")
+        // "333333333333" is neither owned/workgroup nor shared, and must be excluded despite
+        // the user's ADMIN role and any direct UserMapping.
+        every { userMappingRepository.findByAwsAccountId(any()) } returns emptyList()
+
+        val result = service.sendUserVulnerabilityNotifications(
+            thresholdDays = 30,
+            dryRun = true,
+            notificationUser = "admin@example.com",
+            notAll = true
+        )
+
+        assertThat(result.notificationScope.name).isEqualTo("RESTRICTED_AWS_OVERDUE")
+        assertThat(result.recipients).containsExactly("admin@example.com")
+        assertThat(result.awsAccountsAffected).isEqualTo(2)
     }
 
     @Test

--- a/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/SecmanCli.kt
@@ -692,6 +692,11 @@ class SecmanCli {
                   --dry-run                Preview planned notifications without sending emails
                   --verbose, -v            Detailed logging (show per-recipient status)
                   --days <number>          Vulnerability age threshold in days (default: 30)
+                  --notification-user <email>  Only notify this specific user email (skip all others)
+                  --notall                 With --notification-user for an ADMIN/SECCHAMPION: restrict to AWS
+                                           accounts backing assets the user owns (manual creator, scan uploader,
+                                           or owner), belongs to via workgroup, or has via AWS account sharing —
+                                           instead of the full global view those roles get by default
 
                 Description:
                   Identifies AWS accounts with systems having vulnerabilities open longer than
@@ -703,6 +708,7 @@ class SecmanCli {
                   secman send-notification-users --dry-run
                   secman send-notification-users --days 60 --verbose
                   secman send-notification-users --dry-run --days 14
+                  secman send-notification-users --notification-user admin@example.com --notall
             """.trimIndent(),
 
             "send-patch-notifications" to """

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendNotificationUsersCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendNotificationUsersCommand.kt
@@ -31,6 +31,9 @@ class SendNotificationUsersCommand : Runnable {
     @Option(names = ["--notification-user"], description = ["Only notify this specific user email (skip all others)"])
     var notificationUser: String? = null
 
+    @Option(names = ["--notall"], description = ["With --notification-user for an ADMIN/SECCHAMPION: restrict to AWS accounts backing assets the user owns (manual creator, scan uploader, or owner), belongs to via workgroup, or has via AWS account sharing — instead of the full global view"])
+    var notAll: Boolean = false
+
     @Option(names = ["--username"], description = ["Backend username (or set SECMAN_ADMIN_NAME env var)"])
     var username: String? = null
 
@@ -62,6 +65,9 @@ class SendNotificationUsersCommand : Runnable {
             if (notificationUser != null) {
                 println("Notification user filter: $notificationUser")
             }
+            if (notAll) {
+                println("--notall: restricting to owned/workgroup/shared AWS accounts only")
+            }
             println()
 
             val effectiveUrl = getEffectiveBackendUrl()
@@ -78,6 +84,9 @@ class SendNotificationUsersCommand : Runnable {
             )
             if (notificationUser != null) {
                 requestBody["notificationUser"] = notificationUser!!
+            }
+            if (notAll) {
+                requestBody["notAll"] = true
             }
 
             val result = cliHttpClient.postMap(


### PR DESCRIPTION
## Summary

- Adds a `--notall` flag to the CLI `send-notification-users` command (and the mirroring `send_vulnerability_notifications` MCP tool). When used with `--notification-user` for an ADMIN/SECCHAMPION user, it replaces the default global AWS-account view with a restricted one covering only accounts backing assets the user directly owns (manual creator, scan uploader, or `owner` field), belongs to via workgroup membership, or has access to via AWS account sharing.
- New `UserVulnerabilityNotificationService.NotificationScope.RESTRICTED_AWS_OVERDUE` scope, backed by a new `AssetRepository.findDistinctCloudAccountIdsByOwnershipOrWorkgroup` query combined with the existing AWS-account-sharing lookup.
- Threaded `notAll` through `CliController.SendUserVulnNotificationsRequest`, the CLI command's request body/help text, and `SendVulnerabilityNotificationsTool`'s input schema.
- Docs updated in `docs/CLI.md`.

## Test plan

- [ ] `./gradlew build` (blocked in this sandbox by network policy — could not run; needs CI/local verification)
- [x] Added `UserVulnerabilityNotificationServiceTest` case verifying an ADMIN `--notification-user --notall` run is restricted to owned/shared accounts, excluding an account it would otherwise see globally
- [ ] `./scripts/startbackenddev.sh` starts cleanly (not runnable in this sandbox)
- [ ] Manual CLI smoke test: `./scripts/secman send-notification-users --notification-user <admin-email> --notall --dry-run`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbXAWD37Fk2xgWJFbjgC9G)_