### PR TITLE
Fix race conditions across business logic and SQL, add analysis doc

### DIFF
--- a/docs/RACE_CONDITIONS.md
+++ b/docs/RACE_CONDITIONS.md
@@ -1,0 +1,392 @@
+# Race-Condition Analysis — Business Logic & SQL
+
+Systematic review of the backend for concurrency defects: check-then-act windows,
+lost updates, transaction-boundary mistakes, and SQL-level races. Each finding lists
+the location, the interleaving that triggers it, the consequence, and the fix —
+**Fixed** items were remediated in the change that introduced this document;
+**Deferred** items are documented with a recommended follow-up.
+
+Environment facts that frame the analysis:
+
+- MariaDB / InnoDB with the connection pool at **READ COMMITTED**
+  (see `CrowdStrikeVulnerabilityImportService` and `application.yml`). Uncommitted
+  concurrent writes are invisible, so *pre-insert* count/exists checks can never
+  see a racing insert.
+- Only two entities carry `@Version` optimistic locking: `Workgroup` and
+  `VulnerabilityExceptionRequest`. All other mutable shared entities have no
+  lost-update protection.
+- `hbm2ddl.auto: update` does **not** retro-add a `@Column(unique = true)` to a
+  column that already existed — annotated uniqueness may be unenforced on
+  long-lived databases (see Deferred D5).
+- Micronaut AOP is bypassed on direct self-invocation: a `@Transactional` /
+  `@Async` method called on `this` from the same class runs **without** its
+  advice. The in-repo cure is the `selfProvider` pattern
+  (`jakarta.inject.Provider<Self>`, see `CrowdStrikeVulnerabilityImportService`).
+
+## Recurring root-cause patterns and their canonical fixes
+
+| Pattern | Canonical fix (in-repo example) |
+|---|---|
+| Check-then-act (find→create, count→insert, read-flag→send) | DB unique constraint + catch-violation-and-refetch; or atomic guarded `UPDATE … WHERE <precondition>` checking affected rows; or insert-then-recheck with deterministic ranking |
+| Read-modify-write without `@Version` | `@Version` + `DeadlockRetry` (see `VulnerabilityExceptionRequest` approval flow) |
+| Self-invocation bypassing `@Transactional`/`@Async` | `selfProvider.get().method()` (`CrowdStrikeVulnerabilityImportService`) |
+| `@Scheduled` jobs with no mutual exclusion | Per-row claim via guarded `UPDATE` in `REQUIRES_NEW` (this change); optionally a `GET_LOCK`-based scheduler mutex (deferred) |
+| Side effects racing the publishing transaction | `@TransactionalEventListener(AFTER_COMMIT)` (`ExceptionRequestNotificationListener`) — but only when every publisher runs inside a transaction |
+
+---
+
+## HIGH severity
+
+### H1 — Asset find-or-create races (no unique constraint on `asset.name`) — *Mitigated, constraint Deferred (D1)*
+
+**Locations:** `AssetMergeService.findOrCreateAsset` / `importAsset`,
+`CrowdStrikeVulnerabilityImportService.createNewAsset`,
+`AwsAccountRiskAssessmentService.findOrCreateAccountAsset`,
+`VulnerabilityService.addVulnerabilityFromCliLocked`.
+
+**Race:** every path is `findByName(…)` → conditional `save(…)`. Two concurrent
+imports of the same brand-new hostname both see "absent" and both insert.
+`asset.name` has only a non-unique index (`idx_asset_name`), so the result is
+**two asset rows with the same name** — split vulnerability history, inflated
+dashboard counts. The CrowdStrike importer's `PESSIMISTIC_WRITE` lock only covers
+assets that already exist; it cannot lock a row that hasn't been inserted yet.
+Concurrent importers are the norm (the CrowdStrike CLI runs 3 workers).
+
+**Fixed (mitigation):** `AssetMergeService.findOrCreateAsset` and
+`AwsAccountRiskAssessmentService.findOrCreateAccountAsset` now catch a failed
+create and re-fetch/merge into the winner's row. The CLI path is serialized by the
+repaired striped lock (H5). **Deferred:** the real fix is a DB unique constraint —
+see D1 for why that migration is not auto-generated here.
+
+### H2 — Requirement-ID sequence read without a lock — *Fixed*
+
+**Location:** `RequirementIdService.getNextId` / `resetSequence`;
+`RequirementIdSequenceRepository`.
+
+**Race:** the repository method was *named* `findByIdForUpdate` but its explicit
+`@Query` was a plain JPQL `SELECT` with no `@Lock` — no `FOR UPDATE` was ever
+emitted. Two concurrent requirement creations read the same `next_value`, both
+format `REQ-N`, and the loser dies on the `uk_requirement_internal_id` unique
+constraint (and the sequence advances by 1 instead of 2).
+
+**Fix:** `getNextId`/`resetSequence` now lock the sequence row via
+`entityManager.find(…, LockModeType.PESSIMISTIC_WRITE)` (a real
+`SELECT … FOR UPDATE`) inside their `@Transactional`; the misleading repository
+method was removed.
+
+### H3 — Materialized-view swap not atomic (self-invocation) — *Fixed*
+
+**Location:** `MaterializedViewRefreshService.executeRefresh` →
+`swapMaterializedView`.
+
+**Race:** `swapMaterializedView` is `@Transactional` and was written to make the
+`deleteAll()` + `saveAll()` replacement atomic — but it was invoked on `this`
+from `executeRefresh`, so Micronaut's AOP proxy was bypassed and the two
+repository calls committed **separately**. Any reader (user dashboard "Overdue
+Patching", Outdated Assets page) between the two commits saw an empty or
+half-built view — exactly the "false 0 overdue assets" bug the method's comment
+claims to have fixed. `updateJob` had the same latent issue.
+
+**Fix:** injected `Provider<MaterializedViewRefreshService>` and routed
+`swapMaterializedView`, `updateJob`, and `executeRefreshAsync` through
+`selfProvider.get()` (the established Feature-053 pattern).
+
+### H4 — Materialized-view refresh double-start — *Fixed*
+
+**Location:** `MaterializedViewRefreshService.triggerAsyncRefresh`.
+
+**Race:** the "already running?" guard was `findRunningJob()` (plain read) →
+`save(new RUNNING job)`. Two concurrent triggers (manual endpoint + CLI-import
+trigger, or two import batches) both read `null` and both started a full refresh.
+Two concurrent refreshes make even a correctly-atomic swap meaningless — the view
+can end up doubled. The stale-recovery branch also started a second refresh on
+top of a slow-but-alive 60-minute job.
+
+**Fix:** insert-then-recheck. After committing its job row, each trigger re-reads
+all RUNNING jobs; only the lowest job id proceeds — younger duplicates mark
+themselves FAILED ("Duplicate trigger") and return the winner. Deterministic under
+any interleaving because every contender sees all committed rows post-insert.
+
+### H5 — CLI add-vulnerability striped lock broken — *Fixed*
+
+**Location:** `VulnerabilityService.addVulnerabilityFromCli`.
+
+**Race:** the per-hostname lock was removed from the map in `finally`
+(`cliAddLocks.remove(lockKey, lock)`). Interleaving: A holds `lock1`, B blocks on
+`lock1`, A finishes and removes the entry, C creates a fresh `lock2` and enters —
+then B acquires the now-orphaned `lock1` and runs **concurrently with C** for the
+same hostname. That defeats the exact duplicate-asset/lost-update protection the
+lock was built for.
+
+**Fix:** entries are no longer removed — the map is bounded by the number of
+distinct hostnames per JVM lifetime (one `Any` each), which is the standard
+correct form of this idiom.
+
+### H6 — GitHub Dependabot import replace unguarded — *Fixed (+ V243)*
+
+**Location:** `GithubRepoImportService.importRepositories` / `persistRepo`.
+
+**Race (three defects):**
+1. `persistRepo` (`@Transactional`) was self-invoked → advice bypassed → the
+   snapshot insert, alert delete, and alert reinsert each committed separately.
+2. No lock: two concurrent imports (CLI + UI "Import now") interleave
+   delete₁/delete₂/insert₁/insert₂ → **duplicated alert rows** per repo.
+3. No unique constraint on `(github_repository_id, alert_number)` to backstop it.
+
+**Fix:** `persistRepo` is now called through `selfProvider` inside
+`DeadlockRetry.withRetry`; it takes a `PESSIMISTIC_WRITE` lock on the repo row
+(mirroring the CrowdStrike import); migration **V243** dedupes existing rows and
+adds `uk_ghalert_repo_alert UNIQUE (github_repository_id, alert_number)` (also
+declared on the entity).
+
+### H7 — Assessment token double-use — *Fixed*
+
+**Location:** `ResponseController.submitAssessment`; `AssessmentToken`.
+
+**Race:** the one-time token was consumed by `read isUsed==false` →
+`markAsUsed()` → `update()`. Two concurrent submits both passed `isValid()` and
+both completed the assessment; the "used" state was never claimed atomically
+(no `@Version`, no guarded update).
+
+**Fix:** `AssessmentTokenRepository.claimToken` — a guarded
+`UPDATE … SET is_used = true WHERE token = ? AND is_used = false` returning the
+affected-row count. Exactly one submit wins; the loser gets the
+`TOKEN_EXPIRED` response.
+
+### H8 — User-created event listener vs. publishing transaction — *Hardened; dead listener documented*
+
+**Locations:** `UserMappingService.onUserCreated` (`@EventListener @Async`),
+publishers in `UserService.createUser`, `AddUserTool`, `OAuthService`.
+
+**Race:** an `@Async` `@EventListener` fires immediately on `publishEvent`, on
+another thread. If a publisher ever runs inside a transaction, the listener races
+the commit: at READ COMMITTED it cannot see the user row (silently skips mapping
+application) or links mappings to an entity whose transaction may still roll back.
+Today's live publishers happen to publish **after** their save has committed, so
+the window is latent, not active — but nothing enforces that. Converting the
+listener to `@TransactionalEventListener(AFTER_COMMIT)` would be wrong here:
+Micronaut *drops* such events when no transaction is active, which would break all
+current (non-transactional) publishers.
+
+**Fix:** `applyFutureUserMapping` now re-loads the user by id inside its own
+transaction and skips gracefully when the row isn't visible, instead of writing
+FKs against a detached, possibly-uncommitted instance.
+
+**Discovered defect (out of scope, flagged):**
+`UserMappingApplicationService.onUserCreated` listens to a shadow event class
+`com.secman.service.UserCreatedEvent` defined at the bottom of its own file, while
+every publisher publishes `com.secman.event.UserCreatedEvent` — the listener
+**never fires**, so Feature 049's PENDING-mapping auto-application is dead code.
+Enabling it would race `UserMappingService.onUserCreated` over the same rows, so
+this needs a deliberate consolidation, not a one-line fix. Also:
+`UserController.create` (`@Transactional`) creates users **without publishing the
+event at all**, so admin-UI-created users never get pending mappings applied.
+
+### H9 — Safety brakes: count in one snapshot, delete in another — *Partially fixed (asset-match-clear); rest Deferred (D4)*
+
+**Locations:** `AssetMatchClearService.clear`,
+`CrowdStrikeCleanupAuditService.run`/`checkSafetyBrake`,
+`CrowdStrikeVulnerabilityImportService.reconcileStaleCrowdStrikeImports`.
+
+**Race:** candidate lists, brake denominators, and the actual deletes are separate
+statements at READ COMMITTED with no shared snapshot. Worst case in
+asset-match-clear: an asset re-imported (its `cloudInstanceId` re-matched) between
+the scan and the delete loop was still deleted from the stale candidate list —
+**a live asset destroyed**. Two overlapping cleanup runs can also each stay under
+`maxDeletePercent` while their union exceeds it.
+
+**Fix (asset-match-clear):** each candidate is now re-verified immediately before
+deletion (row still exists, instance id still absent from the snapshot, account
+still in scope); re-matched assets are skipped and counted as
+`revalidationSkips`. **Deferred:** single-transaction brake recomputation and a
+run-level mutex for the CrowdStrike cleanup (D4).
+
+---
+
+## MEDIUM severity
+
+### M1 — Export-job concurrency caps count-then-insert — *Fixed*
+
+**Location:** `ExportJobService.startExport`.
+
+**Race:** `count running < cap` → `save` is not atomic; N concurrent requests all
+pass before any insert is visible, so `maxConcurrentPerUser` (default 1) and
+`maxConcurrentGlobal` (default 5) were advisory. Memory-bound Excel exports could
+pile past the ceiling the caps exist to enforce.
+
+**Fix:** the job row is inserted and committed first (`createJobRow`,
+REQUIRES_NEW via self-proxy), then re-checked against committed state: jobs are
+ranked `(createdAt, id)` and only ranks within the cap survive; losers fail their
+own job and throw the same user-facing error as the pre-check. The pre-checks
+remain for the fast common path.
+
+### M2 — AI-job caps (per-assessment + global) count-then-insert — *Fixed*
+
+**Location:** `AiSuggestionJobService.startJob` / `runJobInBackground`.
+
+**Race:** same shape as M1. Two concurrent starts for one assessment both passed
+the `findByRiskAssessmentIdAndStatusIn` guard → two active AI jobs per assessment
+(double LLM spend, racing suggestion writes); the global cap
+(`maxConcurrentJobsGlobal`) was likewise exceedable — defeating the operator's
+cost-concurrency budget.
+
+**Fix:** `checkStartRace` runs at the top of the background runner, **after** the
+job row is committed and **before any paid LLM call**: the lowest active job id
+per assessment wins; globally only the oldest `cap` active jobs proceed; losers
+mark themselves FAILED with a clear reason.
+
+### M3 — Unguarded job status transitions — *Fixed*
+
+**Locations:** `ExportJobService.markJobAsProcessing`/`markJobAsCompleted`/
+`markJobAsFailed`; `AiSuggestionJobService.markRunning`/`markFailed`/
+`applySuccess`/`applyFailure`/`incrementFailed`.
+
+**Race:** all transitions blindly `findById` → set status → `update`. A stale-job
+auto-reset (5-min heartbeat threshold, which a long COUNTING query can exceed) or
+a cancel could mark a job FAILED/CANCELLED while the worker was still running —
+and the worker's `markJobAsCompleted` then **resurrected** it to COMPLETED. AI
+jobs kept accruing cost/counters and writing `Response` rows after cancellation.
+
+**Fix:** every transition now verifies the current status first
+(PENDING/PROCESSING → terminal only; terminal states are never overwritten);
+`applySuccess`/`applyFailure` drop results for terminal jobs (a cancelled job's
+in-flight requirement no longer writes suggestions); an orphaned export file is
+deleted when completion loses the race.
+
+### M4 — Scheduler double-runs: expiration + reminder double-sends — *Fixed*
+
+**Locations:** `ExceptionExpirationScheduler.processExpirations` /
+`sendExpirationReminders`; `AwsAccountRiskAssessmentService.processDeadlineReminders`.
+
+**Race:** with two app instances (or a run overlapping a slow previous one), both
+runs loaded the same APPROVED-expired requests and both sent expiration emails and
+wrote audit rows; the reminder dedup (`reminderSentAt == null` → send → stamp) was
+read-then-write, so both runs sent. The AWS risk-assessment 2-day/1-day reminders
+had the identical pattern.
+
+**Fix:** claim-before-send everywhere. Expirations: atomic
+`UPDATE … SET status='EXPIRED' WHERE id=? AND status='APPROVED'` in a
+REQUIRES_NEW transaction (bumping the `@Version`); only the winner runs the side
+effects. Reminders: atomic `SET …_sent_at = ? WHERE …_sent_at IS NULL`; only the
+winner emails; a failed send releases the claim (best-effort) so the next run
+retries — the documented trade-off is that a lost release skips a reminder rather
+than duplicating it. Loaded entities are deliberately never mutated in the outer
+session so the claims' version bumps can't trigger optimistic-lock rollbacks.
+
+### M5 — OAuth state not atomically consumed — *Fixed*
+
+**Locations:** `OAuthController.callback`/`callbackApi`; `OAuthService`.
+
+**Race:** the state row was deleted only at the **end** of `handleCallback`, so
+for the whole token-exchange window two callbacks carrying the same state
+(browser double-submit, provider retry) both passed the read-only lookup and both
+entered the flow. Only the IdP's single-use authorization code prevented a double
+login; for a brand-new user both callbacks raced `findOrCreateUser`, and the loser
+turned a valid login into "Could not create your account". (The existing
+`findStateByValueWithRetry` addresses the *opposite* race — a fast Azure callback
+arriving before the state-save commit is visible — and is unchanged.)
+
+**Fix:** the controller now claims the state atomically before processing —
+`deleteByStateToken` returns its row count and `claimOAuthState` (REQUIRES_NEW)
+lets exactly one callback win; the loser is rejected up front. Additionally,
+`findOrCreateUser` recovers from a lost provisioning race by re-fetching the
+winner's committed user instead of failing the login.
+
+### M6 — Duplicate AWS-account risk assessments — *Fixed (app-level)*
+
+**Location:** `AwsAccountRiskAssessmentService.createAssessment`;
+`aws_account_risk_assessment` (V237, no unique constraint).
+
+**Race/defect:** nothing prevented a re-run (or two overlapping runs) of the
+mapping import from creating a second `RiskAssessment` + tracking row for the same
+`(account, owner)` — duplicate owner emails and a duplicate reminder stream.
+
+**Fix:** creation is now idempotent — skipped (with the existing assessment id
+reported) when an **open** (STARTED) assessment is already tracked for the pair.
+A hard DB unique on `(aws_account_id, owner_email)` was deliberately not added: a
+*new* assessment for the same pair is legitimate once the previous one completed;
+only concurrent/repeated creation of open ones is a defect. The narrow
+two-overlapping-imports window that remains is bounded by the sequential
+processing inside each import run.
+
+### M7 — find-then-save "upserts" on unique keys — *Fixed*
+
+**Locations:** `VulnerabilityStatisticsCacheService.upsertCache`,
+`AwsCleanServerKpiService.upsertCache`,
+`CrowdStrikeVulnerabilityImportService.upsertAndUnionSeverityHistory`.
+
+**Race:** each was `findByKey` → insert-or-update. Two concurrent writers both saw
+"absent" and both inserted; the loser hit the unique/PK constraint. For the
+severity history this **rolled back the loser's entire reconcile transaction**;
+for the statistics cache it failed a refresh.
+
+**Fix:** native `INSERT … ON DUPLICATE KEY UPDATE` repository methods
+(`upsertByCacheKey`, `upsertSeverity`) — conflict-free under any interleaving,
+using the constraints that already exist (`cache_key` unique, severity PK).
+
+---
+
+## LOW severity / informational (no code change)
+
+- **No `@Version` on hot mutable entities** — `Asset`, `UserMapping`,
+  `AppSettings`, `RiskAssessment`, `Vulnerability`, `ExportJob`,
+  `AiSuggestionJob`, `AssessmentToken`. Concurrent read-modify-write flows
+  (e.g. `AssetMergeService.mergeAssetData` vs. CrowdStrike `updateAsset`) are
+  last-writer-wins: a group-append computed on a stale snapshot can drop the other
+  importer's groups. Recommended: selective `@Version` rollout combined with
+  `DeadlockRetry`-style retries, starting with `Asset`.
+- **`AppSettings` singleton by convention only** — `getOrCreateSettings` is
+  find-all-or-create with no constraint; two concurrent first calls can create two
+  rows and `findAll().first()` becomes nondeterministic. Low traffic; fix together
+  with D5.
+- **Shared SSE progress sink** — `MaterializedViewRefreshService` uses one
+  process-wide multicast sink for all refresh jobs and has no replay; subscribers
+  see other jobs' events (filterable by `jobId`) and late subscribers miss early
+  events. `ExceptionBadgeUpdateHandler`'s KDoc claims `Replay(1)` but builds a
+  plain multicast sink (the initial count is delivered via `Flux.concat`, so
+  behavior is correct — the comment is wrong).
+- **`EmailNotificationEventListener`** — not transaction-phased and runs on a
+  detached coroutine scope; in-flight sends are silently dropped on shutdown.
+  No delivery guarantee is currently claimed, so documented only.
+- **`AiSuggestionJobRepository.findStaleByStatus`** treats a QUEUED job with a
+  `NULL` heartbeat as immediately stale; the hourly watchdog could kill a job in
+  the sub-second window before `markRunning` stamps the first heartbeat. The new
+  status guards prevent any resurrection weirdness; consider adding
+  `createdAt < threshold` to the staleness predicate.
+- **Correct-by-design examples worth copying:** exception-request approval
+  (`@Version` + `DeadlockRetry`), CrowdStrike per-asset replace
+  (`PESSIMISTIC_WRITE` + deadlock retry), `ExceptionRequestNotificationListener`
+  (`AFTER_COMMIT`), `ExceptionMaterializationService` (all races biased toward
+  the safe direction + hourly/daily reconciliation sweeps),
+  `AccessibleAssetIdsCache` (`@RequestScope`, no sharing).
+
+---
+
+## Deferred items (recommended follow-ups)
+
+- **D1 — `UNIQUE` constraint on `asset.name`.** The definitive fix for H1. Not
+  auto-generated here because production databases may already contain duplicate
+  names, and the dedup migration must merge rows while re-pointing FKs
+  (vulnerabilities, scan_results, workgroup links, tags) — a data-shape-dependent
+  operation that should be run deliberately: (1) report duplicates, (2) merge
+  keeping the row with relations/lowest id, (3) `ALTER TABLE asset ADD CONSTRAINT
+  uk_asset_name UNIQUE (name)`. Until then the app-level mitigations from H1/H5
+  bound the exposure.
+- **D2 — Distributed scheduler mutex.** The per-row claims (M4) remove the
+  harmful double-sends, but every `@Scheduled` method still *runs* on every
+  instance. A MariaDB `GET_LOCK`-based mutex (or a claim table) would skip
+  redundant runs wholesale. Architectural choice — one advisory-lock helper could
+  serve all schedulers.
+- **D3 — `@Version` rollout** (see LOW section).
+- **D4 — CrowdStrike cleanup brake in one transaction** + run-level mutual
+  exclusion between the scheduled and manual cleanup paths; same for the
+  reconcile sweep's refreshed/stale counters (currently three separate statements
+  at READ COMMITTED).
+- **D5 — Schema audit for annotated-but-unenforced unique constraints.** Because
+  `hbm2ddl.auto: update` won't add unique indexes to pre-existing columns, verify
+  in production that `users.username`, `users.email`, and other
+  `@Column(unique = true)` columns actually carry unique indexes; add explicit
+  Flyway constraints where missing (with dedup pre-steps).
+- **D6 — Consolidate the user-created listeners** (H8): delete or rewire the dead
+  `UserMappingApplicationService` listener and its shadow event class, and decide
+  whether `UserController.create` should publish `UserCreatedEvent`.

--- a/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/OAuthController.kt
@@ -167,6 +167,15 @@ open class OAuthController(
             logger.info("OAuth state validated: providerId={}, createdAt={}, expiresAt={}",
                 oauthState.providerId, oauthState.createdAt, oauthState.expiresAt)
 
+            // Atomically consume the single-use state BEFORE processing. Of two concurrent
+            // callbacks with the same state (double-submit, provider retry) exactly one wins
+            // this claim; the loser is rejected here instead of racing through token
+            // exchange and user provisioning.
+            if (!oauthService.claimOAuthState(state)) {
+                logger.error("OAuth state already consumed by a concurrent callback (first 10 chars: {})", state.take(10) + "...")
+                return HttpResponse.redirect<Any>(URI.create("$frontendBaseUrl/login?error=oauth_state_mismatch"))
+            }
+
             // Process OAuth callback with the already-validated state
             val result = oauthService.handleCallback(oauthState, code)
 
@@ -227,6 +236,14 @@ open class OAuthController(
             }
 
             val oauthState = stateOpt.get()
+
+            // Atomic single-use claim - see the redirect callback above.
+            if (!oauthService.claimOAuthState(callbackRequest.state)) {
+                logger.error("OAuth state already consumed by a concurrent callback (first 10 chars: {})",
+                    callbackRequest.state.take(10) + "...")
+                return HttpResponse.badRequest(ErrorResponse("Invalid or expired state parameter. Please try again."))
+            }
+
             val result = oauthService.handleCallback(oauthState, callbackRequest.code)
             
             when (result) {

--- a/src/backendng/src/main/kotlin/com/secman/controller/ResponseController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ResponseController.kt
@@ -221,17 +221,22 @@ open class ResponseController(
             
             // Validate all requirements have been answered
             if (responses.size < requirements.size) {
-                return HttpResponse.badRequest(ErrorResponse("INCOMPLETE_ASSESSMENT", 
+                return HttpResponse.badRequest(ErrorResponse("INCOMPLETE_ASSESSMENT",
                     "Assessment is incomplete. ${responses.size} of ${requirements.size} requirements answered."))
             }
-            
+
+            // Atomically claim the one-time token before completing the assessment. The
+            // isValid() check above is only a fast pre-check - two concurrent submits can
+            // both pass it. The guarded UPDATE (WHERE isUsed = false) lets exactly one
+            // request win; the loser gets 0 rows and is rejected here.
+            val claimed = assessmentTokenRepository.claimToken(token, java.time.LocalDateTime.now())
+            if (claimed == 0) {
+                return HttpResponse.badRequest(ErrorResponse("TOKEN_EXPIRED", "Assessment token has expired or been used"))
+            }
+
             // Mark assessment as completed
             assessment.status = "COMPLETED"
             riskAssessmentRepository.update(assessment)
-            
-            // Mark token as used
-            assessmentToken.markAsUsed()
-            assessmentTokenRepository.update(assessmentToken)
             
             // TODO: Send completion notification email to requestor
             

--- a/src/backendng/src/main/kotlin/com/secman/domain/GithubRepoDependabotAlert.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/GithubRepoDependabotAlert.kt
@@ -17,6 +17,10 @@ import java.time.Instant
 @Entity
 @Table(
     name = "github_repo_dependabot_alert",
+    uniqueConstraints = [
+        // Backstop against concurrent-import interleavings duplicating alert rows (V243).
+        UniqueConstraint(name = "uk_ghalert_repo_alert", columnNames = ["github_repository_id", "alert_number"])
+    ],
     indexes = [
         Index(name = "idx_ghalert_repo", columnList = "github_repository_id"),
         Index(name = "idx_ghalert_severity", columnList = "severity")

--- a/src/backendng/src/main/kotlin/com/secman/repository/AssessmentTokenRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AssessmentTokenRepository.kt
@@ -29,6 +29,15 @@ interface AssessmentTokenRepository : JpaRepository<AssessmentToken, Long> {
     fun findValidTokensByRiskAssessmentId(assessmentId: Long, now: LocalDateTime): List<AssessmentToken>
     
     fun deleteByRiskAssessmentId(riskAssessmentId: Long): Long
-    
+
     fun deleteByExpiresAtBefore(date: LocalDateTime): Long
+
+    /**
+     * Atomically claim a one-time token. Returns 1 when this caller won the claim, 0 when the
+     * token was already used (or does not exist). A read-check-write of isUsed is racy — two
+     * concurrent submits both see isUsed=false and both complete the assessment; this guarded
+     * UPDATE lets exactly one submit win.
+     */
+    @Query("UPDATE AssessmentToken t SET t.isUsed = true, t.usedAt = :now, t.updatedAt = :now WHERE t.token = :token AND t.isUsed = false")
+    fun claimToken(token: String, now: LocalDateTime): Int
 }

--- a/src/backendng/src/main/kotlin/com/secman/repository/AwsAccountRiskAssessmentRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/AwsAccountRiskAssessmentRepository.kt
@@ -28,4 +28,39 @@ interface AwsAccountRiskAssessmentRepository : JpaRepository<AwsAccountRiskAsses
         """
     )
     fun findPendingDeadlineReminders(today: LocalDate, windowEnd: LocalDate): List<AwsAccountRiskAssessment>
+
+    /**
+     * Atomically claim the 1-day deadline reminder (claim-before-send). Also stamps the
+     * 2-day slot when still unset, collapsing a missed 2-day reminder into this send.
+     * Returns 1 only for the winning caller - overlapping scheduler runs get 0 and must
+     * not email.
+     */
+    @Query(
+        """
+        UPDATE AwsAccountRiskAssessment t
+        SET t.reminderOneDaySentAt = :now,
+            t.reminderTwoDaysSentAt = COALESCE(t.reminderTwoDaysSentAt, :now)
+        WHERE t.id = :id AND t.reminderOneDaySentAt IS NULL
+        """
+    )
+    fun claimOneDayReminder(id: Long, now: java.time.LocalDateTime): Int
+
+    /** Atomically claim the 2-day deadline reminder. See [claimOneDayReminder]. */
+    @Query("UPDATE AwsAccountRiskAssessment t SET t.reminderTwoDaysSentAt = :now WHERE t.id = :id AND t.reminderTwoDaysSentAt IS NULL")
+    fun claimTwoDayReminder(id: Long, now: java.time.LocalDateTime): Int
+
+    /** Best-effort claim release when the reminder email failed after a successful claim. */
+    @Query(
+        """
+        UPDATE AwsAccountRiskAssessment t
+        SET t.reminderOneDaySentAt = NULL,
+            t.reminderTwoDaysSentAt = CASE WHEN t.reminderTwoDaysSentAt = :claimedAt THEN NULL ELSE t.reminderTwoDaysSentAt END
+        WHERE t.id = :id AND t.reminderOneDaySentAt = :claimedAt
+        """
+    )
+    fun releaseOneDayReminderClaim(id: Long, claimedAt: java.time.LocalDateTime): Int
+
+    /** Best-effort claim release for the 2-day reminder. */
+    @Query("UPDATE AwsAccountRiskAssessment t SET t.reminderTwoDaysSentAt = NULL WHERE t.id = :id AND t.reminderTwoDaysSentAt = :claimedAt")
+    fun releaseTwoDayReminderClaim(id: Long, claimedAt: java.time.LocalDateTime): Int
 }

--- a/src/backendng/src/main/kotlin/com/secman/repository/CrowdStrikeSeverityHistoryRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/CrowdStrikeSeverityHistoryRepository.kt
@@ -1,15 +1,33 @@
 package com.secman.repository
 
 import com.secman.domain.CrowdStrikeSeverityHistory
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 
 /**
  * Repository for the severity-history table used by the CrowdStrike reconcile
  * sweep. The natural ID is the severity string itself (already uppercased).
  *
  * Callers should use `findAll()` to read the full historical union; writes go
- * through the standard JPA `save`/`update` flow handled by the import service.
+ * through [upsertSeverity] (atomic, safe under concurrent reconcile runs).
  */
 @Repository
-interface CrowdStrikeSeverityHistoryRepository : JpaRepository<CrowdStrikeSeverityHistory, String>
+interface CrowdStrikeSeverityHistoryRepository : JpaRepository<CrowdStrikeSeverityHistory, String> {
+
+    /**
+     * Atomic upsert of one severity row. The previous findById-then-save pattern raced under
+     * concurrent CLI workers: both saw "no row" for a new severity, both inserted, and the
+     * loser's primary-key violation rolled back its entire reconcile transaction.
+     */
+    @Query(
+        value = """
+            INSERT INTO crowdstrike_severity_history (severity, first_seen_at, last_seen_at)
+            VALUES (:severity, :now, :now)
+            ON DUPLICATE KEY UPDATE last_seen_at = VALUES(last_seen_at)
+        """,
+        nativeQuery = true
+    )
+    fun upsertSeverity(severity: String, now: LocalDateTime): Int
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/ExportJobRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/ExportJobRepository.kt
@@ -66,4 +66,9 @@ interface ExportJobRepository : JpaRepository<ExportJob, String> {
      * Find all jobs with a specific status
      */
     fun findByStatus(status: ExportJobStatus): List<ExportJob>
+
+    /**
+     * Find all jobs in any of the given statuses (post-insert concurrency-cap recheck)
+     */
+    fun findByStatusIn(statuses: List<ExportJobStatus>): List<ExportJob>
 }

--- a/src/backendng/src/main/kotlin/com/secman/repository/MaterializedViewRefreshJobRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/MaterializedViewRefreshJobRepository.kt
@@ -31,6 +31,14 @@ interface MaterializedViewRefreshJobRepository : JpaRepository<MaterializedViewR
     fun findRunningJob(): Optional<MaterializedViewRefreshJob>
 
     /**
+     * All RUNNING jobs, oldest id first. Used by the post-insert duplicate-trigger
+     * re-check in triggerAsyncRefresh: when two concurrent triggers both insert a
+     * RUNNING job, the lowest id wins and younger duplicates mark themselves failed.
+     */
+    @Query("SELECT j FROM MaterializedViewRefreshJob j WHERE j.status = 'RUNNING' ORDER BY j.id ASC")
+    fun findRunningJobs(): List<MaterializedViewRefreshJob>
+
+    /**
      * Count jobs by status (for metrics)
      *
      * Task: T008

--- a/src/backendng/src/main/kotlin/com/secman/repository/OAuthStateRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/OAuthStateRepository.kt
@@ -15,7 +15,13 @@ interface OAuthStateRepository : JpaRepository<OAuthState, Long> {
     @Query("DELETE FROM OAuthState o WHERE o.expiresAt < :now")
     fun deleteExpiredStates(now: LocalDateTime = LocalDateTime.now())
 
-    fun deleteByStateToken(stateToken: String)
+    /**
+     * Deletes the state row and reports how many rows were removed. The count makes the
+     * delete usable as an atomic single-use claim: exactly one of two concurrent callbacks
+     * carrying the same state gets 1, the other gets 0.
+     */
+    @Query("DELETE FROM OAuthState o WHERE o.stateToken = :stateToken")
+    fun deleteByStateToken(stateToken: String): Int
 
     /**
      * Count active states for a provider (for observability/debugging)

--- a/src/backendng/src/main/kotlin/com/secman/repository/RequirementIdSequenceRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/RequirementIdSequenceRepository.kt
@@ -1,14 +1,11 @@
 package com.secman.repository
 
 import com.secman.domain.RequirementIdSequence
-import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
-import java.util.*
 
 @Repository
-interface RequirementIdSequenceRepository : JpaRepository<RequirementIdSequence, Long> {
-
-    @Query("SELECT s FROM RequirementIdSequence s WHERE s.id = :id", nativeQuery = false)
-    fun findByIdForUpdate(id: Long): Optional<RequirementIdSequence>
-}
+interface RequirementIdSequenceRepository : JpaRepository<RequirementIdSequence, Long>
+// Note: the former findByIdForUpdate(id) was a plain SELECT despite its name (the explicit
+// @Query carried no lock). Locked access now goes through RequirementIdService, which uses
+// EntityManager.find(..., LockModeType.PESSIMISTIC_WRITE) for a real SELECT ... FOR UPDATE.

--- a/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityExceptionRequestRepository.kt
@@ -314,4 +314,29 @@ interface VulnerabilityExceptionRequestRepository : JpaRepository<VulnerabilityE
      */
     @Query("UPDATE VulnerabilityExceptionRequest r SET r.reviewedByUser = NULL WHERE r.reviewedByUser.id = :userId")
     fun nullifyReviewedByUserForUser(userId: Long): Int
+
+    /**
+     * Atomically claim the APPROVED→EXPIRED transition for one request. Returns 1 only for
+     * the caller that wins; overlapping scheduler runs (second instance, or a run overlapping
+     * a slow previous one) get 0 and must skip the request's side effects (exception
+     * deactivation, expiration emails, audit row). Bumps the optimistic-lock version so
+     * stale in-memory copies fail on their next entity update.
+     */
+    @Query("UPDATE VulnerabilityExceptionRequest r SET r.status = :newStatus, r.updatedAt = :now, r.version = r.version + 1 WHERE r.id = :id AND r.status = :expectedStatus")
+    fun claimStatusTransition(id: Long, expectedStatus: ExceptionRequestStatus, newStatus: ExceptionRequestStatus, now: LocalDateTime): Int
+
+    /**
+     * Atomically claim the expiration reminder for one request (claim-before-send).
+     * Returns 1 for the single winner; every other concurrent run gets 0 and must not email.
+     */
+    @Query("UPDATE VulnerabilityExceptionRequest r SET r.reminderSentAt = :now, r.version = r.version + 1 WHERE r.id = :id AND r.reminderSentAt IS NULL")
+    fun claimReminder(id: Long, now: LocalDateTime): Int
+
+    /**
+     * Best-effort compensation when the reminder email failed after a successful claim:
+     * release the claim so the next scheduler run retries. If this release itself is lost,
+     * the reminder is skipped rather than duplicated (documented trade-off).
+     */
+    @Query("UPDATE VulnerabilityExceptionRequest r SET r.reminderSentAt = NULL, r.version = r.version + 1 WHERE r.id = :id AND r.reminderSentAt = :claimedAt")
+    fun releaseReminderClaim(id: Long, claimedAt: LocalDateTime): Int
 }

--- a/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityStatisticsCacheRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/VulnerabilityStatisticsCacheRepository.kt
@@ -1,12 +1,33 @@
 package com.secman.repository
 
 import com.secman.domain.VulnerabilityStatisticsCache
+import io.micronaut.data.annotation.Query
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 import java.util.Optional
 
 @Repository
 interface VulnerabilityStatisticsCacheRepository : JpaRepository<VulnerabilityStatisticsCache, Long> {
 
     fun findByCacheKey(cacheKey: String): Optional<VulnerabilityStatisticsCache>
+
+    /**
+     * Atomic upsert on cache_key (unique). Replaces the racy find-then-save/update pattern:
+     * two concurrent refreshes both seeing "no row yet" would both INSERT and one would die
+     * on the unique constraint, failing that refresh. ON DUPLICATE KEY UPDATE makes the
+     * write conflict-free regardless of interleaving.
+     */
+    @Query(
+        value = """
+            INSERT INTO vulnerability_statistics_cache (cache_key, cached_json, last_refreshed_at, refresh_duration_ms)
+            VALUES (:cacheKey, :cachedJson, :lastRefreshedAt, :refreshDurationMs)
+            ON DUPLICATE KEY UPDATE
+                cached_json = VALUES(cached_json),
+                last_refreshed_at = VALUES(last_refreshed_at),
+                refresh_duration_ms = VALUES(refresh_duration_ms)
+        """,
+        nativeQuery = true
+    )
+    fun upsertByCacheKey(cacheKey: String, cachedJson: String, lastRefreshedAt: LocalDateTime, refreshDurationMs: Long?): Int
 }

--- a/src/backendng/src/main/kotlin/com/secman/scheduler/ExceptionExpirationScheduler.kt
+++ b/src/backendng/src/main/kotlin/com/secman/scheduler/ExceptionExpirationScheduler.kt
@@ -47,6 +47,37 @@ open class ExceptionExpirationScheduler(
     private val logger = LoggerFactory.getLogger(ExceptionExpirationScheduler::class.java)
 
     /**
+     * Self proxy so the claim helpers below run in REQUIRES_NEW transactions even though
+     * they are invoked from within this class (Micronaut AOP is bypassed on direct
+     * self-invocation - same pattern as CrowdStrikeVulnerabilityImportService).
+     */
+    @Inject
+    internal lateinit var selfProvider: jakarta.inject.Provider<ExceptionExpirationScheduler>
+
+    /**
+     * Claim the APPROVED→EXPIRED transition in an independently committed transaction.
+     * Committing per claim (instead of at the end of the whole scheduler run) makes the
+     * claim immediately visible to an overlapping run on another instance, and keeps the
+     * row lock held only for this short transaction rather than across email sending.
+     */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    open fun claimExpirationNewTx(requestId: Long, now: LocalDateTime): Boolean =
+        requestRepository.claimStatusTransition(
+            requestId, ExceptionRequestStatus.APPROVED, ExceptionRequestStatus.EXPIRED, now
+        ) == 1
+
+    /** Claim the expiration reminder in an independently committed transaction. */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    open fun claimReminderNewTx(requestId: Long, now: LocalDateTime): Boolean =
+        requestRepository.claimReminder(requestId, now) == 1
+
+    /** Release a reminder claim (best-effort) in an independently committed transaction. */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    open fun releaseReminderClaimNewTx(requestId: Long, claimedAt: LocalDateTime) {
+        requestRepository.releaseReminderClaim(requestId, claimedAt)
+    }
+
+    /**
      * Daily job to expire old exception requests.
      *
      * **Schedule**: Every day at midnight (00:00:00)
@@ -59,7 +90,14 @@ open class ExceptionExpirationScheduler(
      * 4. Send expiration notification to requester
      * 5. Log audit event
      *
-     * **Transactional**: Ensures all updates succeed or roll back together
+     * **Concurrency**: each request is claimed via an atomic guarded UPDATE
+     * (APPROVED→EXPIRED) in its own REQUIRES_NEW transaction (committed per
+     * request), so overlapping runs (a second app instance at midnight, or a
+     * run overlapping a slow previous one) process each request's side effects
+     * (deactivation, emails, audit row) exactly once. The outer @Transactional
+     * remains for the Hibernate session (lazy vulnerability/asset access) —
+     * the loaded entities are intentionally never mutated here, since the claim
+     * bumps the row's @Version and a dirty flush at commit would collide with it.
      */
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
@@ -81,9 +119,16 @@ open class ExceptionExpirationScheduler(
 
             for (request in expiredRequests) {
                 try {
-                    // Update request status to EXPIRED
-                    request.status = ExceptionRequestStatus.EXPIRED
-                    requestRepository.update(request)
+                    // Atomically claim the APPROVED→EXPIRED transition (REQUIRES_NEW, commits
+                    // immediately); a concurrent run that already expired this request gets a
+                    // 0-row no-op and skips all side effects. NOTE: the in-memory entity is
+                    // deliberately NOT mutated - the claim already bumped the row's @Version,
+                    // so a dirty flush at outer-transaction commit would throw an optimistic-
+                    // lock failure and roll back the deactivations below.
+                    if (!selfProvider.get().claimExpirationNewTx(request.id!!, now)) {
+                        logger.debug("Request {} already expired by a concurrent run - skipping", request.id)
+                        continue
+                    }
                     expiredCount++
 
                     logger.debug("Expired request {}: subject={}, scope={}, CVE={}, asset={}, expirationDate={}",
@@ -142,8 +187,15 @@ open class ExceptionExpirationScheduler(
      * **Process**:
      * 1. Find APPROVED requests with expiration_date between now and now + 7 days
      *    whose reminder_sent_at is still NULL
-     * 2. Send reminder email to requester
-     * 3. Persist reminder_sent_at so the email is sent exactly once, even across restarts
+     * 2. Atomically claim the reminder (guarded UPDATE on reminder_sent_at IS NULL),
+     *    then send the email - claim-before-send means overlapping runs (second app
+     *    instance, overlapping schedule) can never double-send
+     * 3. If the send fails after a successful claim, the claim is released (best-effort)
+     *    so the next run retries; a lost release skips the reminder rather than
+     *    duplicating it
+     *
+     * Outer @Transactional only provides the Hibernate session for lazy access;
+     * claims commit independently via REQUIRES_NEW and entities are never mutated.
      */
     @Scheduled(cron = "0 0 8 * * ?")
     @Transactional
@@ -166,13 +218,21 @@ open class ExceptionExpirationScheduler(
 
             for (request in expiringRequests) {
                 try {
-                    val sent = notificationService.notifyRequesterOfExpiration(request).get()
+                    val claimedAt = LocalDateTime.now()
+                    if (!selfProvider.get().claimReminderNewTx(request.id!!, claimedAt)) {
+                        logger.debug("Reminder for request {} already claimed by a concurrent run - skipping", request.id)
+                        continue
+                    }
+
+                    val sent = try {
+                        notificationService.notifyRequesterOfExpiration(request).get()
+                    } catch (e: Exception) {
+                        logger.error("Reminder send threw for request {}: {}", request.id, e.message)
+                        false
+                    }
 
                     if (sent) {
-                        request.reminderSentAt = LocalDateTime.now()
-                        requestRepository.update(request)
                         remindersSentCount++
-
                         logger.debug("Sent expiration reminder for request {}: CVE={}, asset={}, expiresIn={} days",
                             request.id,
                             request.vulnerability?.vulnerabilityId,
@@ -180,7 +240,8 @@ open class ExceptionExpirationScheduler(
                             java.time.temporal.ChronoUnit.DAYS.between(now.toLocalDate(), request.expirationDate.toLocalDate())
                         )
                     } else {
-                        logger.warn("Failed to send expiration reminder for request {}", request.id)
+                        logger.warn("Failed to send expiration reminder for request {} - releasing claim for retry", request.id)
+                        selfProvider.get().releaseReminderClaimNewTx(request.id!!, claimedAt)
                     }
 
                 } catch (e: Exception) {

--- a/src/backendng/src/main/kotlin/com/secman/service/AiSuggestionJobService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AiSuggestionJobService.kt
@@ -182,6 +182,17 @@ open class AiSuggestionJobService(
         val originalName = Thread.currentThread().name
         Thread.currentThread().name = "ai-job-$jobId"
         try {
+            // Post-commit concurrency-cap recheck. startJob's guards are count-then-insert:
+            // two concurrent starts for the same assessment (or N starts against the global
+            // cap) can all pass them before any insert is visible. Now that this job's row
+            // is committed, rank it against all committed active jobs and self-fail losers
+            // BEFORE any paid LLM call is made.
+            val lostReason = checkStartRace(jobId)
+            if (lostReason != null) {
+                log.warn("AI job {} lost the start race ({}) — failing it before any AI call", jobId, lostReason)
+                markFailed(jobId, "Rejected at start: $lostReason")
+                return
+            }
             markRunning(jobId)
             val ctx = buildContext(assessmentId)
             val flag = cancelFlags[jobId] ?: AtomicBoolean(false)
@@ -241,9 +252,40 @@ open class AiSuggestionJobService(
     open fun loadRequirement(id: Long): Requirement? =
         requirementRepository.findById(id).orElse(null)
 
+    /**
+     * Post-commit start-race verification for a freshly inserted job. Returns null when the
+     * job may proceed, or a reason string when it lost against concurrent committed jobs.
+     * Deterministic: the lowest active job id per assessment wins, and globally only the
+     * oldest [AiRiskAssessmentConfig.maxConcurrentJobsGlobal] active jobs proceed.
+     */
+    @Transactional(TxType.REQUIRES_NEW)
+    open fun checkStartRace(jobId: Long): String? {
+        val j = aiJobRepository.findById(jobId).orElse(null) ?: return "job row missing"
+        if (j.status.isTerminal()) return null // cancelled before start — background loop exits via flag
+        val activeStatuses = listOf(AiSuggestionJobStatus.QUEUED, AiSuggestionJobStatus.RUNNING)
+
+        val perAssessment = aiJobRepository.findByRiskAssessmentIdAndStatusIn(j.riskAssessmentId, activeStatuses)
+        val assessmentWinner = perAssessment.minByOrNull { it.id!! }
+        if (assessmentWinner != null && assessmentWinner.id != jobId) {
+            return "another AI job (id=${assessmentWinner.id}) is already active for assessment ${j.riskAssessmentId}"
+        }
+
+        val activeGlobal = aiJobRepository.findByStatusIn(activeStatuses).sortedBy { it.id }
+        val rank = activeGlobal.indexOfFirst { it.id == jobId }
+        if (rank >= config.maxConcurrentJobsGlobal) {
+            return "global AI-job concurrency limit (${config.maxConcurrentJobsGlobal}) exceeded (rank ${rank + 1})"
+        }
+        return null
+    }
+
     @Transactional(TxType.REQUIRES_NEW)
     open fun markRunning(jobId: Long) {
         val j = aiJobRepository.findById(jobId).orElse(null) ?: return
+        // Status guard: don't resurrect a job that was cancelled/reclaimed while QUEUED.
+        if (j.status != AiSuggestionJobStatus.QUEUED) {
+            log.warn("Skipping RUNNING transition for AI job {} - current status is {}", jobId, j.status)
+            return
+        }
         j.status = AiSuggestionJobStatus.RUNNING
         j.startedAt = LocalDateTime.now()
         j.lastHeartbeatAt = LocalDateTime.now()
@@ -253,6 +295,12 @@ open class AiSuggestionJobService(
     @Transactional(TxType.REQUIRES_NEW)
     open fun markFailed(jobId: Long, errorMessage: String) {
         val j = aiJobRepository.findById(jobId).orElse(null) ?: return
+        // Terminal guard: the watchdog (reclaimStaleJobs) and the owning worker race here -
+        // never overwrite COMPLETED/CANCELLED with FAILED.
+        if (j.status.isTerminal()) {
+            log.warn("Skipping FAILED transition for AI job {} - already terminal ({})", jobId, j.status)
+            return
+        }
         j.status = AiSuggestionJobStatus.FAILED
         j.errorMessage = errorMessage
         j.finishedAt = LocalDateTime.now()
@@ -263,6 +311,8 @@ open class AiSuggestionJobService(
     @Transactional(TxType.REQUIRES_NEW)
     open fun incrementFailed(jobId: Long, errorMessage: String? = null) {
         val j = aiJobRepository.findById(jobId).orElse(null) ?: return
+        // Terminal guard: a cancelled/reclaimed job's counters must not keep moving.
+        if (j.status.isTerminal()) return
         j.failedCount++
         j.lastHeartbeatAt = LocalDateTime.now()
         if (errorMessage != null && j.errorMessage.isNullOrBlank()) j.errorMessage = errorMessage
@@ -297,6 +347,17 @@ open class AiSuggestionJobService(
         userId: Long,
         result: SuggestionResult
     ) {
+        // Terminal guard: an in-flight requirement can complete after cancelJob or the
+        // watchdog marked the job terminal. Persisting the suggestion/Response and bumping
+        // cost/counters then would mutate a terminal job (and write AI answers the user
+        // explicitly cancelled) - drop the result instead.
+        val jobAtStart = aiJobRepository.findById(jobId).orElse(null)
+        if (jobAtStart == null || jobAtStart.status.isTerminal()) {
+            log.warn("Dropping AI result for requirement {} - job {} is {}", requirementId, jobId,
+                jobAtStart?.status ?: "missing")
+            return
+        }
+
         // 1) supersede any prior APPLIED row for this (assessment, requirement)
         aiSuggestionRepository.markAppliedAsSuperseded(assessmentId, requirementId)
 
@@ -377,6 +438,13 @@ open class AiSuggestionJobService(
         requirementId: Long,
         errorMessage: String
     ) {
+        // Terminal guard - see applySuccess.
+        val jobAtStart = aiJobRepository.findById(jobId).orElse(null)
+        if (jobAtStart == null || jobAtStart.status.isTerminal()) {
+            log.warn("Dropping AI failure record for requirement {} - job {} is {}", requirementId, jobId,
+                jobAtStart?.status ?: "missing")
+            return
+        }
         aiSuggestionRepository.save(AiAnswerSuggestion(
             jobId = jobId,
             riskAssessmentId = assessmentId,

--- a/src/backendng/src/main/kotlin/com/secman/service/AssetMatchClearService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AssetMatchClearService.kt
@@ -175,10 +175,33 @@ open class AssetMatchClearService(
 
         val errors = mutableListOf<AssetMatchClearErrorDto>()
         var deletedCount = 0
+        var revalidationSkips = 0
         val operationId = java.util.UUID.randomUUID().toString()
 
         candidates.forEach { candidate ->
             try {
+                // Re-verify the stale-candidate predicate immediately before deleting. The
+                // candidate list is a snapshot from the scan above; a concurrent import can
+                // re-match the asset (change its cloudInstanceId to one present in the
+                // snapshot, or move it to an uncovered account) between the scan and this
+                // delete - deleting from the stale list would then destroy a live asset.
+                val current = assetRepository.findById(candidate.assetId).orElse(null)
+                val currentInstance = current?.cloudInstanceId?.trim()?.lowercase()
+                val currentAccount = current?.cloudAccountId?.trim()
+                val stillStale = current != null &&
+                    !currentInstance.isNullOrEmpty() &&
+                    currentInstance !in normalizedResources &&
+                    (strict || currentAccount in normalizedAccounts)
+                if (!stillStale) {
+                    revalidationSkips++
+                    log.info(
+                        "Skipping asset {} ({}): no longer matches the stale predicate at delete time " +
+                            "(concurrently re-imported or moved)",
+                        candidate.assetId, candidate.name
+                    )
+                    return@forEach
+                }
+
                 assetCascadeDeleteService.deleteAsset(
                     assetId = candidate.assetId,
                     username = username,
@@ -208,9 +231,9 @@ open class AssetMatchClearService(
         }
 
         log.info(
-            "asset_match_clear_run dryRun=false user={} snapshotAccounts={} snapshotResources={} scoped={} candidates={} deleted={} errors={} status={}",
+            "asset_match_clear_run dryRun=false user={} snapshotAccounts={} snapshotResources={} scoped={} candidates={} deleted={} revalidationSkips={} errors={} status={}",
             username, normalizedAccounts.size, normalizedResources.size,
-            scopedAssets.size, candidates.size, deletedCount, errors.size, status
+            scopedAssets.size, candidates.size, deletedCount, revalidationSkips, errors.size, status
         )
 
         return AssetMatchClearResponse(
@@ -224,7 +247,7 @@ open class AssetMatchClearService(
             uncoveredAccounts = uncoveredAccounts,
             candidateCount = candidates.size,
             deletedCount = deletedCount,
-            skippedCount = errors.size,
+            skippedCount = errors.size + revalidationSkips,
             candidates = candidates,
             errors = errors,
             status = status,

--- a/src/backendng/src/main/kotlin/com/secman/service/AssetMergeService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AssetMergeService.kt
@@ -61,7 +61,16 @@ open class AssetMergeService(
             mergeAssetData(existingAsset.get(), ip, groups, cloudAccountId, cloudInstanceId, osVersion, adDomain)
         } else {
             log.debug("Creating new asset for hostname: {}", hostname)
-            createAsset(hostname, ip, groups, cloudAccountId, cloudInstanceId, osVersion, adDomain)
+            // Best-effort duplicate mitigation: find-then-create is racy (asset.name has no DB
+            // unique constraint yet - see docs/RACE_CONDITIONS.md). If a concurrent importer
+            // created the asset between the check and the save, merge into the winner's row.
+            try {
+                createAsset(hostname, ip, groups, cloudAccountId, cloudInstanceId, osVersion, adDomain)
+            } catch (e: Exception) {
+                val winner = assetRepository.findByName(hostname).orElseThrow { e }
+                log.info("Concurrent import created asset '{}' first - merging into id={}", hostname, winner.id)
+                mergeAssetData(winner, ip, groups, cloudAccountId, cloudInstanceId, osVersion, adDomain)
+            }
         }
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/AwsAccountRiskAssessmentService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AwsAccountRiskAssessmentService.kt
@@ -155,6 +155,27 @@ open class AwsAccountRiskAssessmentService(
         val today = LocalDate.now()
         val endDate = today.plusDays(deadlineDays.toLong())
 
+        // Idempotency guard: re-running an import (or two overlapping imports) must not
+        // create a second assessment + tracking row + reminder stream for the same
+        // (account, owner) while one is still open. No DB unique constraint is used here
+        // because a NEW assessment for the same pair is legitimate once the previous one
+        // is completed; only concurrent/repeated creation of OPEN ones is a defect.
+        val existingOpen = trackingRepository.findByAwsAccountId(awsAccountId)
+            .filter { it.ownerEmail.equals(ownerEmail, ignoreCase = true) }
+            .firstOrNull { it.riskAssessment.status == "STARTED" }
+        if (existingOpen != null) {
+            log.info(
+                "Skipping risk assessment creation for AWS account {} / owner {}: open assessment {} already tracked",
+                awsAccountId, ownerEmail, existingOpen.riskAssessment.id
+            )
+            return AccountRiskAssessmentInfo(
+                awsAccountId = awsAccountId,
+                ownerEmail = ownerEmail,
+                riskAssessmentId = existingOpen.riskAssessment.id,
+                error = "Skipped: an open risk assessment (id=${existingOpen.riskAssessment.id}) already exists for this account/owner"
+            )
+        }
+
         val asset = findOrCreateAccountAsset(awsAccountId, ownerEmail)
         val ownerUser = userRepository.findByEmailIgnoreCase(ownerEmail).orElse(null)
 
@@ -216,16 +237,23 @@ open class AwsAccountRiskAssessmentService(
         val existing = assetRepository.findByName(assetName).orElse(null)
         if (existing != null) return existing
 
-        return assetRepository.save(
-            Asset(
-                name = assetName,
-                type = ACCOUNT_ASSET_TYPE,
-                owner = ownerEmail,
-                description = "Automatically created for the risk assessment of AWS account " +
-                    "$awsAccountId (user-mapping import)",
-                cloudAccountId = awsAccountId
+        // Best-effort duplicate mitigation: find-then-save is racy (asset.name has no DB
+        // unique constraint yet - see docs/RACE_CONDITIONS.md), so if a concurrent import
+        // created the asset between the check and the save, fall back to the winner's row.
+        return try {
+            assetRepository.save(
+                Asset(
+                    name = assetName,
+                    type = ACCOUNT_ASSET_TYPE,
+                    owner = ownerEmail,
+                    description = "Automatically created for the risk assessment of AWS account " +
+                        "$awsAccountId (user-mapping import)",
+                    cloudAccountId = awsAccountId
+                )
             )
-        )
+        } catch (e: Exception) {
+            assetRepository.findByName(assetName).orElseThrow { e }
+        }
     }
 
     // --- Deadline reminders -------------------------------------------------
@@ -236,14 +264,21 @@ open class AwsAccountRiskAssessmentService(
      * [com.secman.scheduler.AwsAccountRiskAssessmentReminderScheduler];
      * [today] is injectable for tests.
      *
-     * Idempotent across restarts: each reminder is stamped on the tracking row
-     * after a successful send. If the 2-day reminder was missed (e.g. downtime),
-     * the 1-day pass sends a single catch-up reminder and stamps both.
-     * Only open assessments (status STARTED) are reminded.
+     * Idempotent across restarts AND across concurrent runs: each reminder slot is
+     * claimed via an atomic guarded UPDATE (claim-before-send) committed per row, so
+     * overlapping scheduler runs (multi-instance deploys, a run overlapping a slow
+     * previous one) can never double-send. If the 2-day reminder was missed (e.g.
+     * downtime), the 1-day claim stamps both slots and a single catch-up reminder is
+     * sent. When a send fails after a successful claim, the claim is released
+     * (best-effort) so the next run retries. Only open assessments (status STARTED)
+     * are reminded.
+     *
+     * Deliberately NOT @Transactional: the claims must commit per row to be visible
+     * to concurrent runs, and a method-wide transaction rolling back after emails
+     * went out would un-stamp already-sent reminders.
      *
      * @return number of reminder emails sent
      */
-    @Transactional
     open fun processDeadlineReminders(today: LocalDate = LocalDate.now()): Int {
         val pending = trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2))
         if (pending.isEmpty()) return 0
@@ -253,27 +288,23 @@ open class AwsAccountRiskAssessmentService(
             val endDate = tracking.riskAssessment.endDate
             val daysLeft = ChronoUnit.DAYS.between(today, endDate)
             try {
-                when {
-                    daysLeft <= 1 && tracking.reminderOneDaySentAt == null -> {
-                        if (sendReminder(tracking, daysLeft, endDate)) {
-                            val now = LocalDateTime.now()
-                            tracking.reminderOneDaySentAt = now
-                            // Collapse a missed 2-day reminder into this send —
-                            // two reminder mails in the same run would be noise.
-                            if (tracking.reminderTwoDaysSentAt == null) {
-                                tracking.reminderTwoDaysSentAt = now
-                            }
-                            trackingRepository.update(tracking)
-                            sent++
-                        }
-                    }
-                    daysLeft == 2L && tracking.reminderTwoDaysSentAt == null -> {
-                        if (sendReminder(tracking, daysLeft, endDate)) {
-                            tracking.reminderTwoDaysSentAt = LocalDateTime.now()
-                            trackingRepository.update(tracking)
-                            sent++
-                        }
-                    }
+                val claimedAt = LocalDateTime.now()
+                val isOneDaySlot = daysLeft <= 1 && tracking.reminderOneDaySentAt == null
+                val isTwoDaySlot = !isOneDaySlot && daysLeft == 2L && tracking.reminderTwoDaysSentAt == null
+
+                val claimed = when {
+                    isOneDaySlot -> trackingRepository.claimOneDayReminder(tracking.id!!, claimedAt) == 1
+                    isTwoDaySlot -> trackingRepository.claimTwoDayReminder(tracking.id!!, claimedAt) == 1
+                    else -> false
+                }
+                if (!claimed) continue
+
+                if (sendReminder(tracking, daysLeft, endDate)) {
+                    sent++
+                } else {
+                    log.warn("Deadline reminder send failed for tracking {} - releasing claim for retry", tracking.id)
+                    if (isOneDaySlot) trackingRepository.releaseOneDayReminderClaim(tracking.id!!, claimedAt)
+                    else trackingRepository.releaseTwoDayReminderClaim(tracking.id!!, claimedAt)
                 }
             } catch (e: Exception) {
                 log.error("Failed to send deadline reminder for tracking {} (assessment {}): {}",

--- a/src/backendng/src/main/kotlin/com/secman/service/AwsCleanServerKpiService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AwsCleanServerKpiService.kt
@@ -2,7 +2,6 @@ package com.secman.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.secman.domain.Vulnerability
-import com.secman.domain.VulnerabilityStatisticsCache
 import com.secman.dto.AwsCleanServerKpiCacheData
 import com.secman.dto.AwsCleanServerKpiResponse
 import com.secman.repository.AssetRepository
@@ -130,22 +129,8 @@ open class AwsCleanServerKpiService(
 
     @Transactional
     open fun upsertCache(json: String, durationMs: Long) {
-        val existing = cacheRepository.findByCacheKey(CACHE_KEY)
-        if (existing.isPresent) {
-            val entry = existing.get()
-            entry.cachedJson = json
-            entry.lastRefreshedAt = LocalDateTime.now()
-            entry.refreshDurationMs = durationMs
-            cacheRepository.update(entry)
-        } else {
-            cacheRepository.save(
-                VulnerabilityStatisticsCache(
-                    cacheKey = CACHE_KEY,
-                    cachedJson = json,
-                    lastRefreshedAt = LocalDateTime.now(),
-                    refreshDurationMs = durationMs
-                )
-            )
-        }
+        // Atomic native upsert on the cache_key unique index - see
+        // VulnerabilityStatisticsCacheRepository.upsertByCacheKey for the race this closes.
+        cacheRepository.upsertByCacheKey(CACHE_KEY, json, LocalDateTime.now(), durationMs)
     }
 }

--- a/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/CrowdStrikeVulnerabilityImportService.kt
@@ -5,7 +5,6 @@ import com.secman.constants.AssetOwners
 import com.secman.constants.VulnerabilitySources
 import com.secman.domain.Asset
 import com.secman.domain.CrowdStrikeImportHistory
-import com.secman.domain.CrowdStrikeSeverityHistory
 import com.secman.domain.Vulnerability
 import com.secman.dto.CrowdStrikeVulnerabilityBatchDto
 import com.secman.dto.ImportStatisticsDto
@@ -419,15 +418,10 @@ open class CrowdStrikeVulnerabilityImportService(
     private fun upsertAndUnionSeverityHistory(currentSeverities: List<String>): List<String> {
         val now = LocalDateTime.now()
         for (sev in currentSeverities.toSet()) {
-            val existing = severityHistoryRepository.findById(sev).orElse(null)
-            if (existing == null) {
-                severityHistoryRepository.save(
-                    CrowdStrikeSeverityHistory(severity = sev, firstSeenAt = now, lastSeenAt = now)
-                )
-            } else {
-                existing.lastSeenAt = now
-                severityHistoryRepository.update(existing)
-            }
+            // Atomic ON DUPLICATE KEY upsert: the former findById-then-save raced under
+            // concurrent CLI workers - both inserted a new severity and the loser's PK
+            // violation rolled back its whole reconcile transaction.
+            severityHistoryRepository.upsertSeverity(sev, now)
         }
         val historical = severityHistoryRepository.findAll().map { it.severity }
         return (currentSeverities + historical).distinct()

--- a/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
@@ -67,6 +67,14 @@ open class ExportJobService(
     private val log = LoggerFactory.getLogger(ExportJobService::class.java)
     private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
+    /**
+     * Provider for self-reference so internal calls to @Transactional(REQUIRES_NEW) members
+     * (createJobRow, markJobAsFailed) go through the AOP proxy (same pattern as
+     * CrowdStrikeVulnerabilityImportService, Feature 053).
+     */
+    @jakarta.inject.Inject
+    internal lateinit var selfProvider: jakarta.inject.Provider<ExportJobService>
+
     companion object {
         // Lifecycle stage labels persisted to ExportJob.currentStage so the UI can
         // surface "Counting rows...", "Writing file...", etc. instead of a bare %.
@@ -100,7 +108,6 @@ open class ExportJobService(
      * @return Created job DTO
      * @throws IllegalStateException if rate limits exceeded
      */
-    @Transactional
     open fun startExport(authentication: Authentication, exportType: ExportType = ExportType.VULNERABILITIES): ExportJobDto {
         val username = authentication.name
         log.info("Starting export job for user: {}, type: {}", username, exportType)
@@ -111,6 +118,9 @@ open class ExportJobService(
         // Auto-reset zombie jobs that got stuck (e.g., server restart during processing)
         autoResetStaleJobs(username, exportType, runningStatuses)
 
+        // Fast pre-checks. These are advisory only: two concurrent requests can both pass
+        // them before either insert is visible (READ COMMITTED). The authoritative check is
+        // the post-insert recheck below.
         val userRunningJobs = exportJobRepository.countByUsernameAndExportTypeAndStatusIn(username, exportType, runningStatuses)
         if (userRunningJobs >= maxConcurrentPerUser) {
             log.warn("User {} already has {} running {} export(s), max allowed: {}", username, userRunningJobs, exportType, maxConcurrentPerUser)
@@ -123,19 +133,25 @@ open class ExportJobService(
             throw IllegalStateException("Server is busy with exports. Please try again in a few minutes.")
         }
 
-        // Create job
+        // Create + commit the job row (REQUIRES_NEW via the self proxy), then re-verify the
+        // caps against committed state. Insert-then-recheck makes the limits enforceable:
+        // when N requests race past the pre-checks, every one of them now sees all N
+        // committed PENDING rows and only the jobs ranked within the cap (oldest first,
+        // id as tie-break) survive; the rest fail themselves deterministically.
         val jobId = UUID.randomUUID().toString()
-        val job = ExportJob(
-            id = jobId,
-            username = username,
-            status = ExportJobStatus.PENDING,
-            exportType = exportType
-        )
+        val savedJob = selfProvider.get().createJobRow(jobId, username, exportType)
 
-        val savedJob = exportJobRepository.save(job)
-        // Force immediate flush to avoid MariaDB JDBC driver batching bug
-        // (IndexOutOfBoundsException in handleStandardResults)
-        entityManager.flush()
+        val overCapReason = checkCapsAfterInsert(savedJob, exportType, runningStatuses)
+        if (overCapReason != null) {
+            log.warn("Export job {} lost the concurrency-cap race ({}), failing it", jobId, overCapReason)
+            selfProvider.get().markJobAsFailed(jobId, "Rejected at start: $overCapReason")
+            throw IllegalStateException(
+                if (overCapReason.startsWith("per-user"))
+                    "You already have a ${exportType.name.lowercase()} export in progress. Please wait for it to complete."
+                else
+                    "Server is busy with exports. Please try again in a few minutes."
+            )
+        }
         log.info("Created export job: {}", jobId)
 
         // Start async processing using ExecutorService
@@ -155,6 +171,50 @@ open class ExportJobService(
         }
 
         return ExportJobDto.fromEntity(savedJob)
+    }
+
+    /**
+     * Insert the new job row in its own committed transaction so the cap recheck
+     * (and concurrent requests' rechecks) can see it.
+     */
+    @Transactional(TxType.REQUIRES_NEW)
+    open fun createJobRow(jobId: String, username: String, exportType: ExportType): ExportJob {
+        val job = ExportJob(
+            id = jobId,
+            username = username,
+            status = ExportJobStatus.PENDING,
+            exportType = exportType
+        )
+        val savedJob = exportJobRepository.save(job)
+        // Force immediate flush to avoid MariaDB JDBC driver batching bug
+        // (IndexOutOfBoundsException in handleStandardResults)
+        entityManager.flush()
+        return savedJob
+    }
+
+    /**
+     * Post-insert cap verification. Returns null when [ownJob] is within both caps, or a
+     * short reason string when it must be rejected. Ranking is (createdAt, id) ascending,
+     * so under a race exactly the oldest `cap` jobs survive on every contender's view of
+     * committed state - deterministic, no livelock where all racers self-reject.
+     */
+    private fun checkCapsAfterInsert(ownJob: ExportJob, exportType: ExportType, runningStatuses: List<ExportJobStatus>): String? {
+        val comparator = compareBy<ExportJob>({ it.createdAt }, { it.id })
+
+        val userJobs = exportJobRepository.findByUsernameAndStatusIn(ownJob.username, runningStatuses)
+            .filter { it.exportType == exportType }
+            .sortedWith(comparator)
+        val userRank = userJobs.indexOfFirst { it.id == ownJob.id }
+        if (userRank >= maxConcurrentPerUser) {
+            return "per-user cap exceeded (rank ${userRank + 1} of max $maxConcurrentPerUser)"
+        }
+
+        val globalJobs = exportJobRepository.findByStatusIn(runningStatuses).sortedWith(comparator)
+        val globalRank = globalJobs.indexOfFirst { it.id == ownJob.id }
+        if (globalRank >= maxConcurrentGlobal) {
+            return "global cap exceeded (rank ${globalRank + 1} of max $maxConcurrentGlobal)"
+        }
+        return null
     }
 
     /**
@@ -400,6 +460,12 @@ open class ExportJobService(
     @Transactional(TxType.REQUIRES_NEW)
     open fun markJobAsProcessing(jobId: String) {
         val job = exportJobRepository.findById(jobId).orElse(null) ?: return
+        // Status guard: never resurrect a job that a concurrent actor (cancel endpoint,
+        // stale-job auto-reset) already moved to a terminal state.
+        if (job.status != ExportJobStatus.PENDING) {
+            log.warn("Skipping PROCESSING transition for job {} - current status is {}", jobId, job.status)
+            return
+        }
         job.status = ExportJobStatus.PROCESSING
         job.startedAt = LocalDateTime.now()
         exportJobRepository.update(job)
@@ -440,6 +506,15 @@ open class ExportJobService(
     @Transactional(TxType.REQUIRES_NEW)
     open fun markJobAsCompleted(jobId: String, filePath: String, fileName: String, fileSizeBytes: Long, totalItems: Long) {
         val job = exportJobRepository.findById(jobId).orElse(null) ?: return
+        // Status guard: a job that was auto-reset to FAILED (stale heartbeat) or CANCELLED
+        // while this worker was still writing the file must stay terminal - blindly setting
+        // COMPLETED here resurrected FAILED jobs and produced FAILED->COMPLETED flip-flops.
+        if (job.status != ExportJobStatus.PENDING && job.status != ExportJobStatus.PROCESSING) {
+            log.warn("Skipping COMPLETED transition for job {} - already terminal ({}); deleting orphaned file {}",
+                jobId, job.status, filePath)
+            runCatching { java.io.File(filePath).delete() }
+            return
+        }
         job.status = ExportJobStatus.COMPLETED
         job.completedAt = LocalDateTime.now()
         job.filePath = filePath
@@ -455,6 +530,11 @@ open class ExportJobService(
     @Transactional(TxType.REQUIRES_NEW)
     open fun markJobAsFailed(jobId: String, errorMessage: String) {
         val job = exportJobRepository.findById(jobId).orElse(null) ?: return
+        // Status guard: don't overwrite COMPLETED/CANCELLED/EXPIRED set by a concurrent actor.
+        if (job.status != ExportJobStatus.PENDING && job.status != ExportJobStatus.PROCESSING) {
+            log.warn("Skipping FAILED transition for job {} - already terminal ({})", jobId, job.status)
+            return
+        }
         job.status = ExportJobStatus.FAILED
         job.completedAt = LocalDateTime.now()
         job.errorMessage = errorMessage

--- a/src/backendng/src/main/kotlin/com/secman/service/GithubRepoImportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/GithubRepoImportService.kt
@@ -10,6 +10,8 @@ import com.secman.repository.GithubRepoFindingSnapshotRepository
 import com.secman.repository.GithubRepositoryRepository
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.inject.Singleton
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -36,9 +38,19 @@ open class GithubRepoImportService(
     private val snapshotRepository: GithubRepoFindingSnapshotRepository,
     private val alertRepository: GithubRepoDependabotAlertRepository,
     private val githubClient: GithubAppClientService,
-    private val ownerEmailMappingRepository: GithubOwnerEmailMappingRepository
+    private val ownerEmailMappingRepository: GithubOwnerEmailMappingRepository,
+    private val entityManager: EntityManager
 ) {
     private val logger = LoggerFactory.getLogger(GithubRepoImportService::class.java)
+
+    /**
+     * Provider for self-reference so persistRepo's @Transactional applies on the internal
+     * call (AOP proxy bypass fix, same as CrowdStrikeVulnerabilityImportService / Feature 053).
+     * Without it the per-repo snapshot insert, alert delete and alert reinsert each commit
+     * separately - a crash or concurrent import can leave a repo with no or duplicated alerts.
+     */
+    @jakarta.inject.Inject
+    internal lateinit var selfProvider: jakarta.inject.Provider<GithubRepoImportService>
 
     @Serdeable
     data class ImportResult(
@@ -78,7 +90,11 @@ open class GithubRepoImportService(
                 }
                 totalCritical += counts.critical
                 totalHigh += counts.high
-                val wasNew = persistRepo(repoDto, counts, now)
+                // Via the self proxy so @Transactional applies; deadlock-retried because the
+                // per-repo transaction takes a PESSIMISTIC_WRITE lock on the repo row.
+                val wasNew = DeadlockRetry.withRetry("github-import ${repoDto.fullName}") {
+                    selfProvider.get().persistRepo(repoDto, counts, now)
+                }
                 if (wasNew) created++ else updated++
             } catch (e: Exception) {
                 logger.warn("GitHub import: failed for {}: {}", repoDto.fullName, e.message)
@@ -109,9 +125,19 @@ open class GithubRepoImportService(
         counts: GithubAppClientService.SeverityCounts,
         now: Instant
     ): Boolean {
-        val existing = githubRepositoryRepository.findByGithubRepoId(repoDto.repoId)
+        val resolved = githubRepositoryRepository.findByGithubRepoId(repoDto.repoId)
             .or { githubRepositoryRepository.findByFullName(repoDto.fullName) }
             .orElse(null)
+
+        // Serialize concurrent imports of the same repo (CLI + UI "Import now" can overlap):
+        // a PESSIMISTIC_WRITE row lock makes the snapshot insert + alert delete + alert
+        // reinsert below mutually exclusive per repo. Without it, interleaved delete/insert
+        // pairs from two runs produce duplicated alert rows. New repos can't be locked
+        // (no row yet) - there the unique constraints on github_repo_id / full_name make
+        // the second concurrent creator fail instead of duplicating.
+        val existing = resolved?.id?.let {
+            entityManager.find(GithubRepository::class.java, it, LockModeType.PESSIMISTIC_WRITE)
+        }
 
         val isNew = existing == null
         val repo = existing ?: GithubRepository()

--- a/src/backendng/src/main/kotlin/com/secman/service/MaterializedViewRefreshService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/MaterializedViewRefreshService.kt
@@ -46,6 +46,16 @@ open class MaterializedViewRefreshService(
 ) {
     private val log = LoggerFactory.getLogger(MaterializedViewRefreshService::class.java)
 
+    /**
+     * Provider for self-reference so @Transactional/@Async apply on internal method calls
+     * (same AOP-proxy-bypass fix as CrowdStrikeVulnerabilityImportService, Feature 053).
+     * Without this, executeRefresh() invoking swapMaterializedView() on `this` bypasses the
+     * proxy and the delete+insert swap runs as two separate transactions — readers can then
+     * observe an empty half-swapped view.
+     */
+    @jakarta.inject.Inject
+    internal lateinit var selfProvider: jakarta.inject.Provider<MaterializedViewRefreshService>
+
     // SSE sink for broadcasting refresh progress to all connected clients
     // Many().multicast() allows multiple subscribers
     private val progressSink: Sinks.Many<RefreshProgressEvent> = Sinks.many().multicast().onBackpressureBuffer()
@@ -102,8 +112,21 @@ open class MaterializedViewRefreshService(
         )
         val savedJob = refreshJobRepository.save(job)
 
-        // Execute refresh asynchronously
-        executeRefreshAsync(savedJob.id!!)
+        // Re-check after insert: the running-job read above is not atomic with the save, so
+        // two concurrent triggers can both pass it and both insert a RUNNING job. The job with
+        // the lowest id wins; any younger duplicate marks itself failed and defers to the winner,
+        // guaranteeing at most one live refresh (and one atomic view swap) at a time.
+        val oldestRunning = refreshJobRepository.findRunningJobs().firstOrNull()
+        if (oldestRunning != null && oldestRunning.id != savedJob.id) {
+            log.info("Concurrent refresh trigger lost the race - deferring to running job: jobId={}, winnerJobId={}",
+                savedJob.id, oldestRunning.id)
+            savedJob.markFailed("Duplicate trigger - refresh job ${oldestRunning.id} was already running")
+            refreshJobRepository.update(savedJob)
+            return oldestRunning
+        }
+
+        // Execute refresh asynchronously (via self proxy so @Async applies on the internal call)
+        selfProvider.get().executeRefreshAsync(savedJob.id!!)
 
         return savedJob
     }
@@ -183,7 +206,7 @@ open class MaterializedViewRefreshService(
         }.toMap()
 
         job.totalAssets = assetsWithOverdueVulns.size
-        updateJob(job)
+        selfProvider.get().updateJob(job)
 
         log.info("Found {} assets with overdue vulnerabilities (after exception filtering)", assetsWithOverdueVulns.size)
 
@@ -199,7 +222,7 @@ open class MaterializedViewRefreshService(
             // Update progress
             val processed = ((batchIndex + 1) * BATCH_SIZE).coerceAtMost(assetsWithOverdueVulns.size)
             job.updateProgress(processed)
-            updateJob(job)
+            selfProvider.get().updateJob(job)
 
             // Publish progress event
             publishProgressEvent(job, "Processing assets...")
@@ -213,11 +236,13 @@ open class MaterializedViewRefreshService(
         // this point leaves the previous snapshot intact. The write phase is small
         // (one row per outdated asset), so a single transaction is cheap; only the
         // read/compute phase above must stay outside a transaction.
-        swapMaterializedView(materializedRecords)
+        // Invoked via the self proxy - a direct call on `this` would bypass the AOP
+        // interceptor and split the delete+insert into two separate transactions.
+        selfProvider.get().swapMaterializedView(materializedRecords)
 
         // Step 5: Mark job as completed
         job.markCompleted()
-        updateJob(job)
+        selfProvider.get().updateJob(job)
 
         // Step 6 & 7: Refresh derived data (statistics cache + heatmap)
         refreshDerivedData(allOverdueVulnerabilities)

--- a/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
@@ -642,10 +642,37 @@ open class OAuthService(
     }
 
     /**
+     * Atomically consume a single-use OAuth state. Deletes the row in an independently
+     * committed transaction and returns true only for the caller that actually removed it.
+     *
+     * This is the state-side half of double-callback protection: two concurrent callbacks
+     * carrying the same state (browser double-submit, provider retry) both pass the read-only
+     * [findStateByValueWithRetry] lookup, but exactly one wins this claim. Previously the
+     * state was only deleted at the END of handleCallback, so during the whole token-exchange
+     * window it stayed reusable and only the IdP's single-use authorization code prevented a
+     * duplicate login/user-creation flow on secman's side.
+     */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    open fun claimOAuthState(stateToken: String): Boolean {
+        return try {
+            val deleted = oauthStateRepository.deleteByStateToken(stateToken)
+            if (deleted == 0) {
+                logger.warn("OAuth state {}... already consumed by a concurrent callback", stateToken.take(10))
+            }
+            deleted > 0
+        } catch (e: Exception) {
+            logger.error("Failed to claim OAuth state {}...: {}", stateToken.take(10), e.message)
+            false
+        }
+    }
+
+    /**
      * Delete OAuth state token quietly in its own transaction.
      *
      * Commits independently so state cleanup never interferes with the main flow.
      * Non-fatal: orphaned states are cleaned up by the scheduled job every 5 minutes.
+     * With the up-front [claimOAuthState] in the controller these calls are usually
+     * 0-row no-ops, kept as belt-and-braces cleanup on every exit path.
      */
     @Transactional(Transactional.TxType.REQUIRES_NEW)
     open fun deleteOAuthStateQuietly(stateToken: String) {
@@ -966,6 +993,16 @@ open class OAuthService(
 
             UserCreationResult(user = savedUser, isNewUser = true)
         } catch (e: jakarta.persistence.PersistenceException) {
+            // Two near-simultaneous first logins for the same new email can both pass the
+            // findByEmailIgnoreCase check and both attempt the insert; the loser hits the
+            // unique constraint on username/email. Instead of failing that login, re-fetch:
+            // the winner's committed user is the account this login belongs to.
+            val concurrentlyCreated = userRepository.findByEmailIgnoreCase(email).orElse(null)
+            if (concurrentlyCreated != null) {
+                logger.warn("OAuth user creation lost a concurrent-provisioning race for email={} - " +
+                    "reusing user id={} created by the winner", email, concurrentlyCreated.id)
+                return UserCreationResult(user = concurrentlyCreated, isNewUser = false)
+            }
             logger.error("Database error creating OAuth user (email={}, username={}): {} - {}",
                 email, username, e.javaClass.simpleName, e.message, e)
             null

--- a/src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/RequirementIdService.kt
@@ -1,22 +1,27 @@
 package com.secman.service
 
-import com.secman.repository.RequirementIdSequenceRepository
+import com.secman.domain.RequirementIdSequence
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import jakarta.transaction.Transactional
 
 @Singleton
 open class RequirementIdService(
-    @Inject private val sequenceRepository: RequirementIdSequenceRepository
+    @Inject private val entityManager: EntityManager
 ) {
 
     @Transactional
     open fun getNextId(): String {
-        val sequence = sequenceRepository.findByIdForUpdate(1L)
-            .orElseThrow { IllegalStateException("Requirement ID sequence not initialized. Run database migrations.") }
+        // PESSIMISTIC_WRITE (SELECT ... FOR UPDATE) serializes concurrent callers on the
+        // sequence row. The previous repository read was a plain SELECT despite being named
+        // "findByIdForUpdate", so two concurrent requirement creations could both read the
+        // same nextValue and issue the same REQ-xxx id (then collide on the internal_id
+        // unique constraint).
+        val sequence = lockSequenceRow()
         val nextVal = sequence.nextValue
         sequence.nextValue = nextVal + 1
-        sequenceRepository.update(sequence)
         return formatId(nextVal)
     }
 
@@ -27,10 +32,13 @@ open class RequirementIdService(
      */
     @Transactional
     open fun resetSequence() {
-        val sequence = sequenceRepository.findByIdForUpdate(1L)
-            .orElseThrow { IllegalStateException("Requirement ID sequence not initialized. Run database migrations.") }
+        val sequence = lockSequenceRow()
         sequence.nextValue = 1
-        sequenceRepository.update(sequence)
+    }
+
+    private fun lockSequenceRow(): RequirementIdSequence {
+        return entityManager.find(RequirementIdSequence::class.java, 1L, LockModeType.PESSIMISTIC_WRITE)
+            ?: throw IllegalStateException("Requirement ID sequence not initialized. Run database migrations.")
     }
 
     fun formatId(num: Int): String {

--- a/src/backendng/src/main/kotlin/com/secman/service/UserMappingService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/UserMappingService.kt
@@ -420,30 +420,43 @@ open class UserMappingService(
     open fun applyFutureUserMapping(user: User): Int {
         var appliedCount = 0
 
-        // Find future user mappings (case-insensitive email match, no user reference, not yet applied)
-        val futureMappings = userMappingRepository.findByEmail(user.email)
-            .filter { it.user == null && it.appliedAt == null }
-
-        if (futureMappings.isEmpty()) {
-            log.debug("No future user mappings found for email: ${user.email}")
+        // Re-load the user inside this transaction instead of trusting the detached instance
+        // from the event. The @Async listener races the publisher: if a (future) transactional
+        // caller publishes UserCreatedEvent before its own commit, the user row is not yet
+        // visible here (READ COMMITTED) — linking mappings to the detached instance would then
+        // either violate the FK or point at a row that may still be rolled back. Skipping is
+        // safe: the mapping stays unapplied and is picked up on the next relevant event.
+        val managedUser = user.id?.let { userRepository.findById(it).orElse(null) }
+        if (managedUser == null) {
+            log.warn("applyFutureUserMapping: user id=${user.id} email=${user.email} not visible yet " +
+                "(publisher transaction not committed?) - skipping mapping application")
             return 0
         }
 
-        log.info("Found ${futureMappings.size} future user mapping(s) for email: ${user.email}")
+        // Find future user mappings (case-insensitive email match, no user reference, not yet applied)
+        val futureMappings = userMappingRepository.findByEmail(managedUser.email)
+            .filter { it.user == null && it.appliedAt == null }
+
+        if (futureMappings.isEmpty()) {
+            log.debug("No future user mappings found for email: ${managedUser.email}")
+            return 0
+        }
+
+        log.info("Found ${futureMappings.size} future user mapping(s) for email: ${managedUser.email}")
 
         for (futureMapping in futureMappings) {
             // Check for conflicting pre-existing mapping (mapping with user reference for same composite key)
             val hasConflict = if (futureMapping.ipAddress != null) {
                 userMappingRepository.existsByEmailAndIpAddressAndDomain(
-                    user.email, futureMapping.ipAddress, futureMapping.domain
+                    managedUser.email, futureMapping.ipAddress, futureMapping.domain
                 ) && userMappingRepository.findByEmailAndIpAddressAndDomain(
-                    user.email, futureMapping.ipAddress, futureMapping.domain
+                    managedUser.email, futureMapping.ipAddress, futureMapping.domain
                 ).map { it.user != null }.orElse(false)
             } else {
                 userMappingRepository.existsByEmailAndAwsAccountIdAndDomain(
-                    user.email, futureMapping.awsAccountId, futureMapping.domain
+                    managedUser.email, futureMapping.awsAccountId, futureMapping.domain
                 ) && userMappingRepository.findByEmailAndAwsAccountIdAndDomain(
-                    user.email, futureMapping.awsAccountId, futureMapping.domain
+                    managedUser.email, futureMapping.awsAccountId, futureMapping.domain
                 ).map { it.user != null }.orElse(false)
             }
 
@@ -456,15 +469,15 @@ open class UserMappingService(
             }
 
             // Apply the future mapping to the user
-            futureMapping.user = user
+            futureMapping.user = managedUser
             futureMapping.appliedAt = Instant.now()
             userMappingRepository.update(futureMapping)
 
-            log.info("Applied future user mapping id=${futureMapping.id} to user ${user.email}")
+            log.info("Applied future user mapping id=${futureMapping.id} to user ${managedUser.email}")
             appliedCount++
         }
 
-        log.info("Applied $appliedCount future user mapping(s) to user ${user.email}")
+        log.info("Applied $appliedCount future user mapping(s) to user ${managedUser.email}")
         return appliedCount
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityService.kt
@@ -1965,13 +1965,15 @@ open class VulnerabilityService(
      */
     open fun addVulnerabilityFromCli(request: AddVulnerabilityRequestDto): AddVulnerabilityResponseDto {
         val lockKey = request.hostname.trim().lowercase()
+        // The lock object must stay in the map for the key's lifetime. The previous
+        // remove-in-finally variant broke mutual exclusion: thread A removes the entry while
+        // thread B is still blocked on the old lock object, thread C then creates a fresh lock
+        // for the same hostname and runs concurrently with B — exactly the duplicate-asset race
+        // this lock exists to prevent. The map is bounded by the number of distinct hostnames
+        // per JVM lifetime (a plain Any per entry), so entries are intentionally never removed.
         val lock = cliAddLocks.computeIfAbsent(lockKey) { Any() }
         return synchronized(lock) {
-            try {
-                addVulnerabilityFromCliLocked(request)
-            } finally {
-                cliAddLocks.remove(lockKey, lock)
-            }
+            addVulnerabilityFromCliLocked(request)
         }
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityStatisticsCacheService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityStatisticsCacheService.kt
@@ -195,22 +195,9 @@ open class VulnerabilityStatisticsCacheService(
 
     @Transactional
     open fun upsertCache(cacheKey: String, json: String, durationMs: Long) {
-        val existing = cacheRepository.findByCacheKey(cacheKey)
-        if (existing.isPresent) {
-            val entry = existing.get()
-            entry.cachedJson = json
-            entry.lastRefreshedAt = LocalDateTime.now()
-            entry.refreshDurationMs = durationMs
-            cacheRepository.update(entry)
-        } else {
-            cacheRepository.save(
-                VulnerabilityStatisticsCache(
-                    cacheKey = cacheKey,
-                    cachedJson = json,
-                    lastRefreshedAt = LocalDateTime.now(),
-                    refreshDurationMs = durationMs
-                )
-            )
-        }
+        // Atomic native upsert (ON DUPLICATE KEY on the cache_key unique index). The previous
+        // find-then-save/update was racy under concurrent refreshes: both saw "no row", both
+        // inserted, and one refresh died on the unique constraint.
+        cacheRepository.upsertByCacheKey(cacheKey, json, LocalDateTime.now(), durationMs)
     }
 }

--- a/src/backendng/src/main/resources/db/migration/V243__github_repo_alert_unique.sql
+++ b/src/backendng/src/main/resources/db/migration/V243__github_repo_alert_unique.sql
@@ -1,0 +1,16 @@
+-- Race-condition hardening: concurrent GitHub imports (CLI + UI "Import now")
+-- could interleave the per-repo delete+reinsert of Dependabot alerts and leave
+-- duplicated (github_repository_id, alert_number) rows. The import now takes a
+-- per-repo row lock; this constraint is the database-level backstop.
+
+-- 1) Remove any duplicates already produced by the unguarded window
+--    (keep the lowest id per (repo, alert_number)).
+DELETE a FROM github_repo_dependabot_alert a
+JOIN github_repo_dependabot_alert b
+  ON a.github_repository_id = b.github_repository_id
+ AND a.alert_number = b.alert_number
+ AND a.id > b.id;
+
+-- 2) Enforce uniqueness going forward.
+ALTER TABLE github_repo_dependabot_alert
+    ADD CONSTRAINT uk_ghalert_repo_alert UNIQUE (github_repository_id, alert_number);

--- a/src/backendng/src/test/kotlin/com/secman/scheduler/ExceptionExpirationSchedulerTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/scheduler/ExceptionExpirationSchedulerTest.kt
@@ -1,0 +1,154 @@
+package com.secman.scheduler
+
+import com.secman.domain.ExceptionRequestStatus
+import com.secman.domain.VulnerabilityException
+import com.secman.domain.VulnerabilityExceptionRequest
+import com.secman.repository.VulnerabilityExceptionRepository
+import com.secman.repository.VulnerabilityExceptionRequestRepository
+import com.secman.service.ActiveExceptionsCacheInvalidator
+import com.secman.service.ExceptionRequestAuditService
+import com.secman.service.ExceptionRequestNotificationService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Concurrency-safety tests for the expiration scheduler: overlapping runs (a second app
+ * instance, or a run overlapping a slow previous one) must process each request's side
+ * effects exactly once - enforced by atomic per-request claims.
+ */
+@DisplayName("ExceptionExpirationScheduler claims")
+class ExceptionExpirationSchedulerTest {
+
+    private val requestRepository = mockk<VulnerabilityExceptionRequestRepository>(relaxed = true)
+    private val exceptionRepository = mockk<VulnerabilityExceptionRepository>(relaxed = true)
+    private val auditService = mockk<ExceptionRequestAuditService>(relaxed = true)
+    private val notificationService = mockk<ExceptionRequestNotificationService>(relaxed = true)
+    private val cacheInvalidator = mockk<ActiveExceptionsCacheInvalidator>(relaxed = true)
+
+    private lateinit var scheduler: ExceptionExpirationScheduler
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = ExceptionExpirationScheduler(
+            requestRepository, exceptionRepository, auditService, notificationService, cacheInvalidator
+        )
+        // Production gets the AOP self-proxy injected; the plain instance suffices here.
+        scheduler.selfProvider = jakarta.inject.Provider { scheduler }
+        every { notificationService.notifyRequesterOfExpiration(any()) } returns
+            CompletableFuture.completedFuture(true)
+        every { notificationService.notifyAdminsAndSecChampionsOfExpiration(any()) } returns
+            CompletableFuture.completedFuture(true)
+    }
+
+    private fun approvedRequest(id: Long) = VulnerabilityExceptionRequest(
+        id = id,
+        requestedByUsername = "alice",
+        subject = VulnerabilityException.Subject.CVE,
+        scope = VulnerabilityException.Scope.GLOBAL,
+        subjectValue = "CVE-2026-0001",
+        scopeValue = null,
+        reason = "expired exception request under test - reason padding",
+        expirationDate = LocalDateTime.now().minusDays(1),
+        status = ExceptionRequestStatus.APPROVED,
+        autoApproved = false,
+        cveId = "CVE-2026-0001",
+        assetId = null
+    ).apply {
+        createdAt = LocalDateTime.now().minusDays(30)
+        updatedAt = LocalDateTime.now().minusDays(1)
+        version = 0
+    }
+
+    @Test
+    fun `expiration winner runs side effects exactly once`() {
+        val request = approvedRequest(1L)
+        every {
+            requestRepository.findByStatusAndExpirationDateLessThanEqual(ExceptionRequestStatus.APPROVED, any())
+        } returns listOf(request)
+        every {
+            requestRepository.claimStatusTransition(1L, ExceptionRequestStatus.APPROVED, ExceptionRequestStatus.EXPIRED, any())
+        } returns 1
+
+        scheduler.processExpirations()
+
+        verify(exactly = 1) { notificationService.notifyRequesterOfExpiration(request) }
+        verify(exactly = 1) { notificationService.notifyAdminsAndSecChampionsOfExpiration(request) }
+        verify(exactly = 1) { auditService.logExpiration(request) }
+    }
+
+    @Test
+    fun `lost expiration claim skips all side effects`() {
+        val request = approvedRequest(2L)
+        every {
+            requestRepository.findByStatusAndExpirationDateLessThanEqual(ExceptionRequestStatus.APPROVED, any())
+        } returns listOf(request)
+        // A concurrent run already flipped APPROVED -> EXPIRED: 0 rows affected here.
+        every {
+            requestRepository.claimStatusTransition(2L, ExceptionRequestStatus.APPROVED, ExceptionRequestStatus.EXPIRED, any())
+        } returns 0
+
+        scheduler.processExpirations()
+
+        verify(exactly = 0) { notificationService.notifyRequesterOfExpiration(any()) }
+        verify(exactly = 0) { notificationService.notifyAdminsAndSecChampionsOfExpiration(any()) }
+        verify(exactly = 0) { auditService.logExpiration(any()) }
+        verify(exactly = 0) { exceptionRepository.delete(any()) }
+    }
+
+    @Test
+    fun `reminder is sent only by the claim winner`() {
+        val request = approvedRequest(3L).apply {
+            expirationDate = LocalDateTime.now().plusDays(3)
+            reminderSentAt = null
+        }
+        every {
+            requestRepository.findByStatusAndExpirationDateBetween(ExceptionRequestStatus.APPROVED, any(), any())
+        } returns listOf(request)
+        every { requestRepository.claimReminder(3L, any()) } returns 1
+
+        scheduler.sendExpirationReminders()
+
+        verify(exactly = 1) { notificationService.notifyRequesterOfExpiration(request) }
+        verify(exactly = 0) { requestRepository.releaseReminderClaim(any(), any()) }
+    }
+
+    @Test
+    fun `lost reminder claim sends nothing`() {
+        val request = approvedRequest(4L).apply {
+            expirationDate = LocalDateTime.now().plusDays(3)
+            reminderSentAt = null
+        }
+        every {
+            requestRepository.findByStatusAndExpirationDateBetween(ExceptionRequestStatus.APPROVED, any(), any())
+        } returns listOf(request)
+        every { requestRepository.claimReminder(4L, any()) } returns 0
+
+        scheduler.sendExpirationReminders()
+
+        verify(exactly = 0) { notificationService.notifyRequesterOfExpiration(any()) }
+    }
+
+    @Test
+    fun `failed reminder send releases the claim for retry`() {
+        val request = approvedRequest(5L).apply {
+            expirationDate = LocalDateTime.now().plusDays(3)
+            reminderSentAt = null
+        }
+        every {
+            requestRepository.findByStatusAndExpirationDateBetween(ExceptionRequestStatus.APPROVED, any(), any())
+        } returns listOf(request)
+        every { requestRepository.claimReminder(5L, any()) } returns 1
+        every { notificationService.notifyRequesterOfExpiration(request) } returns
+            CompletableFuture.completedFuture(false)
+
+        scheduler.sendExpirationReminders()
+
+        verify(exactly = 1) { requestRepository.releaseReminderClaim(5L, any()) }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/AssetMatchClearServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AssetMatchClearServiceTest.kt
@@ -9,6 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.Optional
 
 class AssetMatchClearServiceTest {
 
@@ -136,6 +137,7 @@ class AssetMatchClearServiceTest {
         val gone = awsAsset(7L, "ghost", "111", "i-bbb")
         every { assetRepository.findAwsAssetsInAccounts(setOf("111")) } returns listOf(gone)
         every { assetRepository.countAwsAssetsInAccounts(setOf("111")) } returns 1L
+        every { assetRepository.findById(7L) } returns Optional.of(gone)
         every {
             assetCascadeDeleteService.deleteAsset(7L, "admin", forceTimeout = true, bulkOperationId = any())
         } returns mockk(relaxed = true)
@@ -230,6 +232,8 @@ class AssetMatchClearServiceTest {
         val ok = awsAsset(12L, "ok", "111", "i-y")
         every { assetRepository.findAwsAssetsInAccounts(setOf("111")) } returns listOf(blocked, ok)
         every { assetRepository.countAwsAssetsInAccounts(setOf("111")) } returns 10L  // brake disabled by ratio
+        every { assetRepository.findById(11L) } returns Optional.of(blocked)
+        every { assetRepository.findById(12L) } returns Optional.of(ok)
         every {
             assetCascadeDeleteService.deleteAsset(11L, "admin", forceTimeout = true, bulkOperationId = any())
         } throws IllegalStateException("referenced by risk")
@@ -250,6 +254,52 @@ class AssetMatchClearServiceTest {
         assertThat(result.errors).hasSize(1)
         assertThat(result.errors[0].assetName).isEqualTo("blocked")
         assertThat(result.status).isEqualTo("PARTIAL")
+    }
+
+    @Test
+    fun `re-verifies candidates at delete time and skips concurrently re-matched assets`() {
+        // Scan snapshot: i-bbb is stale (not in the resource set) → candidate.
+        val scanned = awsAsset(7L, "ghost", "111", "i-bbb")
+        every { assetRepository.findAwsAssetsInAccounts(setOf("111")) } returns listOf(scanned)
+        every { assetRepository.countAwsAssetsInAccounts(setOf("111")) } returns 1L
+        // Between scan and delete, a concurrent import re-matched the asset: its
+        // cloudInstanceId now IS in the snapshot → deleting it would destroy a live asset.
+        val reimported = awsAsset(7L, "ghost", "111", "i-aaa")
+        every { assetRepository.findById(7L) } returns Optional.of(reimported)
+
+        val result = service.clear(
+            accountIds = listOf("111"),
+            resourceIds = listOf("i-aaa"),
+            dryRun = false,
+            username = "admin",
+            maxDeletePercent = 100
+        )
+
+        assertThat(result.candidateCount).isEqualTo(1)
+        assertThat(result.deletedCount).isEqualTo(0)
+        assertThat(result.skippedCount).isEqualTo(1)
+        assertThat(result.errors).isEmpty()
+        verify(exactly = 0) { assetCascadeDeleteService.deleteAsset(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `re-verification skips candidates deleted by a concurrent run`() {
+        val scanned = awsAsset(8L, "gone", "111", "i-bbb")
+        every { assetRepository.findAwsAssetsInAccounts(setOf("111")) } returns listOf(scanned)
+        every { assetRepository.countAwsAssetsInAccounts(setOf("111")) } returns 1L
+        every { assetRepository.findById(8L) } returns Optional.empty()
+
+        val result = service.clear(
+            accountIds = listOf("111"),
+            resourceIds = listOf("i-aaa"),
+            dryRun = false,
+            username = "admin",
+            maxDeletePercent = 100
+        )
+
+        assertThat(result.deletedCount).isEqualTo(0)
+        assertThat(result.skippedCount).isEqualTo(1)
+        verify(exactly = 0) { assetCascadeDeleteService.deleteAsset(any(), any(), any(), any()) }
     }
 
     private fun awsAsset(id: Long, name: String, account: String, instance: String): Asset =

--- a/src/backendng/src/test/kotlin/com/secman/service/AwsAccountRiskAssessmentServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AwsAccountRiskAssessmentServiceTest.kt
@@ -131,6 +131,39 @@ class AwsAccountRiskAssessmentServiceTest {
     }
 
     @Test
+    fun `skips creation when an open assessment is already tracked for the account-owner pair`() {
+        val openAssessment = RiskAssessment(
+            id = 77L,
+            startDate = LocalDate.now().minusDays(3),
+            endDate = LocalDate.now().plusDays(4),
+            assessmentBasisType = AssessmentBasisType.ASSET,
+            assessmentBasisId = 1L,
+            assessor = champion1,
+            requestor = admin
+        )
+        every { trackingRepository.findByAwsAccountId("111111111111") } returns listOf(
+            AwsAccountRiskAssessment(
+                id = 300L,
+                awsAccountId = "111111111111",
+                ownerEmail = "ALICE@corp.com", // case-insensitive match
+                riskAssessment = openAssessment,
+                useCaseName = "Cloud Onboarding"
+            )
+        )
+
+        val results = service.startAssessmentsForNewAccounts(
+            listOf(NewAccountImportInfo("111111111111", listOf("alice@corp.com"))),
+            "Cloud Onboarding", 7, 9L
+        )
+
+        assertThat(results.single().error).contains("already exists")
+        assertThat(results.single().riskAssessmentId).isEqualTo(77L)
+        verify(exactly = 0) { riskAssessmentRepository.save(any()) }
+        verify(exactly = 0) { trackingRepository.save(any()) }
+        verify(exactly = 0) { emailService.sendEmail(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `creates dedicated AWS account asset when none exists`() {
         val assetSlot = slot<Asset>()
         every { assetRepository.save(capture(assetSlot)) } answers { firstArg<Asset>().apply { id = 100L } }
@@ -236,14 +269,14 @@ class AwsAccountRiskAssessmentServiceTest {
         val today = LocalDate.now()
         val t = tracking(endDate = today.plusDays(2))
         every { trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2)) } returns listOf(t)
+        every { trackingRepository.claimTwoDayReminder(300L, any()) } returns 1
 
         val sent = service.processDeadlineReminders(today)
 
         assertThat(sent).isEqualTo(1)
-        assertThat(t.reminderTwoDaysSentAt).isNotNull()
-        assertThat(t.reminderOneDaySentAt).isNull()
+        verify { trackingRepository.claimTwoDayReminder(300L, any()) }
         verify { emailService.sendEmail("alice@corp.com", match { it.contains("2 days") }, any(), any()) }
-        verify { trackingRepository.update(t) }
+        verify(exactly = 0) { trackingRepository.claimOneDayReminder(any(), any()) }
     }
 
     @Test
@@ -251,11 +284,12 @@ class AwsAccountRiskAssessmentServiceTest {
         val today = LocalDate.now()
         val t = tracking(endDate = today.plusDays(1), twoSent = true)
         every { trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2)) } returns listOf(t)
+        every { trackingRepository.claimOneDayReminder(300L, any()) } returns 1
 
         val sent = service.processDeadlineReminders(today)
 
         assertThat(sent).isEqualTo(1)
-        assertThat(t.reminderOneDaySentAt).isNotNull()
+        verify { trackingRepository.claimOneDayReminder(300L, any()) }
         verify { emailService.sendEmail("alice@corp.com", match { it.contains("1 day") }, any(), any()) }
     }
 
@@ -264,13 +298,14 @@ class AwsAccountRiskAssessmentServiceTest {
         val today = LocalDate.now()
         val t = tracking(endDate = today.plusDays(1))
         every { trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2)) } returns listOf(t)
+        // claimOneDayReminder stamps BOTH slots in one atomic UPDATE (catch-up collapse).
+        every { trackingRepository.claimOneDayReminder(300L, any()) } returns 1
 
         val sent = service.processDeadlineReminders(today)
 
         assertThat(sent).isEqualTo(1)
-        assertThat(t.reminderOneDaySentAt).isNotNull()
-        assertThat(t.reminderTwoDaysSentAt).isNotNull()
         verify(exactly = 1) { emailService.sendEmail(any(), any(), any(), any()) }
+        verify(exactly = 0) { trackingRepository.claimTwoDayReminder(any(), any()) }
     }
 
     @Test
@@ -286,16 +321,30 @@ class AwsAccountRiskAssessmentServiceTest {
     }
 
     @Test
-    fun `failed reminder email leaves state unstamped for retry on next run`() {
+    fun `lost reminder claim means a concurrent run already sent - no duplicate email`() {
         val today = LocalDate.now()
         val t = tracking(endDate = today.plusDays(2))
         every { trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2)) } returns listOf(t)
+        // Another instance won the guarded UPDATE: 0 rows affected here.
+        every { trackingRepository.claimTwoDayReminder(300L, any()) } returns 0
+
+        val sent = service.processDeadlineReminders(today)
+
+        assertThat(sent).isEqualTo(0)
+        verify(exactly = 0) { emailService.sendEmail(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `failed reminder email releases the claim for retry on next run`() {
+        val today = LocalDate.now()
+        val t = tracking(endDate = today.plusDays(2))
+        every { trackingRepository.findPendingDeadlineReminders(today, today.plusDays(2)) } returns listOf(t)
+        every { trackingRepository.claimTwoDayReminder(300L, any()) } returns 1
         every { emailService.sendEmail(any(), any(), any(), any()) } returns CompletableFuture.completedFuture(false)
 
         val sent = service.processDeadlineReminders(today)
 
         assertThat(sent).isEqualTo(0)
-        assertThat(t.reminderTwoDaysSentAt).isNull()
-        verify(exactly = 0) { trackingRepository.update(any<AwsAccountRiskAssessment>()) }
+        verify { trackingRepository.releaseTwoDayReminderClaim(300L, any()) }
     }
 }

--- a/src/backendng/src/test/kotlin/com/secman/service/GithubRepoImportServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/GithubRepoImportServiceTest.kt
@@ -14,6 +14,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -29,6 +31,7 @@ class GithubRepoImportServiceTest {
     private lateinit var alertRepository: GithubRepoDependabotAlertRepository
     private lateinit var client: GithubAppClientService
     private lateinit var ownerEmailMappingRepository: GithubOwnerEmailMappingRepository
+    private lateinit var entityManager: EntityManager
     private lateinit var service: GithubRepoImportService
 
     private val config = GithubAppConfig(id = 1, appId = "12345", privateKeyPem = "pem")
@@ -41,7 +44,10 @@ class GithubRepoImportServiceTest {
         alertRepository = mockk()
         client = mockk()
         ownerEmailMappingRepository = mockk()
-        service = GithubRepoImportService(configRepository, repoRepository, snapshotRepository, alertRepository, client, ownerEmailMappingRepository)
+        entityManager = mockk()
+        service = GithubRepoImportService(configRepository, repoRepository, snapshotRepository, alertRepository, client, ownerEmailMappingRepository, entityManager)
+        // Production gets the AOP self-proxy injected; the plain instance suffices in unit tests.
+        service.selfProvider = jakarta.inject.Provider { service }
 
         every { configRepository.findActiveConfig() } returns Optional.of(config)
         every { client.getInstallationToken(config) } returns "token"
@@ -110,6 +116,7 @@ class GithubRepoImportServiceTest {
             lastHighCriticalFindingAt = null
         )
         every { repoRepository.findByGithubRepoId(7) } returns Optional.of(existing)
+        every { entityManager.find(GithubRepository::class.java, 42L, LockModeType.PESSIMISTIC_WRITE) } returns existing
         every { client.listInstallationRepositories("token", "https://api.github.com") } returns listOf(repoDto(7))
         every { client.countOpenDependabotAlerts("token", "org", "repo7", "https://api.github.com") } returns
             GithubAppClientService.SeverityCounts(critical = 0, high = 0)
@@ -238,6 +245,7 @@ class GithubRepoImportServiceTest {
             ownerEmail = "manual@example.com"
         )
         every { repoRepository.findByGithubRepoId(7) } returns Optional.of(existing)
+        every { entityManager.find(GithubRepository::class.java, 42L, LockModeType.PESSIMISTIC_WRITE) } returns existing
         every { client.listInstallationRepositories("token", "https://api.github.com") } returns listOf(repoDto(7))
         every { client.countOpenDependabotAlerts("token", "org", "repo7", "https://api.github.com") } returns
             GithubAppClientService.SeverityCounts(critical = 0, high = 0)
@@ -259,6 +267,7 @@ class GithubRepoImportServiceTest {
             ownerEmail = "org-default@example.com"
         )
         every { repoRepository.findByGithubRepoId(7) } returns Optional.of(existing)
+        every { entityManager.find(GithubRepository::class.java, 42L, LockModeType.PESSIMISTIC_WRITE) } returns existing
         every { client.listInstallationRepositories("token", "https://api.github.com") } returns listOf(repoDto(7))
         every { client.countOpenDependabotAlerts("token", "org", "repo7", "https://api.github.com") } returns
             GithubAppClientService.SeverityCounts(critical = 0, high = 0)

--- a/src/backendng/src/test/kotlin/com/secman/service/MaterializedViewRefreshServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/MaterializedViewRefreshServiceTest.kt
@@ -58,6 +58,9 @@ class MaterializedViewRefreshServiceTest {
             vulnerabilityService,
             awsCleanServerKpiService
         )
+        // In production Micronaut injects the AOP self-proxy; in unit tests the plain
+        // instance is fine (no transactionality to assert here).
+        service.selfProvider = jakarta.inject.Provider { service }
     }
 
     private fun overdueVulnerability(): Vulnerability {

--- a/src/backendng/src/test/kotlin/com/secman/service/RequirementIdServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/RequirementIdServiceTest.kt
@@ -1,0 +1,74 @@
+package com.secman.service
+
+import com.secman.domain.RequirementIdSequence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("RequirementIdService")
+class RequirementIdServiceTest {
+
+    private lateinit var entityManager: EntityManager
+    private lateinit var service: RequirementIdService
+
+    @BeforeEach
+    fun setUp() {
+        entityManager = mockk()
+        service = RequirementIdService(entityManager)
+    }
+
+    @Test
+    fun `getNextId locks the sequence row with PESSIMISTIC_WRITE and increments it`() {
+        val sequence = RequirementIdSequence(id = 1L, nextValue = 41)
+        every {
+            entityManager.find(RequirementIdSequence::class.java, 1L, LockModeType.PESSIMISTIC_WRITE)
+        } returns sequence
+
+        val id = service.getNextId()
+
+        assertThat(id).isEqualTo("REQ-041")
+        assertThat(sequence.nextValue).isEqualTo(42)
+        // The lock mode is the point of the fix: a plain read here allowed two concurrent
+        // requirement creations to issue the same REQ id.
+        verify {
+            entityManager.find(RequirementIdSequence::class.java, 1L, LockModeType.PESSIMISTIC_WRITE)
+        }
+    }
+
+    @Test
+    fun `getNextId fails when the sequence row is missing`() {
+        every {
+            entityManager.find(RequirementIdSequence::class.java, 1L, LockModeType.PESSIMISTIC_WRITE)
+        } returns null
+
+        assertThatThrownBy { service.getNextId() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("not initialized")
+    }
+
+    @Test
+    fun `resetSequence sets the locked row back to 1`() {
+        val sequence = RequirementIdSequence(id = 1L, nextValue = 500)
+        every {
+            entityManager.find(RequirementIdSequence::class.java, 1L, LockModeType.PESSIMISTIC_WRITE)
+        } returns sequence
+
+        service.resetSequence()
+
+        assertThat(sequence.nextValue).isEqualTo(1)
+    }
+
+    @Test
+    fun `formatId pads below 1000 and passes larger values through`() {
+        assertThat(service.formatId(7)).isEqualTo("REQ-007")
+        assertThat(service.formatId(999)).isEqualTo("REQ-999")
+        assertThat(service.formatId(1000)).isEqualTo("REQ-1000")
+    }
+}


### PR DESCRIPTION
## Summary

Systematic race-condition analysis of the backend business logic and SQL, with fixes for everything safely remediable in one change. The full analysis — every finding with its location, the interleaving that triggers it, the consequence, and the fix or deferral rationale — is in **`docs/RACE_CONDITIONS.md`**.

### Highest-impact fixes

- **Materialized view (outdated assets)** — `swapMaterializedView` was self-invoked, so its `@Transactional` was bypassed by Micronaut AOP: the `deleteAll`+`saveAll` swap committed as two transactions and readers could see an empty view (the exact "false 0 overdue assets" bug its comment claims to fix). Now routed through a `selfProvider` proxy. The "already running" guard was also check-then-act; a post-insert re-check now guarantees at most one live refresh.
- **Requirement IDs** — `findByIdForUpdate` was a plain `SELECT` despite its name (explicit `@Query`, no lock). Concurrent creations could issue duplicate `REQ-xxx` ids. Now a real `PESSIMISTIC_WRITE` (`SELECT … FOR UPDATE`) on the sequence row.
- **One-time tokens** — assessment-token submit and OAuth state consumption were read-check-write; both are now atomic claims (guarded `UPDATE`/`DELETE` checking affected rows), so double-submits can no longer complete an assessment twice or race the OAuth callback flow.
- **GitHub Dependabot import** — `persistRepo`'s `@Transactional` was bypassed (self-invocation), there was no lock, and no unique constraint: concurrent imports (CLI + UI) could interleave the delete+reinsert and duplicate alert rows. Now: self-proxy + per-repo `PESSIMISTIC_WRITE` + `DeadlockRetry` + migration **V243** (dedup + `UNIQUE (github_repository_id, alert_number)`).
- **CLI add-vulnerability lock** — the striped lock removed its map entry in `finally` while a waiter could still hold the stale lock object, letting two threads run the "locked" section concurrently for one hostname. Entries are no longer removed.
- **Job concurrency caps** — export-job (per-user/global) and AI-job (per-assessment/global) caps were count-then-insert and freely exceedable. Now insert-then-recheck with deterministic oldest-wins ranking; AI losers self-fail **before any paid LLM call**. Status transitions are now guarded so a stale-reset/cancelled job can't be resurrected to COMPLETED and a cancelled AI job stops accruing cost and writing suggestions.
- **Schedulers** — exception expiration, expiration reminders, and AWS risk-assessment deadline reminders all had read-flag-then-send patterns that double-sent emails (and double-wrote audit rows) on multi-instance/overlapping runs. All now claim-before-send via atomic guarded `UPDATE`s in `REQUIRES_NEW` transactions.
- **Safety brake (asset-match-clear)** — a concurrently re-imported live asset could be deleted from a stale candidate list; each candidate is now re-verified against the snapshot predicate immediately before deletion.
- **Upserts** — statistics cache, AWS clean-server KPI, and CrowdStrike severity history moved from racy find-then-save to native `INSERT … ON DUPLICATE KEY UPDATE` (a severity-history PK collision previously rolled back an entire reconcile run).
- **User provisioning** — concurrent OAuth first-logins for the same new email now recover by reusing the winner's committed user instead of failing the login; the user-created mapping listener re-loads the user in-transaction instead of trusting a detached (possibly uncommitted) entity.

### Deliberately deferred (documented in `docs/RACE_CONDITIONS.md`)

- `UNIQUE` constraint on `asset.name` — needs an operator-run FK-repointing dedup migration on production data; app-level catch-and-refetch mitigations were added in the meantime.
- Distributed scheduler mutex (`GET_LOCK`-based), selective `@Version` rollout, single-transaction CrowdStrike-cleanup brake, schema audit for `hbm2ddl`-unenforced unique constraints.
- **Discovered defect flagged, not changed:** `UserMappingApplicationService.onUserCreated` listens to a shadow event class that is never published — it has never fired (Feature 049 PENDING-mapping auto-apply is dead code) and needs deliberate consolidation.

### Changes

- 24 main-source files, 1 new Flyway migration (V243), `docs/RACE_CONDITIONS.md`.
- Tests: new `RequirementIdServiceTest`, `ExceptionExpirationSchedulerTest`; updated `AssetMatchClearServiceTest`, `AwsAccountRiskAssessmentServiceTest`, `GithubRepoImportServiceTest`, `MaterializedViewRefreshServiceTest` for the new claim/lock semantics.

### Verification status

⚠️ **This session's remote environment blocks Maven Central and the Gradle distribution/plugin portals (network policy), so `./gradlew build` could not be run here** — the wrapper cannot even download Gradle, and no dependency cache exists in the container. The dev-start script and E2E gates (`/e2ejs`, `/e2evulnexception`) additionally require `pass-cli`/`SECMAN_HOST`, which are unavailable in this environment. All changes were desk-checked against existing code and test conventions, but **CI (or a local `./gradlew build` + both E2E gates) must run before merge** — per the repo's own completion rules this PR is not merge-ready until those pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7SWxDUPSb9nXat6uQbJpC

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7SWxDUPSb9nXat6uQbJpC)_