### PR TITLE
Make /requirements/download reachable without login

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt
@@ -68,6 +68,7 @@ open class ReleaseController(
      * Optional filter by status, with pagination
      */
     @Get
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun listReleases(
         @QueryValue("status") status: Release.ReleaseStatus?,
         @QueryValue("page") page: Int?,
@@ -110,6 +111,7 @@ open class ReleaseController(
      * GET /api/releases/{id} - Get release details
      */
     @Get("/{id}")
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun getReleaseById(@PathVariable id: Long): HttpResponse<Map<String, Any>> {
         logger.debug("Getting release by ID: $id")
 

--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
@@ -407,13 +407,14 @@ open class RequirementController(
     }
 
     @Get("/export/docx")
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun exportToDocx(
         @Nullable @QueryValue("releaseId") releaseId: Long?,
         @QueryValue(defaultValue = "LATEST") templateMode: String,
         @Nullable @QueryValue("templateId") templateId: Long?,
         @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
         @Nullable @QueryValue("classification") classification: String?,
-        authentication: Authentication
+        @Nullable authentication: Authentication?
     ): HttpResponse<*> {
         val exportData = resolveRequirementExportData(releaseId)
             ?: return HttpResponse.notFound(mapOf("error" to "Release not found"))
@@ -466,6 +467,7 @@ open class RequirementController(
     }
 
     @Get("/export/docx/usecase/{usecaseId}")
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun exportToDocxByUseCase(
         @PathVariable usecaseId: Long,
         @Nullable @QueryValue("releaseId") releaseId: Long?,
@@ -473,7 +475,7 @@ open class RequirementController(
         @Nullable @QueryValue("templateId") templateId: Long?,
         @QueryValue(defaultValue = "REJECT") missingPlaceholderBehavior: String,
         @Nullable @QueryValue("classification") classification: String?,
-        authentication: Authentication
+        @Nullable authentication: Authentication?
     ): HttpResponse<*> {
         val useCaseOptional = useCaseRepository.findById(usecaseId)
 
@@ -549,6 +551,7 @@ open class RequirementController(
     }
 
     @Get("/export/xlsx")
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun exportToExcel(@Nullable @QueryValue("releaseId") releaseId: Long?): HttpResponse<*> {
         val requirements: List<Requirement>
         val filename: String
@@ -590,6 +593,7 @@ open class RequirementController(
     }
 
     @Get("/export/xlsx/usecase/{usecaseId}")
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     fun exportToExcelByUseCase(@PathVariable usecaseId: Long, @Nullable @QueryValue("releaseId") releaseId: Long?): HttpResponse<*> {
         val useCaseOptional = useCaseRepository.findById(usecaseId)
 
@@ -673,8 +677,9 @@ open class RequirementController(
         scope: RequirementExportScope,
         releaseId: Long?,
         usecaseId: Long?,
-        authentication: Authentication
+        authentication: Authentication?
     ): HttpResponse<*> {
+        val exportedBy = authentication?.name ?: "anonymous"
         val behavior = parseMissingPlaceholderBehavior(missingPlaceholderBehavior)
         val resolvedTemplate = try {
             resolveTemplate(templateMode, templateId, adHocTemplate, behavior)
@@ -688,7 +693,7 @@ open class RequirementController(
                 templateBytes = resolvedTemplate.bytes,
                 requirements = requirements,
                 title = title,
-                exportedBy = authentication.name,
+                exportedBy = exportedBy,
                 language = language ?: "english",
                 classification = classification ?: "Internal"
             )
@@ -700,7 +705,7 @@ open class RequirementController(
             RequirementExportTemplateUsage(
                 template = resolvedTemplate.savedTemplate,
                 templateSha256 = resolvedTemplate.sha256,
-                exportedBy = authentication.name,
+                exportedBy = exportedBy,
                 exportScope = scope,
                 releaseId = releaseId,
                 usecaseId = usecaseId,

--- a/src/backendng/src/main/kotlin/com/secman/controller/UseCaseController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/UseCaseController.kt
@@ -53,6 +53,7 @@ open class UseCaseController(
     )
 
     @Get
+    @Secured(SecurityRule.IS_ANONYMOUS) // Public: powers the unauthenticated /requirements/download page
     @Transactional(readOnly = true)
     open fun getUseCases(): HttpResponse<List<UseCase>> {
         return try {

--- a/src/frontend/src/layouts/Layout.astro
+++ b/src/frontend/src/layouts/Layout.astro
@@ -16,7 +16,7 @@ interface Props {
 const { title = "SecMan" } = Astro.props; // Updated default title
 
 // Define public paths that don't require login
-const publicPaths = ['/login']; // Add other public paths if needed
+const publicPaths = ['/login', '/requirements/download']; // Add other public paths if needed
 
 // Check auth status on the server-side for initial load
 let user = null;


### PR DESCRIPTION
## Summary
- Added `/requirements/download` to the frontend `Layout.astro` public-path list so the page no longer redirects anonymous visitors to `/login`.
- Opened the specific backend endpoints the page depends on to anonymous access via method-level `@Secured(SecurityRule.IS_ANONYMOUS)` overrides, leaving every other endpoint on those controllers role-gated as before:
  - `GET /api/usecases` (`UseCaseController`)
  - `GET /api/releases`, `GET /api/releases/{id}` (`ReleaseController`)
  - `GET /api/requirements/export/docx[/usecase/{id}]`, `GET /api/requirements/export/xlsx[/usecase/{id}]` (`RequirementController`)
- `RequirementController`'s docx export endpoints now accept a nullable `Authentication`, falling back to `"anonymous"` for export-usage attribution (`exportedBy`) when no user is logged in.

## Test plan
- [x] `cd src/frontend && npm ci && npm run build` — exits 0
- [ ] `./gradlew build` — **could not run**: this sandbox's egress policy blocks `services.gradle.org` (Gradle 9.6.1 wrapper distribution) and the Gradle plugin portal, so the wrapper cannot download and no cached distribution/dependencies are available. Changes were reviewed manually for correctness (Kotlin syntax, nullable-Authentication handling, `@Secured` placement) but not compiled locally.
- [ ] `./scripts/startbackenddev.sh` — not run, blocked by the same build limitation
- [ ] `/e2ejs`, `/e2evulnexception` — not run

Please run the backend build/startup and E2E gates in an environment with full network access before merging, since these touch access control (`@Secured`) on multiple controllers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JXz8nckTdKfPf7ossGcpoX)_