### PR TITLE
Fix "Active Standard Releases" dashboard KPI always showing "-"

### DIFF
--- a/src/frontend/src/components/HomeStatisticsDashboard.tsx
+++ b/src/frontend/src/components/HomeStatisticsDashboard.tsx
@@ -90,10 +90,10 @@ const HomeStatisticsDashboard: React.FC = () => {
       }
 
       try {
-        const releasesResp = await authenticatedGet('/api/releases');
+        const releasesResp = await authenticatedGet('/api/releases?status=ACTIVE');
         if (releasesResp.ok) {
-          const releases = await releasesResp.json();
-          next.releases = Array.isArray(releases) ? releases.length : null;
+          const releasesPage = await releasesResp.json();
+          next.releases = typeof releasesPage?.totalItems === 'number' ? releasesPage.totalItems : null;
         }
       } catch (error) {
         console.warn('Failed to load release statistics:', error);
@@ -149,7 +149,7 @@ const HomeStatisticsDashboard: React.FC = () => {
 
   const cards: StatItem[] = [
     { label: 'Systems in Asset Inventory', value: formatCount(stats.assets), subtitle: 'All asset records', icon: 'bi-hdd-network' },
-    { label: 'Active Standard Releases', value: formatCount(stats.releases), subtitle: 'All release records', icon: 'bi-journals' },
+    { label: 'Active Standard Releases', value: formatCount(stats.releases), subtitle: 'Releases with status ACTIVE', icon: 'bi-journals' },
     { label: 'Running Risk Assessments', value: formatCount(stats.runningAssessments), subtitle: 'Status: IN_PROGRESS', icon: 'bi-clipboard2-pulse' },
     { label: 'Last CrowdStrike Import', value: stats.lastCrowdStrikeCheckin ?? '—', subtitle: 'Most recent server check-in', icon: 'bi-shield-check' }
   ];


### PR DESCRIPTION
## Summary
- Fixes the post-login "Active Standard Releases" KPI tile always rendering `—`, even when an ACTIVE release exists.
- `GET /api/releases` returns a paginated object (`{data, currentPage, totalItems, ...}`), not a bare array, but `HomeStatisticsDashboard.tsx` checked `Array.isArray(releases)`, which was always `false`, so the stat stayed `null`.
- Now fetches `/api/releases?status=ACTIVE` and reads `totalItems` from the response, matching the tile's label ("Active Standard Releases") instead of counting all releases regardless of status.
- Updated the tile subtitle from "All release records" to "Releases with status ACTIVE" to match the corrected behavior.

## Test plan
- [x] `npm run build` in `src/frontend` completes with no TypeScript/build errors.
- [ ] Manual: log in as an ADMIN/SECCHAMPION user with at least one ACTIVE release and confirm the dashboard tile shows the correct count instead of `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013sUXzuFsbq3HsbhRawy31t)_