### PR TITLE
Document MCP tool for application register quality-check reminders

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -680,7 +680,7 @@ sudo yum install nmap      # RHEL/CentOS
 
 ### `send-application-register-reminders` — application register overdue reminders
 
-Notifies responsible users about application register entries that have not been reviewed within a configurable threshold (default: 365 days). Calls `POST /api/cli/application-register/reminders/send`. Requires `ADMIN`.
+Emails each overdue application register entry's business owner and application manager when `Last quality check` is older than the threshold (or unset). Default threshold: 365 days. Calls `POST /api/cli/application-register/reminders/send`. Requires `ADMIN`.
 
 ```bash
 ./scripts/secman send-application-register-reminders --dry-run

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -211,6 +211,7 @@ curl -XPOST http://localhost:8080/mcp \
 - **`delete_user`** (ADMIN) — `email`*.
 - **`send_admin_summary`** (ADMIN) — same payload as CLI `send-admin-summary`.
 - **`send_patch_notifications`** (ADMIN) — notify users about missing patches (overdue vulnerabilities), filtered by the first character of their email. Args: `emailPrefix`* (e.g. `"a"`), `days` (default `30`), `dryRun` (default `false`). Mirrors CLI `send-patch-notifications`. Requires User Delegation.
+- **`send_application_register_reminders`** (ADMIN) — emails each application register entry's business owner and application manager when `lastQualityCheck` is older than `days` (or unset). Args: `days` (default `365`, min `1`), `dryRun` (default `false` — preview overdue entries and recipients without sending). Result includes `status` (`SUCCESS`/`DRY_RUN`/`PARTIAL_FAILURE`/`FAILURE`), `entriesOverdue`, `recipientCount`, `emailsSent`, `emailsFailed`, `recipients[]`, `failedRecipients[]`. API-key permission: `NOTIFICATIONS_SEND`. Mirrors CLI `send-application-register-reminders`. Requires User Delegation.
 
 ### GitHub repositories (delegation)
 - **`import_github_repos`** (ADMIN/VULN) — imports every repository accessible via the configured GitHub App, including each repo's open high/critical Dependabot alert counts, and writes one finding snapshot per run (the 30-day history). No arguments. API-key permission: `VULNERABILITIES_READ`. Errors: `NO_GITHUB_CONFIG` when no active GitHub App configuration exists (Admin → GitHub App). Mirrors CLI `import-github-repos`. Requires User Delegation.

--- a/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterReminderService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ApplicationRegisterReminderService.kt
@@ -51,9 +51,6 @@ class ApplicationRegisterReminderService(
             }
             val ok = emailService.sendEmail(recipient, subject, bodyText, renderHtmlBody(bodyText)).get()
             if (ok) sent += recipient else failed += recipient
-            if (verbose) {
-                // no-op, method kept for parity with other send services
-            }
         }
 
         val status = when {

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendApplicationRegisterRemindersCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendApplicationRegisterRemindersCommand.kt
@@ -52,5 +52,22 @@ class SendApplicationRegisterRemindersCommand : Runnable {
         println("Recipients: ${result["recipientCount"]}")
         println("Emails sent: ${result["emailsSent"]}")
         println("Emails failed: ${result["emailsFailed"]}")
+
+        if (verbose) {
+            @Suppress("UNCHECKED_CAST")
+            val recipients = result["recipients"] as? List<String> ?: emptyList()
+            @Suppress("UNCHECKED_CAST")
+            val failedRecipients = result["failedRecipients"] as? List<String> ?: emptyList()
+            if (recipients.isNotEmpty()) {
+                println()
+                println(if (dryRun) "Would notify:" else "Notified:")
+                recipients.forEach { println("  - $it") }
+            }
+            if (failedRecipients.isNotEmpty()) {
+                println()
+                println("Failed to notify:")
+                failedRecipients.forEach { println("  - $it") }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

The requested feature — CLI + MCP function to notify Application Register business owners / application managers when `Last quality check` is older than a configurable threshold (default 365 days), with a dry-run mode — was already implemented end-to-end on `main`:

- CLI: `send-application-register-reminders --days <n> --dry-run --verbose`
- MCP tool: `send_application_register_reminders` (ADMIN, requires User Delegation, `NOTIFICATIONS_SEND` permission)
- Service: `ApplicationRegisterReminderService` (repository query `findEntriesOverdueForQualityCheck`)
- CLI docs: `docs/CLI.md`

This PR closes the two real gaps found while verifying that:

1. **`docs/MCP.md` had no entry** for `send_application_register_reminders` — added, following the existing format used by neighboring `NOTIFICATIONS_SEND` tools.
2. **`--verbose` on the CLI command was a documented no-op** — the docs described it as producing "detailed per-recipient output," but neither the CLI command nor the service actually printed anything extra when the flag was set. Fixed by having the CLI command print the `recipients[]` / `failedRecipients[]` lists already returned in the API response (same idiom already used in `NotifyNewAccountsCommand.kt`). Also removed the corresponding dead no-op branch in `ApplicationRegisterReminderService`.

## Changes

- `docs/MCP.md` — new bullet documenting `send_application_register_reminders`.
- `docs/CLI.md` — tightened the description of `send-application-register-reminders` to explicitly name business owner + application manager as recipients.
- `src/cli/.../SendApplicationRegisterRemindersCommand.kt` — `--verbose` now prints the notified/would-notify and failed recipient lists.
- `src/backendng/.../ApplicationRegisterReminderService.kt` — removed dead no-op `if (verbose)` block.

## Note on verification

I was unable to run `./gradlew build` or `./scripts/startbackenddev.sh` in this environment — the sandbox's network policy blocks `services.gradle.org`, `plugins.gradle.org`, and `repo.maven.apache.org` (needed to fetch the Gradle 9.6.1 wrapper distribution / resolve the Kotlin Gradle plugin), so the build tooling itself is unreachable. I did:
- Manually re-read every changed file for syntax correctness.
- Confirmed the new CLI verbose-output code matches an existing, working idiom byte-for-byte in style (`NotifyNewAccountsCommand.kt`'s `(result["recipients"] as? List<String>) ?: emptyList()` pattern).
- Confirmed the `recipients`/`failedRecipients` fields already exist on the JSON response DTO (`CliController.ApplicationRegisterReminderResultDto`), so no backend/DTO change was needed for the CLI fix.

Given this, a CI run or manual `./gradlew build` should still be performed to confirm compilation before merging.

## Test plan

- [ ] `./gradlew build` (blocked locally by network policy — needs to run in CI or a non-sandboxed environment)
- [ ] `./scripts/startbackenddev.sh` starts cleanly
- [ ] `./scripts/secman send-application-register-reminders --dry-run` prints overdue entries/recipients
- [ ] `./scripts/secman send-application-register-reminders --dry-run --verbose` additionally lists recipients
- [ ] MCP `send_application_register_reminders` tool callable per `docs/MCP.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XbFFq5gvakPkHtrKDFBoYp)_