### PR TITLE
feat(app-register): add GitHub repository URL and AWS account IDs

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
@@ -20,6 +20,8 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.rules.SecurityRule
+import java.net.HttpURLConnection
+import java.net.URI
 import java.time.LocalDate
 
 @Controller("/api/applications")
@@ -97,6 +99,35 @@ open class ApplicationRegisterController(
             HttpResponse.notFound()
         } catch (e: IllegalArgumentException) {
             HttpResponse.badRequest(mapOf("error" to e.message))
+        }
+    }
+
+    @Get("/check-github-url")
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    open fun checkGithubUrl(@QueryValue url: String): HttpResponse<Map<String, Any>> {
+        val trimmed = url.trim()
+        if (trimmed.isBlank()) {
+            return HttpResponse.badRequest(mapOf("error" to "URL is required"))
+        }
+        return try {
+            val uri = URI.create(trimmed)
+            if (uri.scheme != "https" && uri.scheme != "http") {
+                return HttpResponse.ok(mapOf("reachable" to false, "reason" to "URL must use http or https"))
+            }
+            val connection = uri.toURL().openConnection() as HttpURLConnection
+            connection.requestMethod = "HEAD"
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+            connection.instanceFollowRedirects = true
+            connection.setRequestProperty("User-Agent", "SecMan/1.0")
+            val status = connection.responseCode
+            connection.disconnect()
+            HttpResponse.ok(mapOf("reachable" to (status in 200..399), "statusCode" to status))
+        } catch (e: IllegalArgumentException) {
+            HttpResponse.ok(mapOf("reachable" to false, "reason" to "Invalid URL format"))
+        } catch (e: Exception) {
+            HttpResponse.ok(mapOf("reachable" to false, "reason" to (e.message ?: "Unreachable")))
         }
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/domain/ApplicationRegister.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/ApplicationRegister.kt
@@ -100,6 +100,12 @@ data class ApplicationRegister(
     @Column(name = "cmdb_workspace_url", columnDefinition = "TEXT")
     var cmdbWorkspaceUrl: String? = null,
 
+    @Column(name = "github_repository_url", columnDefinition = "TEXT")
+    var githubRepositoryUrl: String? = null,
+
+    @Column(name = "aws_account_ids", columnDefinition = "TEXT")
+    var awsAccountIds: String? = null,
+
     @Column(name = "created_at", updatable = false)
     var createdAt: LocalDateTime? = null,
 

--- a/src/backendng/src/main/kotlin/com/secman/dto/ApplicationRegisterDtos.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/ApplicationRegisterDtos.kt
@@ -27,7 +27,9 @@ data class ApplicationRegisterRequest(
     val backupRecoveryUrl: String? = null,
     val incidentAssignmentGroup: String? = null,
     val notes: String? = null,
-    val cmdbWorkspaceUrl: String? = null
+    val cmdbWorkspaceUrl: String? = null,
+    val githubRepositoryUrl: String? = null,
+    val awsAccountIds: List<String> = emptyList()
 )
 
 @Serdeable
@@ -101,6 +103,8 @@ data class ApplicationRegisterDetail(
     val incidentAssignmentGroup: String?,
     val notes: String?,
     val cmdbWorkspaceUrl: String?,
+    val githubRepositoryUrl: String?,
+    val awsAccountIds: List<String>,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
     val createdBy: String?,
@@ -131,6 +135,8 @@ data class ApplicationRegisterDetail(
                 incidentAssignmentGroup = application.incidentAssignmentGroup,
                 notes = application.notes,
                 cmdbWorkspaceUrl = application.cmdbWorkspaceUrl,
+                githubRepositoryUrl = application.githubRepositoryUrl,
+                awsAccountIds = application.awsAccountIds?.split(",")?.map { it.trim() }?.filter { it.isNotBlank() } ?: emptyList(),
                 createdAt = application.createdAt,
                 updatedAt = application.updatedAt,
                 createdBy = application.createdBy,

--- a/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterService.kt
@@ -116,7 +116,9 @@ open class ApplicationRegisterService(
             backupRecoveryUrl = request.backupRecoveryUrl.clean(),
             incidentAssignmentGroup = request.incidentAssignmentGroup.clean(),
             notes = request.notes.clean(),
-            cmdbWorkspaceUrl = request.cmdbWorkspaceUrl.clean()
+            cmdbWorkspaceUrl = request.cmdbWorkspaceUrl.clean(),
+            githubRepositoryUrl = request.githubRepositoryUrl.clean(),
+            awsAccountIds = request.awsAccountIds.map { it.trim() }.filter { it.isNotBlank() }
         )
     }
 
@@ -140,6 +142,8 @@ open class ApplicationRegisterService(
         application.incidentAssignmentGroup = request.incidentAssignmentGroup
         application.notes = request.notes
         application.cmdbWorkspaceUrl = request.cmdbWorkspaceUrl
+        application.githubRepositoryUrl = request.githubRepositoryUrl
+        application.awsAccountIds = if (request.awsAccountIds.isEmpty()) null else request.awsAccountIds.joinToString(",")
     }
 
     private fun allocateCarId(): String {

--- a/src/backendng/src/main/resources/db/migration/V242__application_register_github_aws.sql
+++ b/src/backendng/src/main/resources/db/migration/V242__application_register_github_aws.sql
@@ -1,0 +1,3 @@
+ALTER TABLE application_register
+    ADD COLUMN github_repository_url TEXT NULL,
+    ADD COLUMN aws_account_ids       TEXT NULL;

--- a/src/frontend/src/components/ApplicationRegister.tsx
+++ b/src/frontend/src/components/ApplicationRegister.tsx
@@ -3,6 +3,7 @@ import { formatServerDate } from '../utils/dateUtils';
 import { getUser } from '../utils/auth';
 import { isAdmin, isSecChampion } from '../utils/permissions';
 import {
+  checkGithubUrl,
   createApplication,
   deleteApplication,
   getApplication,
@@ -68,6 +69,8 @@ const emptyForm: ApplicationRegisterSaveRequest = {
   incidentAssignmentGroup: '',
   notes: '',
   cmdbWorkspaceUrl: '',
+  githubRepositoryUrl: '',
+  awsAccountIds: [],
 };
 
 const tabs: Array<{ key: TabKey; label: string; icon: string }> = [
@@ -85,6 +88,7 @@ const fieldGroups: Record<Exclude<TabKey, 'relations'>, Array<{ name: keyof Appl
     { name: 'applicationTechnology', label: 'Application technology', options: ['SAAS', 'Other'] },
     { name: 'applicationArchitecture', label: 'Application architecture', options: ['Legacy', 'Container'] },
     { name: 'backupRecoveryUrl', label: 'Backup and recovery URL' },
+    { name: 'cmdbWorkspaceUrl', label: 'CMDB workspace URL' },
   ],
   organization: [
     { name: 'incidentAssignmentGroup', label: 'Incident management group' },
@@ -104,7 +108,11 @@ const toForm = (application: ApplicationRegisterDetail): ApplicationRegisterSave
   const form = { ...emptyForm };
   Object.keys(form).forEach((key) => {
     const typedKey = key as keyof ApplicationRegisterSaveRequest;
-    form[typedKey] = (application[typedKey] ?? '') as never;
+    if (typedKey === 'awsAccountIds') {
+      form.awsAccountIds = application.awsAccountIds ?? [];
+    } else {
+      form[typedKey] = (application[typedKey] ?? '') as never;
+    }
   });
   return form;
 };
@@ -130,6 +138,9 @@ const ApplicationRegister: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<ReturnType<typeof getUser>>(null);
+  const [githubCheckStatus, setGithubCheckStatus] = useState<'idle' | 'checking' | 'reachable' | 'unreachable'>('idle');
+  const [githubCheckMessage, setGithubCheckMessage] = useState<string>('');
+  const [awsAccountInput, setAwsAccountInput] = useState('');
   const importInputRef = useRef<HTMLInputElement | null>(null);
 
   const user = currentUser;
@@ -230,6 +241,9 @@ const ApplicationRegister: React.FC = () => {
       setShowForm(true);
       setError(null);
       setSuccess(null);
+      setGithubCheckStatus('idle');
+      setGithubCheckMessage('');
+      setAwsAccountInput('');
       window.setTimeout(() => window.scrollTo({ top: 0, behavior: 'smooth' }), 0);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load application');
@@ -249,6 +263,44 @@ const ApplicationRegister: React.FC = () => {
     setShowForm(true);
     setError(null);
     setSuccess(null);
+    setGithubCheckStatus('idle');
+    setGithubCheckMessage('');
+    setAwsAccountInput('');
+  };
+
+  const runGithubCheck = async () => {
+    const url = (formData.githubRepositoryUrl ?? '').trim();
+    if (!url) return;
+    setGithubCheckStatus('checking');
+    setGithubCheckMessage('');
+    try {
+      const result = await checkGithubUrl(url);
+      if (result.reachable) {
+        setGithubCheckStatus('reachable');
+        setGithubCheckMessage(`Reachable (HTTP ${result.statusCode})`);
+      } else {
+        setGithubCheckStatus('unreachable');
+        setGithubCheckMessage(result.reason ?? `HTTP ${result.statusCode}`);
+      }
+    } catch {
+      setGithubCheckStatus('unreachable');
+      setGithubCheckMessage('Check failed');
+    }
+  };
+
+  const addAwsAccount = () => {
+    const id = awsAccountInput.trim();
+    if (!id) return;
+    const current = formData.awsAccountIds ?? [];
+    if (!current.includes(id)) {
+      updateField('awsAccountIds', [...current, id]);
+    }
+    setAwsAccountInput('');
+  };
+
+  const removeAwsAccount = (accountId: string) => {
+    const current = formData.awsAccountIds ?? [];
+    updateField('awsAccountIds', current.filter((a) => a !== accountId));
   };
 
   const cancelForm = () => {
@@ -260,9 +312,12 @@ const ApplicationRegister: React.FC = () => {
     setShowForm(false);
     setError(null);
     setSuccess(null);
+    setGithubCheckStatus('idle');
+    setGithubCheckMessage('');
+    setAwsAccountInput('');
   };
 
-  const updateField = (name: keyof ApplicationRegisterSaveRequest, value: string) => {
+  const updateField = (name: keyof ApplicationRegisterSaveRequest, value: string | string[]) => {
     setFormData((current) => ({ ...current, [name]: value }));
   };
 
@@ -692,6 +747,86 @@ const ApplicationRegister: React.FC = () => {
                 ) : (
                   <div className="row g-3">
                     {activeTab === 'operation' ? renderOperationFields() : fieldGroups[activeTab].map(renderField)}
+                    {activeTab === 'technical' && (
+                      <>
+                        <div className="col-12">
+                          <label className="form-label small fw-semibold text-secondary">GitHub Repository URL</label>
+                          <div className="input-group input-group-sm">
+                            <input
+                              className="form-control"
+                              type="url"
+                              placeholder="https://github.com/org/repo"
+                              value={formData.githubRepositoryUrl ?? ''}
+                              disabled={isReadOnly}
+                              onChange={(event) => {
+                                updateField('githubRepositoryUrl', event.target.value);
+                                setGithubCheckStatus('idle');
+                                setGithubCheckMessage('');
+                              }}
+                            />
+                            {!isReadOnly && (
+                              <button
+                                type="button"
+                                className="btn btn-outline-secondary"
+                                disabled={!formData.githubRepositoryUrl?.trim() || githubCheckStatus === 'checking'}
+                                onClick={() => void runGithubCheck()}
+                              >
+                                {githubCheckStatus === 'checking' ? (
+                                  <><span className="spinner-border spinner-border-sm me-1"></span>Checking...</>
+                                ) : (
+                                  <><i className="bi bi-link-45deg me-1"></i>Check</>
+                                )}
+                              </button>
+                            )}
+                          </div>
+                          {githubCheckStatus === 'reachable' && (
+                            <div className="text-success small mt-1"><i className="bi bi-check-circle me-1"></i>{githubCheckMessage}</div>
+                          )}
+                          {githubCheckStatus === 'unreachable' && (
+                            <div className="text-danger small mt-1"><i className="bi bi-x-circle me-1"></i>Unreachable: {githubCheckMessage}</div>
+                          )}
+                        </div>
+                        <div className="col-12">
+                          <label className="form-label small fw-semibold text-secondary">AWS Account IDs</label>
+                          {!isReadOnly && (
+                            <div className="input-group input-group-sm mb-2">
+                              <input
+                                className="form-control"
+                                type="text"
+                                placeholder="123456789012"
+                                value={awsAccountInput}
+                                onChange={(event) => setAwsAccountInput(event.target.value)}
+                                onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); addAwsAccount(); } }}
+                              />
+                              <button type="button" className="btn btn-outline-primary" onClick={addAwsAccount} disabled={!awsAccountInput.trim()}>
+                                <i className="bi bi-plus"></i> Add
+                              </button>
+                            </div>
+                          )}
+                          {(formData.awsAccountIds ?? []).length === 0 ? (
+                            <div className="text-secondary small">No AWS accounts linked.</div>
+                          ) : (
+                            <div className="d-flex flex-wrap gap-2">
+                              {(formData.awsAccountIds ?? []).map((accountId) => (
+                                <span key={accountId} className="badge bg-light text-dark border d-flex align-items-center gap-1 px-2 py-1">
+                                  <i className="bi bi-cloud"></i>
+                                  {accountId}
+                                  {!isReadOnly && (
+                                    <button
+                                      type="button"
+                                      className="btn-close btn-close-sm ms-1"
+                                      style={{ fontSize: '0.6rem' }}
+                                      aria-label="Remove"
+                                      onClick={() => removeAwsAccount(accountId)}
+                                    />
+                                  )}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/frontend/src/services/applicationRegisterService.ts
+++ b/src/frontend/src/services/applicationRegisterService.ts
@@ -34,6 +34,8 @@ export interface ApplicationRegisterDetail extends ApplicationRegisterSummary {
   incidentAssignmentGroup?: string | null;
   notes?: string | null;
   cmdbWorkspaceUrl?: string | null;
+  githubRepositoryUrl?: string | null;
+  awsAccountIds?: string[];
   createdAt?: string | null;
   createdBy?: string | null;
   updatedBy?: string | null;
@@ -60,6 +62,7 @@ const optionalApplicationFields: Array<keyof ApplicationRegisterSaveRequest> = [
   'incidentAssignmentGroup',
   'notes',
   'cmdbWorkspaceUrl',
+  'githubRepositoryUrl',
 ];
 
 function sanitizeRequest(request: ApplicationRegisterSaveRequest): ApplicationRegisterSaveRequest {
@@ -105,6 +108,11 @@ export async function deleteApplication(id: number): Promise<void> {
     const body = await response.json().catch(() => ({}));
     throw new Error(body.error || body.message || `Failed to delete application: ${response.status}`);
   }
+}
+
+export async function checkGithubUrl(url: string): Promise<{ reachable: boolean; statusCode?: number; reason?: string }> {
+  const params = new URLSearchParams({ url });
+  return parseOrThrow(await authenticatedGet(`/api/applications/check-github-url?${params.toString()}`), 'Failed to check URL');
 }
 
 export async function replaceApplicationAssets(id: number, assetIds: number[]): Promise<ApplicationRegisterDetail> {


### PR DESCRIPTION
## Summary

- **GitHub Repository URL** — new optional field on each application with an inline **Check** button that performs a server-side HTTP HEAD request and shows reachability feedback (green "Reachable (HTTP 200)" or red error reason) without any CORS issues
- **AWS Account IDs** — dynamic list of account IDs (12-digit strings); users add entries via text input + Enter/Add button and remove them with the × badge button
- **DB migration V242** — adds `github_repository_url TEXT` and `aws_account_ids TEXT` (comma-separated) to `application_register`; no breaking schema changes
- Both fields appear in the **Technical Details** tab of the application form alongside the existing technology/architecture/backup URL fields

## Changes

| Layer | File | What changed |
|---|---|---|
| DB | `V242__application_register_github_aws.sql` | Two nullable TEXT columns |
| Entity | `ApplicationRegister.kt` | Two new nullable fields |
| DTOs | `ApplicationRegisterDtos.kt` | Request + Detail DTOs extended; `awsAccountIds` parsed from comma-separated on read |
| Service | `ApplicationRegisterService.kt` | `clean()` and `apply()` handle new fields; list→CSV on write |
| Controller | `ApplicationRegisterController.kt` | New `GET /api/applications/check-github-url?url=` endpoint (IS_AUTHENTICATED, blocking executor) |
| Frontend service | `applicationRegisterService.ts` | New types + `checkGithubUrl()` helper |
| Frontend component | `ApplicationRegister.tsx` | GitHub URL input with Check button + status badge; AWS account badge list in Technical Details tab |

## Test plan

- [ ] Create a new application, enter a valid GitHub URL, click Check → green "Reachable" badge appears
- [ ] Enter an invalid/unreachable URL, click Check → red "Unreachable" badge with reason
- [ ] Add multiple AWS account IDs, verify they appear as removable badges; save and reopen → IDs persist
- [ ] View mode: GitHub URL and AWS account badges are read-only (no Check button, no remove button)
- [ ] Export/import round-trip preserves the new fields

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYQF7tB4vfsUCB4GDuSFhw)_