### PR TITLE
Docker Compose deployment with container-or-RDS database toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ docker/backend/app.jar
 *.yml
 # GitHub Actions workflows must be tracked despite the blanket *.yml ignore above
 !.github/workflows/*.yml
+# Docker Compose file must be tracked despite the blanket *.yml ignore above
+!docker/docker-compose.yml
 .playwright-cli/ChatGPT-Atlas.dmg
 crowdstrike-vulnerability-match-report.json
 crowdstrike-vulnerability-match-report.md

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Full reference (SMTP, OAuth retry, memory tuning, debug logging, vuln settings):
 | [docs/E2E_EXCEPTION_WORKFLOW_TEST.md](docs/E2E_EXCEPTION_WORKFLOW_TEST.md) | Vuln-exception MCP E2E |
 | [docs/SKILLS_AND_AGENTS.md](docs/SKILLS_AND_AGENTS.md) | Claude Code skills + sub-agents wired to this repo |
 | [docs/PASS_CLI.md](docs/PASS_CLI.md) | `pass-cli` (Proton Pass) secret resolution |
-| [docker/README.md](docker/README.md) | Docker container deployment |
+| [docker/README.md](docker/README.md) | Docker deployment: Compose (bundled DB or RDS), single-container, multi-container |
+| [docs/DOCKER_AWS.md](docs/DOCKER_AWS.md) | All-in-one AWS image: ECS/Fargate, Secrets Manager, RDS |
 | [INSTALL.md](INSTALL.md) | Step-by-step install |
 
 ## Workflow

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,83 @@
+# Secman Docker Compose environment — copy to `.env` and fill in.
+# =============================================================================
+#   cp docker/.env.example docker/.env      # then edit
+#   # or let the helper generate one with fresh secrets:
+#   ./docker/compose-up.sh --local-db
+#
+# NEVER commit the real .env — it holds secrets. (.env is gitignored.)
+# Full variable catalog: docs/ENVIRONMENT.md. AWS specifics: docs/DOCKER_AWS.md.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Database mode — pick ONE.
+# -----------------------------------------------------------------------------
+# (A) Bundled MariaDB container  ->  start with:  --profile local-db
+#     The app reaches the container by its compose service name `db`.
+DB_CONNECT=jdbc:mariadb://db:3306/secman
+#
+# (B) Amazon RDS / external MariaDB  ->  start WITHOUT the profile.
+#     Comment out the line above and use your RDS endpoint instead, e.g.:
+# DB_CONNECT=jdbc:mariadb://mydb.abc123.eu-central-1.rds.amazonaws.com:3306/secman
+
+DB_NAME=secman
+DB_USERNAME=secman
+# Required. For the bundled DB this also becomes the container's app-user
+# password on first init. For RDS, this must match the RDS user's password.
+DB_PASSWORD=change-me-strong-db-password
+# Only used by the bundled `db` service (local-db mode).
+DB_ROOT_PASSWORD=change-me-strong-root-password
+
+# -----------------------------------------------------------------------------
+# Schema management
+# -----------------------------------------------------------------------------
+# false = fresh database: Hibernate auto-creates the schema on first boot.
+# true  = existing Flyway-managed schema.
+FLYWAY_DATASOURCES_DEFAULT_ENABLED=false
+
+# -----------------------------------------------------------------------------
+# Security secrets (generate real values — see comments)
+# -----------------------------------------------------------------------------
+# JWT signing key, >=256 bits:            openssl rand -base64 32
+JWT_SECRET=change-me-generate-with-openssl-rand-base64-32-at-least-256-bits
+# Encrypts stored credentials. NEVER rotate once data exists (orphans it).
+#   openssl rand -hex 32
+SECMAN_ENCRYPTION_PASSWORD=change-me-openssl-rand-hex-32
+#   exactly 16 hex chars:                 openssl rand -hex 8
+SECMAN_ENCRYPTION_SALT=0123456789abcdef
+
+# -----------------------------------------------------------------------------
+# Public URLs (CORS, OAuth callbacks, email links) — the address users hit.
+# -----------------------------------------------------------------------------
+FRONTEND_URL=http://localhost:8080
+SECMAN_BACKEND_URL=http://localhost:8080
+# true in production (TLS-fronted). false only for plain-HTTP local testing.
+SECMAN_AUTH_COOKIE_SECURE=false
+
+# -----------------------------------------------------------------------------
+# Host port mappings (compose only)
+# -----------------------------------------------------------------------------
+# Host port -> container :80. Use 80 if you have privileges and want the app
+# directly on the standard port.
+SECMAN_HTTP_PORT=8080
+# Host port -> bundled MariaDB :3306 (local-db mode only).
+DB_HOST_PORT=3307
+
+# -----------------------------------------------------------------------------
+# JVM sizing — tune with the container/task memory.
+# -----------------------------------------------------------------------------
+JAVA_OPTS=-Xmx1024m -Xms256m -XX:+UseContainerSupport
+
+# -----------------------------------------------------------------------------
+# Optional integrations (uncomment to enable) — see docs/ENVIRONMENT.md
+# -----------------------------------------------------------------------------
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM_ADDRESS=secman@example.com
+# SMTP_ENABLE_TLS=true
+# OPENROUTER_API_KEY=
+# AI_RISK_ASSESSMENT_ENABLED=true
+# FALCON_CLIENT_ID=
+# FALCON_CLIENT_SECRET=
+# FALCON_CLOUD_REGION=us-1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,76 @@
 # Secman Docker Deployment
 
-Three standalone Docker containers (no docker-compose) for running the full Secman stack.
+This directory holds three ways to run Secman in Docker. Pick the one that
+fits:
 
-> Looking for the **single-container AWS image** (web server + backend in one
-> container, ECS/Fargate + Secrets Manager)? See `docker/aws/` and
+| Setup | Files | Best for | Database |
+|-------|-------|----------|----------|
+| **Compose (all-in-one)** | `docker-compose.yml`, `compose-up.sh`, `.env.example` | Fastest local/demo start; mirrors the AWS image | **Bundled MariaDB container OR external RDS** (toggle) |
+| **Single-container (AWS)** | `docker/aws/` | ECS/Fargate + Secrets Manager | External RDS / MariaDB |
+| **Multi-container scripts** | `build-all.sh`, `start-*.sh` | Separate backend/frontend/db containers, no compose | Bundled MariaDB container |
+
+> Deploying to AWS ECS/Fargate? The full reference is
 > [docs/DOCKER_AWS.md](../docs/DOCKER_AWS.md).
+
+---
+
+## Option 1 — Docker Compose (recommended, DB is a container *or* RDS)
+
+One compose file runs the all-in-one image (Astro SSR + Micronaut + nginx) and
+lets you choose where the database lives. This is the direct answer to
+"run in AWS with the DB as either a Docker container or an RDS backend":
+develop locally against a bundled MariaDB, then point the same image at RDS in
+AWS by changing one variable.
+
+```bash
+# A) Bundled MariaDB container (dev/demo) — generates docker/.env with secrets
+./docker/compose-up.sh --local-db
+
+# B) External database / Amazon RDS — set DB_CONNECT in docker/.env first
+./docker/compose-up.sh --rds
+```
+
+The helper creates `docker/.env` from `.env.example` on first run, filling in
+freshly generated `JWT_SECRET`, encryption password/salt, and DB passwords.
+Review it before real use. Open `http://localhost:8080` (default host port).
+
+**Database mode is a single switch:**
+
+| Mode | Command | `DB_CONNECT` in `docker/.env` |
+|------|---------|-------------------------------|
+| Container | `compose-up.sh --local-db` | `jdbc:mariadb://db:3306/secman` |
+| RDS / external | `compose-up.sh --rds` | `jdbc:mariadb://<rds-endpoint>:3306/secman` |
+
+In `--rds` mode the bundled `db` service (guarded by the `local-db` compose
+profile) never starts — only the app container runs, talking to your RDS.
+
+Raw compose (no helper):
+
+```bash
+cp docker/.env.example docker/.env            # then edit secrets + DB_CONNECT
+# bundled DB:
+docker compose -f docker/docker-compose.yml --profile local-db up -d
+# RDS:
+docker compose -f docker/docker-compose.yml up -d
+```
+
+Tear down: `docker compose -f docker/docker-compose.yml --profile local-db down`
+(add `-v` to also drop the `secman-db-data` volume).
+
+---
+
+## Option 2 — Single-container AWS image
+
+The same all-in-one image, deployed to AWS ECS/Fargate behind an ALB with
+secrets in AWS Secrets Manager and the database on RDS. Build, push, and task
+definition instructions live in
+[docs/DOCKER_AWS.md](../docs/DOCKER_AWS.md).
+
+---
+
+## Option 3 — Multi-container scripts (no docker-compose)
+
+Three standalone Docker containers for running the full Secman stack.
 
 ## Architecture
 

--- a/docker/compose-up.sh
+++ b/docker/compose-up.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# =============================================================================
+# Secman Docker Compose launcher
+# =============================================================================
+# Brings up the all-in-one Secman image via docker compose, in one of two
+# database modes:
+#
+#   ./docker/compose-up.sh --local-db   Bundled MariaDB container (dev/demo)
+#   ./docker/compose-up.sh --rds        External DB / Amazon RDS (uses your
+#                                        DB_CONNECT from docker/.env)
+#
+# On first run it creates docker/.env from docker/.env.example and fills in
+# freshly generated secrets (JWT, encryption password/salt, DB passwords).
+# Review docker/.env before using it for anything real.
+#
+# Extra args are forwarded to `docker compose up`, e.g.:
+#   ./docker/compose-up.sh --rds -d --build
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+ENV_EXAMPLE="$SCRIPT_DIR/.env.example"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+
+MODE=""
+PASSTHROUGH=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --local-db) MODE="local-db" ;;
+    --rds)      MODE="rds" ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) PASSTHROUGH+=("$arg") ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage: $0 --local-db | --rds  [extra docker compose args]" >&2
+  echo "  --local-db  run a bundled MariaDB container alongside the app" >&2
+  echo "  --rds       use an external database (set DB_CONNECT in docker/.env)" >&2
+  exit 2
+fi
+
+# Pick a compose implementation (v2 plugin preferred, fall back to v1).
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+# --- Generate docker/.env with fresh secrets on first run --------------------
+gen() {
+  # A portable random secret generator: openssl if present, else /dev/urandom.
+  local kind="$1"
+  if command -v openssl >/dev/null 2>&1; then
+    case "$kind" in
+      b64_32) openssl rand -base64 32 ;;
+      hex_32) openssl rand -hex 32 ;;
+      hex_8)  openssl rand -hex 8 ;;
+      hex_12) openssl rand -hex 12 ;;
+    esac
+  else
+    case "$kind" in
+      b64_32) head -c 32 /dev/urandom | base64 ;;
+      hex_32) head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+      hex_8)  head -c 8  /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+      hex_12) head -c 12 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+    esac
+  fi
+}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[compose-up] docker/.env not found — creating it from .env.example with fresh secrets."
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+
+  JWT="$(gen b64_32)"
+  ENC_PW="$(gen hex_32)"
+  ENC_SALT="$(gen hex_8)"
+  DB_PW="$(gen hex_12)"
+  DB_ROOT_PW="$(gen hex_12)"
+
+  # sed -i portability (GNU vs BSD)
+  sedi() { if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi; }
+  set_kv() { sedi "s|^$1=.*|$1=$2|" "$ENV_FILE"; }
+
+  set_kv JWT_SECRET "$JWT"
+  set_kv SECMAN_ENCRYPTION_PASSWORD "$ENC_PW"
+  set_kv SECMAN_ENCRYPTION_SALT "$ENC_SALT"
+  set_kv DB_PASSWORD "$DB_PW"
+  set_kv DB_ROOT_PASSWORD "$DB_ROOT_PW"
+
+  echo "[compose-up] Wrote $ENV_FILE. Review it (URLs, DB_CONNECT, SMTP, etc.) before production use."
+  if [[ "$MODE" == "rds" ]]; then
+    echo "[compose-up] RDS mode: edit DB_CONNECT/DB_USERNAME/DB_PASSWORD in docker/.env to match your RDS instance."
+  fi
+fi
+
+# --- Launch ------------------------------------------------------------------
+ARGS=(-f "$COMPOSE_FILE")
+if [[ "$MODE" == "local-db" ]]; then
+  ARGS+=(--profile local-db)
+fi
+
+echo "[compose-up] Mode: $MODE"
+echo "[compose-up] Running: ${COMPOSE[*]} ${ARGS[*]} up ${PASSTHROUGH[*]:-}"
+exec "${COMPOSE[@]}" "${ARGS[@]}" up ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,73 @@
+# Secman — Docker Compose for the all-in-one image
+# =============================================================================
+# One compose file, two database modes:
+#
+#   1. Bundled MariaDB container  ->  docker compose --profile local-db up
+#   2. External Amazon RDS (or any reachable MariaDB 11.4)
+#                                 ->  docker compose up   (no profile)
+#
+# The database service only starts when the `local-db` profile is enabled, so
+# in RDS mode nothing local is spun up — the app just talks to DB_CONNECT.
+#
+# Configuration is read from ./.env (copy .env.example -> .env first, or let
+# ./compose-up.sh generate one with fresh secrets). See docs/DOCKER_AWS.md.
+#
+# Convenience wrapper:  ./docker/compose-up.sh --local-db | --rds
+# =============================================================================
+
+services:
+  # --- Application: Astro SSR + Micronaut backend + nginx in one container ---
+  secman:
+    build:
+      context: ..
+      dockerfile: docker/aws/Dockerfile
+    image: secman-aio:latest
+    container_name: secman
+    restart: unless-stopped
+    ports:
+      # host:container — container always serves plain HTTP on :80.
+      # Front it with a TLS-terminating reverse proxy / ALB in production.
+      - "${SECMAN_HTTP_PORT:-8080}:80"
+    env_file:
+      - .env
+    depends_on:
+      # In RDS mode the `db` service is not enabled (no profile), so
+      # `required: false` lets the app start without it. In local-db mode the
+      # app waits until MariaDB reports healthy before booting.
+      db:
+        condition: service_healthy
+        required: false
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:80/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
+
+  # --- Bundled database (only with `--profile local-db`) ---
+  db:
+    image: mariadb:11.4
+    container_name: secman-db
+    profiles: ["local-db"]
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-secman-root-pw}
+      MARIADB_DATABASE: ${DB_NAME:-secman}
+      MARIADB_USER: ${DB_USERNAME:-secman}
+      MARIADB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set in .env}
+    volumes:
+      - secman-db-data:/var/lib/mysql
+    ports:
+      # Exposed for host-side inspection only; the app reaches it via the
+      # compose network as host `db`. Change/remove for production.
+      - "${DB_HOST_PORT:-3307}:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+volumes:
+  secman-db-data:
+    name: secman-db-data

--- a/docs/DOCKER_AWS.md
+++ b/docs/DOCKER_AWS.md
@@ -7,8 +7,36 @@ Docker runs. The database is **not** part of the container — point it at
 Amazon RDS (MariaDB) or any reachable MariaDB 11.4.
 
 For the local multi-container setup (separate backend/frontend/database
-containers), see `docker/README.md`. This document only covers the
-all-in-one image.
+containers), see `docker/README.md`. This document covers the all-in-one
+image and how to run it against either a **Docker MariaDB container** or an
+**Amazon RDS** backend.
+
+## Database: container or RDS
+
+The all-in-one image never contains a database — it connects to whatever
+`DB_CONNECT` points at. That single variable is the switch between the two
+supported backends:
+
+| Backend | When | `DB_CONNECT` |
+|---|---|---|
+| **MariaDB Docker container** | Local dev, demos, self-hosted small deployments | `jdbc:mariadb://db:3306/secman` (compose service `db`) |
+| **Amazon RDS (MariaDB 11.4)** | AWS / production | `jdbc:mariadb://<instance>.<id>.<region>.rds.amazonaws.com:3306/secman` |
+
+The quickest way to get either mode running is **Docker Compose**, which also
+manages the optional bundled database:
+
+```bash
+# Bundled MariaDB container (compose starts it via the `local-db` profile)
+./docker/compose-up.sh --local-db
+
+# External DB / Amazon RDS (only the app container runs; set DB_CONNECT first)
+./docker/compose-up.sh --rds
+```
+
+`compose-up.sh` seeds `docker/.env` (from `docker/.env.example`) with freshly
+generated secrets on first run. See `docker/README.md` for the compose
+reference. The rest of this document covers building the image and deploying it
+to AWS ECS/Fargate, where the database is **always RDS**.
 
 ## Architecture
 
@@ -227,5 +255,7 @@ ARN in `valueFrom` plus `ssm:GetParameters` on the role.)
 | Schema errors on first boot against a fresh DB | ensure `FLYWAY_DATASOURCES_DEFAULT_ENABLED=false` so Hibernate creates the schema |
 
 ---
-*See also: `docs/ENVIRONMENT.md` (full variable catalog), `docs/DEPLOYMENT.md`,
-`docs/AWS_SECRETS_SETUP.md`, `docker/README.md` (local multi-container setup).*
+*See also: `docker/docker-compose.yml` + `docker/compose-up.sh` (run the same
+image locally with a bundled DB or against RDS), `docs/ENVIRONMENT.md` (full
+variable catalog), `docs/DEPLOYMENT.md`, `docs/AWS_SECRETS_SETUP.md`,
+`docker/README.md` (local multi-container setup).*


### PR DESCRIPTION
## Summary

Adds a **Docker Compose** layer over the existing all-in-one AWS image so Secman can run in AWS (or locally) with the backend database as **either a bundled MariaDB container or an external Amazon RDS backend** — selected by a single switch. The image, Dockerfiles, and multi-container scripts already existed; this fills the gap for a one-command way to run the same image in both database modes and documents the choice.

## What's new

| File | Purpose |
|---|---|
| `docker/docker-compose.yml` | Runs the all-in-one image (`docker/aws/Dockerfile`). The MariaDB `db` service is gated behind the `local-db` compose profile, so **RDS mode starts only the app container**. `depends_on` uses `required: false` so the app boots without a bundled DB. |
| `docker/.env.example` | Env template documenting both DB modes (`DB_CONNECT` → `db` service vs RDS endpoint), secrets, public URLs, host ports, and optional integrations. |
| `docker/compose-up.sh` | Launcher for `--local-db` / `--rds`. On first run it seeds `docker/.env` from the example with freshly generated secrets (`openssl`, falling back to `/dev/urandom`). |

## Database mode is one switch

```bash
./docker/compose-up.sh --local-db   # bundled MariaDB container (dev/demo)
./docker/compose-up.sh --rds        # external DB / Amazon RDS (set DB_CONNECT)
```

| Mode | `DB_CONNECT` |
|---|---|
| Container | `jdbc:mariadb://db:3306/secman` |
| RDS / external | `jdbc:mariadb://<rds-endpoint>:3306/secman` |

## Docs adapted

- `docker/README.md` — restructured into three clearly-numbered options (Compose, single-container AWS, multi-container scripts) with the DB-mode toggle up front.
- `docs/DOCKER_AWS.md` — new **"Database: container or RDS"** section plus Compose references.
- `README.md` — docs table now links the AWS image doc and describes the Compose option.
- `.gitignore` — un-ignore `docker/docker-compose.yml` (the repo has a blanket `*.yml` ignore; mirrors the existing `.github/workflows/*.yml` exception).

## Testing

- `docker compose config` validated in both modes: RDS mode resolves to the `secman` service only; `--profile local-db` adds the `db` service.
- Verified Compose v2 resolves `${...}` interpolation from `docker/.env` (compose-file directory) regardless of CWD.
- `bash -n` clean on `compose-up.sh`; secret-generation + `sed` rewrite logic exercised in isolation (JWT/base64, 32-hex encryption password, 16-char salt, DB passwords).
- The all-in-one image build itself is unchanged and was not rebuilt here (documented as a ~4 GB Gradle build).

Doc- and deployment-tooling change outside `src/`, `tests/`, `scripts/` — no application code paths touched, so the backend build/startup and E2E gates are not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWwS2xcVegvLREZdNzpF7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWwS2xcVegvLREZdNzpF7d)_