### PR TITLE
Add DB-aware /health check and backend watchdog for DB-loss auto-restart

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -275,20 +275,34 @@ Required: change default admin password; unique `JWT_SECRET`/`SECMAN_ENCRYPTION_
 ## Monitor
 
 ```bash
-curl http://localhost:8080/health      # {"status":"UP",...}
+curl http://localhost:8080/health      # {"status":"UP","checks":{"database":"UP"},...} or 503 DOWN
 curl http://localhost:4321/
 sudo journalctl -u secman-backend  -f
 sudo journalctl -u secman-frontend -f
 sudo tail -f /var/log/nginx/secman-api-{access,error}.log
 ```
 
-Watchdog `/opt/secman/bin/monitor.sh`:
+`/health` actually probes the database (bounded ~3s `SELECT 1`, independent of HikariCP's own 30s connection-timeout) and returns HTTP 503 with `checks.database: "DOWN"` when the DB is unreachable — this is what caught a production incident where the backend silently lost its DB connection and never recovered on its own.
+
+Frontend-only watchdog `/opt/secman/bin/monitor.sh` (unchanged, still handles the frontend; the backend DB-outage case is handled by the dedicated script below):
 ```bash
 #!/usr/bin/env bash
-curl -sf http://localhost:8080/health >/dev/null || { logger -t secman-monitor "backend down";  systemctl restart secman-backend;  }
-curl -sf http://localhost:4321/        >/dev/null || { logger -t secman-monitor "frontend down"; systemctl restart secman-frontend; }
+curl -sf http://localhost:4321/ >/dev/null || { logger -t secman-monitor "frontend down"; systemctl restart secman-frontend; }
 ```
 `*/5 * * * * /opt/secman/bin/monitor.sh`
+
+Backend DB-loss watchdog (`check_backend_health.py`, stdlib-only Python; restarts `secman-backend` only after `--fail-threshold` consecutive failed probes, and suppresses repeat restarts for `--restart-cooldown-minutes` while the DB itself stays down, alerting via Telegram either way):
+```cron
+*/2 * * * * TELEGRAM_BOT_TOKEN=… TELEGRAM_CHAT_ID=… \
+  /opt/secman/src/clinotify/check_backend_health.py \
+  --url https://secman.example.com --fail-threshold 2 --restart-cooldown-minutes 15 \
+  >> /var/log/secman-backend-monitor.log 2>&1
+```
+Requires the cron user to restart the service without a password prompt, e.g. `/etc/sudoers.d/secman-monitor`:
+```
+secman ALL=(root) NOPASSWD: /usr/bin/systemctl restart secman-backend
+```
+and invoke the script with `sudo` in the cron line if the cron user isn't root. State (consecutive-failure count, last-restart timestamp) persists at `--state-file` (default `/var/tmp/secman-backend-monitor.json`). Test safely with `--dry-run` (logs/alerts as usual, skips the actual `systemctl restart`).
 
 CrowdStrike checkin freshness alert (Telegram, stdlib-only Python):
 ```cron

--- a/src/backendng/src/main/kotlin/com/secman/controller/HealthController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/HealthController.kt
@@ -1,30 +1,82 @@
 package com.secman.controller
 
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.serde.annotation.Serdeable
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import javax.sql.DataSource
 
 @Controller
-class HealthController {
+class HealthController @Inject constructor(
+    private val dataSource: DataSource
+) {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(HealthController::class.java)
+        private const val DB_CHECK_TIMEOUT_SECONDS = 3L
+        private val probeExecutor = Executors.newCachedThreadPool { r ->
+            Thread(r, "health-db-probe").apply { isDaemon = true }
+        }
+    }
+
+    @Serdeable
+    data class HealthChecks(
+        val database: String
+    )
 
     @Serdeable
     data class HealthResponse(
         val status: String,
         val service: String,
-        val version: String
+        val version: String,
+        val checks: HealthChecks
     )
 
     @Get("/health")
     @Secured(SecurityRule.IS_ANONYMOUS)
     fun health(): HttpResponse<HealthResponse> {
+        val databaseUp = checkDatabase()
+        val overallStatus = if (databaseUp) "UP" else "DOWN"
         val response = HealthResponse(
-            status = "UP",
+            status = overallStatus,
             service = "secman-backend-ng",
-            version = "0.1"
+            version = "0.1",
+            checks = HealthChecks(database = if (databaseUp) "UP" else "DOWN")
         )
-        return HttpResponse.ok(response)
+        return if (databaseUp) {
+            HttpResponse.ok(response)
+        } else {
+            HttpResponse.status<HealthResponse>(HttpStatus.SERVICE_UNAVAILABLE).body(response)
+        }
+    }
+
+    /**
+     * Bounded on a separate thread: Hikari's own connection-timeout is 30s,
+     * far too slow for a watchdog probe that needs to detect DB loss quickly.
+     */
+    private fun checkDatabase(): Boolean {
+        return try {
+            probeExecutor.submit<Boolean> {
+                dataSource.connection.use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT 1").use { it.next() }
+                    }
+                }
+            }.get(DB_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: TimeoutException) {
+            logger.warn("Health check: database probe timed out after {}s", DB_CHECK_TIMEOUT_SECONDS)
+            false
+        } catch (e: Exception) {
+            logger.warn("Health check: database probe failed: {}", e.message)
+            false
+        }
     }
 }

--- a/src/backendng/src/test/kotlin/com/secman/controller/HealthControllerTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/HealthControllerTest.kt
@@ -1,0 +1,72 @@
+package com.secman.controller
+
+import io.micronaut.http.HttpStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Statement
+import javax.sql.DataSource
+
+class HealthControllerTest {
+
+    @Test
+    fun `health returns UP with 200 when database is reachable`() {
+        val resultSet: ResultSet = mockk()
+        every { resultSet.next() } returns true
+        every { resultSet.close() } returns Unit
+
+        val statement: Statement = mockk()
+        every { statement.executeQuery("SELECT 1") } returns resultSet
+        every { statement.close() } returns Unit
+
+        val connection: Connection = mockk()
+        every { connection.createStatement() } returns statement
+        every { connection.close() } returns Unit
+
+        val dataSource: DataSource = mockk()
+        every { dataSource.connection } returns connection
+
+        val controller = HealthController(dataSource)
+        val response = controller.health()
+
+        assertEquals(HttpStatus.OK, response.status)
+        assertEquals("UP", response.body()!!.status)
+        assertEquals("UP", response.body()!!.checks.database)
+    }
+
+    @Test
+    fun `health returns DOWN with 503 when database connection fails`() {
+        val dataSource: DataSource = mockk()
+        every { dataSource.connection } throws SQLException("Connection refused")
+
+        val controller = HealthController(dataSource)
+        val response = controller.health()
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.status)
+        assertEquals("DOWN", response.body()!!.status)
+        assertEquals("DOWN", response.body()!!.checks.database)
+    }
+
+    @Test
+    fun `health returns DOWN with 503 when the query hangs past the probe timeout`() {
+        val connection: Connection = mockk()
+        every { connection.createStatement() } answers {
+            Thread.sleep(5000)
+            mockk()
+        }
+        every { connection.close() } returns Unit
+
+        val dataSource: DataSource = mockk()
+        every { dataSource.connection } returns connection
+
+        val controller = HealthController(dataSource)
+        val response = controller.health()
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.status)
+        assertEquals("DOWN", response.body()!!.status)
+    }
+}

--- a/src/clinotify/README.md
+++ b/src/clinotify/README.md
@@ -9,6 +9,82 @@ because they only consume the public CrowdStrike-checkin endpoint.
 
 ## Scripts
 
+### `check_backend_health.py`
+
+Polls `GET /health` (a public, unauthenticated endpoint that probes the
+database with a bounded `SELECT 1`) and restarts the `secman-backend`
+systemd service when the database connection is lost — the failure mode
+that caused a production incident where the backend silently stopped
+working and never recovered on its own.
+
+To avoid restarting on a single transient blip, a restart only fires after
+`--fail-threshold` consecutive failed probes (default: 2). To avoid restart
+storms while the database itself stays down for a longer stretch —
+restarting the backend can't fix a dead database — a restart is suppressed
+for `--restart-cooldown-minutes` after it last fired (default: 15); failures
+are still logged and alerted during the cooldown. Small JSON state
+(consecutive-failure count, last-restart timestamp) persists between runs at
+`--state-file` (default `/var/tmp/secman-backend-monitor.json`), since each
+invocation is a single cron tick.
+
+#### Requirements
+
+* Python 3.9+
+* Stdlib only — no `pip install` needed
+* Network access to the secman host (and `api.telegram.org` if alerting)
+* Permission to run `systemctl restart secman-backend` without a password
+  prompt (see the sudoers snippet in `docs/DEPLOYMENT.md`)
+* A Telegram bot token and chat id (optional — restarts still happen
+  without alerting if unset)
+
+#### Usage
+
+```
+check_backend_health.py --url URL
+                        [--service-name NAME] [--fail-threshold N]
+                        [--restart-cooldown-minutes N] [--state-file PATH]
+                        [--telegram-bot-token TOKEN] [--telegram-chat-id CHAT_ID]
+                        [--insecure] [--timeout SECS] [--dry-run] [--verbose]
+```
+
+| Flag                          | Description                                                       |
+|-------------------------------|---------------------------------------------------------------------|
+| `--url`                       | Base URL of the secman instance (e.g. `https://secman.example.com`). |
+| `--service-name`               | systemd service to restart on failure (default: `secman-backend`).  |
+| `--fail-threshold`             | Consecutive failed probes required before restarting (default: 2).  |
+| `--restart-cooldown-minutes`   | Minimum minutes between restarts (default: 15).                     |
+| `--state-file`                 | Path to persist failure count / last-restart time.                  |
+| `--telegram-bot-token`         | Bot token. Defaults to `$TELEGRAM_BOT_TOKEN`.                        |
+| `--telegram-chat-id`           | Chat id. Defaults to `$TELEGRAM_CHAT_ID`.                            |
+| `--insecure`                   | Disable TLS verification on the secman call (self-signed certs).    |
+| `--timeout`                    | HTTP timeout in seconds (default: 10).                               |
+| `--dry-run`                    | Log/alert as usual but skip the actual `systemctl restart`.         |
+| `--verbose` / `-v`             | Print diagnostic info to stdout.                                    |
+
+#### Exit codes
+
+| Code | Meaning                                                          |
+|------|-------------------------------------------------------------------|
+| `0`  | OK — probe succeeded, or failed but still below `--fail-threshold` |
+| `1`  | Transport / parse error, or the restart itself failed              |
+| `2`  | Invalid arguments                                                  |
+| `3`  | Alert fired (restart triggered, or DOWN and still in cooldown)     |
+
+#### Example
+
+Cron, checked every 2 minutes, alerting via Telegram:
+```cron
+*/2 * * * * TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... \
+  /opt/secman/src/clinotify/check_backend_health.py \
+  --url https://secman.example.com --fail-threshold 2 --restart-cooldown-minutes 15 \
+  >> /var/log/secman-backend-monitor.log 2>&1
+```
+
+Dry run (verify behavior without touching systemd):
+```bash
+./check_backend_health.py --url https://secman.example.com --dry-run --verbose
+```
+
 ### `check_crowdstrike_checkin.py`
 
 Polls `GET /api/crowdstrike/last-checkin` (a public, unauthenticated

--- a/src/clinotify/check_backend_health.py
+++ b/src/clinotify/check_backend_health.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Watch secman's DB-aware /health endpoint and restart the secman-backend
+systemd service when the database connection is lost, so a DB outage (or a
+HikariCP pool that never recovers after one) doesn't leave the backend stuck
+returning errors indefinitely.
+
+Queries
+    GET {secman-url}/health
+which returns JSON like {"status": "UP"|"DOWN", "checks": {"database": "UP"|"DOWN"}}.
+A non-200 response, a transport error, or checks.database != "UP" counts as
+one failed probe.
+
+To avoid restarting on a single transient blip, a restart only fires after
+--fail-threshold consecutive failed probes. To avoid restart storms while the
+database itself stays down for a long stretch (restarting the backend can't
+fix a dead database), once a restart has fired, further restarts are
+suppressed for --restart-cooldown-minutes; failures are still logged/alerted
+during the cooldown. Small JSON state (consecutive-failure count, last-restart
+timestamp, last-known-up flag) persists at --state-file between runs, since
+each invocation is a single cron tick.
+
+Exit codes:
+    0  OK, probe succeeded (or failed but below fail-threshold)
+    1  Transport / parse error, cannot determine backend health
+    2  Invalid arguments
+    3  Alert triggered (restart fired, or DOWN and still in cooldown)
+"""
+
+import argparse
+import json
+import os
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta
+
+
+def probe_health(base_url: str, insecure: bool, timeout: int):
+    """Returns (ok: bool, detail: str). ok is True only on HTTP 200 with
+    checks.database == "UP"."""
+    endpoint = base_url.rstrip("/") + "/health"
+    ctx = ssl._create_unverified_context() if insecure else None
+    req = urllib.request.Request(endpoint, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            body = resp.read().decode("utf-8")
+            status_code = resp.status
+    except urllib.error.HTTPError as e:
+        status_code = e.code
+        body = e.read().decode("utf-8") if e.fp else ""
+    try:
+        parsed = json.loads(body) if body else {}
+    except ValueError:
+        parsed = {}
+    db_status = parsed.get("checks", {}).get("database", "UNKNOWN")
+    ok = status_code == 200 and db_status == "UP"
+    detail = f"HTTP {status_code}, checks.database={db_status}"
+    return ok, detail
+
+
+def send_telegram(token: str, chat_id: str, text: str, timeout: int) -> None:
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = json.dumps({"chat_id": chat_id, "text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Telegram API returned HTTP {resp.status}")
+
+
+def load_state(path: str) -> dict:
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, ValueError):
+        return {}
+
+
+def save_state(path: str, state: dict) -> None:
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(state, f)
+    os.replace(tmp_path, path)
+
+
+def restart_backend(service_name: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    subprocess.run(["systemctl", "restart", service_name], check=True)
+
+
+def log(message: str) -> None:
+    try:
+        subprocess.run(["logger", "-t", "secman-backend-monitor", message], check=False)
+    except FileNotFoundError:
+        pass
+    print(message, file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="Base URL of the secman instance (e.g. https://secman.example.com)",
+    )
+    parser.add_argument(
+        "--service-name",
+        default="secman-backend",
+        help="systemd service to restart on failure (default: secman-backend)",
+    )
+    parser.add_argument(
+        "--fail-threshold",
+        type=int,
+        default=2,
+        help="Consecutive failed probes required before restarting (default: 2)",
+    )
+    parser.add_argument(
+        "--restart-cooldown-minutes",
+        type=int,
+        default=15,
+        help="Minimum minutes between restarts, to avoid restart storms "
+             "while the database itself is down (default: 15)",
+    )
+    parser.add_argument(
+        "--state-file",
+        default="/var/tmp/secman-backend-monitor.json",
+        help="Path to persist consecutive-failure count and last-restart time",
+    )
+    parser.add_argument(
+        "--telegram-bot-token",
+        default=os.environ.get("TELEGRAM_BOT_TOKEN"),
+        help="Telegram bot token (default: $TELEGRAM_BOT_TOKEN). Optional — "
+             "restarts still happen without alerting if unset.",
+    )
+    parser.add_argument(
+        "--telegram-chat-id",
+        default=os.environ.get("TELEGRAM_CHAT_ID"),
+        help="Telegram chat id (default: $TELEGRAM_CHAT_ID)",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS verification when calling the secman endpoint",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=10,
+        help="HTTP timeout in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log/alert as usual but skip the actual systemctl restart",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print diagnostic info to stdout",
+    )
+    args = parser.parse_args()
+
+    if args.fail_threshold < 1:
+        print("error: --fail-threshold must be >= 1", file=sys.stderr)
+        return 2
+    if args.restart_cooldown_minutes < 0:
+        print("error: --restart-cooldown-minutes must be >= 0", file=sys.stderr)
+        return 2
+
+    def alert(text: str) -> None:
+        if not (args.telegram_bot_token and args.telegram_chat_id):
+            return
+        try:
+            send_telegram(args.telegram_bot_token, args.telegram_chat_id, text, args.timeout)
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as e:
+            print(f"error: telegram send failed: {e}", file=sys.stderr)
+
+    state = load_state(args.state_file)
+    consecutive_failures = int(state.get("consecutive_failures", 0))
+    last_restart_raw = state.get("last_restart")
+    was_up = bool(state.get("was_up", True))
+
+    try:
+        ok, detail = probe_health(args.url, args.insecure, args.timeout)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"error: failed to query {args.url}/health: {e}", file=sys.stderr)
+        return 1
+
+    if args.verbose:
+        print(f"probe result: {detail}")
+
+    if ok:
+        if not was_up and consecutive_failures > 0:
+            msg = f"secman recovered: {args.url}/health is UP again ({detail})."
+            log(msg)
+            alert(msg)
+        save_state(args.state_file, {"consecutive_failures": 0, "last_restart": last_restart_raw, "was_up": True})
+        if args.verbose:
+            print("OK: backend healthy")
+        return 0
+
+    consecutive_failures += 1
+    if args.verbose:
+        print(f"failure {consecutive_failures}/{args.fail_threshold} (detail: {detail})")
+
+    if consecutive_failures < args.fail_threshold:
+        save_state(args.state_file, {
+            "consecutive_failures": consecutive_failures,
+            "last_restart": last_restart_raw,
+            "was_up": False,
+        })
+        log(f"secman-backend-monitor: probe failed ({detail}), "
+            f"{consecutive_failures}/{args.fail_threshold} consecutive")
+        return 0
+
+    now = datetime.now()
+    last_restart = datetime.fromisoformat(last_restart_raw) if last_restart_raw else None
+    in_cooldown = last_restart is not None and now - last_restart < timedelta(minutes=args.restart_cooldown_minutes)
+
+    if in_cooldown:
+        msg = (f"secman alert: {args.url}/health still DOWN ({detail}) after "
+               f"{consecutive_failures} consecutive failures, but restart cooldown "
+               f"is active (last restart {last_restart.isoformat()}). Not restarting again.")
+        log(msg)
+        alert(msg)
+        save_state(args.state_file, {
+            "consecutive_failures": consecutive_failures,
+            "last_restart": last_restart_raw,
+            "was_up": False,
+        })
+        return 3
+
+    msg = (f"secman alert: {args.url}/health DOWN ({detail}) for "
+           f"{consecutive_failures} consecutive checks. "
+           f"{'Would restart' if args.dry_run else 'Restarting'} {args.service_name}.")
+    log(msg)
+    try:
+        restart_backend(args.service_name, args.dry_run)
+    except subprocess.CalledProcessError as e:
+        err = f"error: failed to restart {args.service_name}: {e}"
+        log(err)
+        alert(err)
+        save_state(args.state_file, {
+            "consecutive_failures": consecutive_failures,
+            "last_restart": last_restart_raw,
+            "was_up": False,
+        })
+        return 1
+
+    alert(msg)
+    save_state(args.state_file, {
+        "consecutive_failures": 0,
+        "last_restart": now.isoformat(),
+        "was_up": False,
+    })
+    print(msg)
+    return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

In production, the backend lost its database connection and stopped working, but nothing restarted it. Root cause: `/health` was a static stub that always returned `{"status":"UP"}` regardless of DB state (Micronaut's built-in health-indicator system is disabled in `application.yml`), so the existing cron watchdog documented in `docs/DEPLOYMENT.md` never noticed the DB was unreachable.

- **`HealthController.kt`**: `/health` now probes the database with a bounded (~3s) `SELECT 1` on a background thread (independent of HikariCP's own 30s connection-timeout, which is too slow for a watchdog probe). Returns HTTP 200 `{"status":"UP","checks":{"database":"UP"},...}` when reachable, HTTP 503 `{"status":"DOWN","checks":{"database":"DOWN"},...}` otherwise. Stays unauthenticated (`IS_ANONYMOUS`) so external monitors can keep hitting it.
- **`src/clinotify/check_backend_health.py`**: new stdlib-only watchdog script (mirrors the existing `check_crowdstrike_checkin.py` pattern: argparse, `urllib`, Telegram alerting, exit codes) that polls `/health` and restarts the `secman-backend` systemd service after N consecutive failed probes (`--fail-threshold`, default 2 — avoids restarting on a single blip). A cooldown (`--restart-cooldown-minutes`, default 15) prevents restart storms while the DB itself stays down for longer, since restarting the backend can't fix a dead DB — it keeps alerting via Telegram instead. Supports `--dry-run` for safe testing.
- **Docs**: `docs/DEPLOYMENT.md` and `src/clinotify/README.md` updated with the new `/health` response shape, the new cron entry, the sudoers snippet needed to let the watchdog restart the service, and state-file/threshold details.

## Test plan

- [x] Manual code review against existing codebase conventions (`HttpResponse.status<T>(...)` pattern, `DataSource` bean wiring via `micronaut-jdbc-hikari`) since a full `./gradlew build` isn't reachable from this sandboxed environment (Maven Central / Gradle plugin portal are blocked by network policy here).
- [x] New unit test `HealthControllerTest` (Mockk-based, no DB needed): UP/200 case, SQLException/503 case, timeout/503 case.
- [x] `check_backend_health.py` exercised end-to-end against a local mock `/health` server: consecutive-failure counting, dry-run restart trigger, cooldown suppression of repeat restarts, recovery alert, bad-args and transport-error exit codes — all verified manually.
- [ ] `./gradlew build` (please run in CI / locally — could not run here due to network policy)
- [ ] `./scripts/startbackenddev.sh` + `curl $SECMAN_HOST/health` (confirm 200/UP with DB up, 503/DOWN with DB stopped)
- [ ] `/e2ejs` and `/e2evulnexception` per repo policy for `src/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013tMMkyaKXaTNgCejo4dtLe)_