### PR TITLE
Add selectable reviewers to requirement release alignment

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -191,7 +191,7 @@ curl -XPOST http://localhost:8080/mcp \
 - **`compare_releases`** — `fromReleaseId`*, `toReleaseId`*. Returns `summary{added,deleted,modified,unchanged}` plus per-requirement diffs.
 
 ### Alignment
-- **`start_alignment`** (ADMIN/REQADMIN) — `releaseId`*. PREPARATION → ALIGNMENT.
+- **`start_alignment`** (ADMIN/REQADMIN) — `release_id`*, `send_notifications` (default true), `reviewer_user_ids` (optional array of REQ-role user IDs; default: all REQ users). PREPARATION → ALIGNMENT.
 - **`get_alignment_status`** — `releaseId`*.
 - **`submit_review`** — `releaseId`*, `approved`*, `comment`.
 - **`finalize_alignment`** (ADMIN/REQADMIN) — `releaseId`*.

--- a/src/backendng/src/main/kotlin/com/secman/controller/AlignmentController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AlignmentController.kt
@@ -61,13 +61,19 @@ open class AlignmentController(
         @Valid @Body request: StartAlignmentRequest?,
         authentication: Authentication
     ): HttpResponse<Map<String, Any>> {
-        logger.info("Starting alignment for release {} by user {} (reviewAll={})", releaseId, authentication.name, request?.reviewAll)
+        logger.info("Starting alignment for release {} by user {} (reviewAll={}, reviewers={})",
+            releaseId, authentication.name, request?.reviewAll, request?.reviewerUserIds?.size ?: "all")
 
         try {
             val user = userRepository.findByUsername(authentication.name)
                 .orElseThrow { NoSuchElementException("User not found: ${authentication.name}") }
 
-            val result = alignmentService.startAlignment(releaseId, user.id!!, request?.reviewAll ?: false)
+            val result = alignmentService.startAlignment(
+                releaseId,
+                user.id!!,
+                request?.reviewAll ?: false,
+                request?.reviewerUserIds
+            )
 
             // Send notification emails to all reviewers
             alignmentEmailService.sendReviewRequestEmails(result.session, result.reviewers)
@@ -141,6 +147,26 @@ open class AlignmentController(
                 "message" to (e.message ?: "Release not found")
             ))
         }
+    }
+
+    /**
+     * GET /api/alignment/eligible-reviewers - List users who can be selected as reviewers
+     * Authorization: ADMIN or RELEASE_MANAGER only
+     */
+    @Get("/alignment/eligible-reviewers")
+    @Secured("ADMIN", "RELEASE_MANAGER")
+    fun getEligibleReviewers(): HttpResponse<Map<String, Any>> {
+        val users = alignmentService.getEligibleReviewers()
+        return HttpResponse.ok(mapOf(
+            "reviewers" to users.map { user ->
+                mapOf(
+                    "id" to user.id,
+                    "username" to user.username,
+                    "email" to user.email
+                )
+            },
+            "totalCount" to users.size
+        ))
     }
 
     // ========== Session-Based Endpoints ==========
@@ -1190,7 +1216,9 @@ open class AlignmentController(
 
 @Serdeable
 data class StartAlignmentRequest(
-    val reviewAll: Boolean = false
+    val reviewAll: Boolean = false,
+    /** Optional subset of REQ-role user IDs to enroll as reviewers; null = all REQ users */
+    val reviewerUserIds: List<Long>? = null
 )
 
 @Serdeable

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/StartAlignmentTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/StartAlignmentTool.kt
@@ -23,7 +23,7 @@ class StartAlignmentTool(
 ) : McpTool {
 
     override val name = "start_alignment"
-    override val description = "Start a requirements alignment process for a DRAFT release. Notifies all REQ-role users to review requirement changes."
+    override val description = "Start a requirements alignment process for a DRAFT release. Notifies REQ-role users to review requirement changes. By default all REQ-role users are enrolled; a subset can be selected via reviewer_user_ids."
     override val operation = McpOperation.WRITE
 
     override val inputSchema = mapOf(
@@ -36,6 +36,11 @@ class StartAlignmentTool(
             "send_notifications" to mapOf(
                 "type" to "boolean",
                 "description" to "Whether to send email notifications to reviewers (default: true)"
+            ),
+            "reviewer_user_ids" to mapOf(
+                "type" to "array",
+                "items" to mapOf("type" to "number"),
+                "description" to "Optional subset of REQ-role user IDs to enroll as reviewers (default: all REQ-role users)"
             )
         ),
         "required" to listOf("release_id")
@@ -56,13 +61,25 @@ class StartAlignmentTool(
         // Extract parameters
         val releaseId = (arguments["release_id"] as? Number)?.toLong()
         val sendNotifications = arguments["send_notifications"] as? Boolean ?: true
+        val reviewerUserIds = (arguments["reviewer_user_ids"] as? List<*>)?.let { rawList ->
+            val ids = rawList.mapNotNull { (it as? Number)?.toLong() }
+            if (ids.size != rawList.size) {
+                return McpToolResult.error("VALIDATION_ERROR", "reviewer_user_ids must be an array of numbers")
+            }
+            ids
+        }
 
         if (releaseId == null) {
             return McpToolResult.error("VALIDATION_ERROR", "release_id is required")
         }
 
         try {
-            val result = alignmentService.startAlignment(releaseId, context.delegatedUserId!!)
+            val result = alignmentService.startAlignment(
+                releaseId,
+                context.delegatedUserId!!,
+                reviewAll = false,
+                reviewerUserIds = reviewerUserIds
+            )
 
             // Send notifications if requested
             if (sendNotifications && result.reviewers.isNotEmpty()) {

--- a/src/backendng/src/main/kotlin/com/secman/service/AlignmentService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AlignmentService.kt
@@ -87,13 +87,22 @@ open class AlignmentService(
      *
      * @param releaseId The release to start alignment for
      * @param initiatorId The user initiating the alignment
+     * @param reviewAll If true, review all requirements instead of only changed ones
+     * @param reviewerUserIds Optional subset of REQ-role user IDs to enroll as reviewers;
+     *                        null means all REQ-role users (default behavior)
      * @return AlignmentStartResult with session details
-     * @throws IllegalArgumentException if release is not in PREPARATION status
+     * @throws IllegalArgumentException if release is not in PREPARATION status or reviewer selection is invalid
      * @throws IllegalStateException if no REQ-role users exist
      */
     @Transactional
-    open fun startAlignment(releaseId: Long, initiatorId: Long, reviewAll: Boolean = false): AlignmentStartResult {
-        logger.info("Starting alignment for release {} by user {} (reviewAll={})", releaseId, initiatorId, reviewAll)
+    open fun startAlignment(
+        releaseId: Long,
+        initiatorId: Long,
+        reviewAll: Boolean = false,
+        reviewerUserIds: List<Long>? = null
+    ): AlignmentStartResult {
+        logger.info("Starting alignment for release {} by user {} (reviewAll={}, reviewerUserIds={})",
+            releaseId, initiatorId, reviewAll, reviewerUserIds)
 
         val release = releaseRepository.findById(releaseId)
             .orElseThrow { NoSuchElementException("Release not found: $releaseId") }
@@ -109,11 +118,7 @@ open class AlignmentService(
         val initiator = userRepository.findById(initiatorId)
             .orElseThrow { NoSuchElementException("User not found: $initiatorId") }
 
-        // Find users with REQ role
-        val reviewerUsers = userRepository.findByRolesContaining(User.Role.REQ)
-        if (reviewerUsers.isEmpty()) {
-            throw IllegalStateException("No users with REQ role found. Cannot start alignment without reviewers.")
-        }
+        val reviewerUsers = resolveReviewers(reviewerUserIds)
 
         // Find baseline release (last ACTIVE)
         val baselineRelease = releaseRepository.findByStatus(ReleaseStatus.ACTIVE).firstOrNull()
@@ -160,6 +165,47 @@ open class AlignmentService(
             modifiedCount = modifiedCount,
             deletedCount = deletedCount
         )
+    }
+
+    /**
+     * Resolve the reviewer set for an alignment session.
+     *
+     * When [reviewerUserIds] is null, all REQ-role users are enrolled (default).
+     * When provided, it must be a non-empty subset of REQ-role users.
+     */
+    private fun resolveReviewers(reviewerUserIds: List<Long>?): List<User> {
+        val eligibleUsers = userRepository.findByRolesContaining(User.Role.REQ)
+        if (eligibleUsers.isEmpty()) {
+            throw IllegalStateException("No users with REQ role found. Cannot start alignment without reviewers.")
+        }
+
+        if (reviewerUserIds == null) {
+            return eligibleUsers
+        }
+
+        val requestedIds = reviewerUserIds.distinct()
+        if (requestedIds.isEmpty()) {
+            throw IllegalArgumentException("At least one reviewer must be selected")
+        }
+
+        val eligibleById = eligibleUsers.associateBy { it.id!! }
+        val ineligibleIds = requestedIds.filter { it !in eligibleById }
+        if (ineligibleIds.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "Invalid reviewer selection: user IDs $ineligibleIds do not exist or do not have the REQ role"
+            )
+        }
+
+        return requestedIds.map { eligibleById.getValue(it) }
+    }
+
+    /**
+     * Get all users eligible to review an alignment (REQ-role users).
+     * Used by the UI to offer reviewer selection when starting an alignment.
+     */
+    @Transactional
+    open fun getEligibleReviewers(): List<User> {
+        return userRepository.findByRolesContaining(User.Role.REQ)
     }
 
     /**

--- a/src/backendng/src/test/kotlin/com/secman/service/AlignmentServiceReviewerSelectionTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/AlignmentServiceReviewerSelectionTest.kt
@@ -1,0 +1,146 @@
+package com.secman.service
+
+import com.secman.domain.AlignmentReviewer
+import com.secman.domain.AlignmentSession
+import com.secman.domain.Release
+import com.secman.domain.User
+import com.secman.repository.*
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+
+/**
+ * Unit tests for reviewer selection in AlignmentService.startAlignment.
+ *
+ * Covers the reviewerUserIds parameter: default enrollment of all REQ-role
+ * users, subset selection, and validation failures.
+ */
+class AlignmentServiceReviewerSelectionTest {
+
+    private lateinit var alignmentSessionRepository: AlignmentSessionRepository
+    private lateinit var alignmentReviewerRepository: AlignmentReviewerRepository
+    private lateinit var alignmentSnapshotRepository: AlignmentSnapshotRepository
+    private lateinit var requirementReviewRepository: RequirementReviewRepository
+    private lateinit var reviewDecisionRepository: ReviewDecisionRepository
+    private lateinit var releaseRepository: ReleaseRepository
+    private lateinit var requirementSnapshotRepository: RequirementSnapshotRepository
+    private lateinit var requirementRepository: RequirementRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var releaseService: ReleaseService
+    private lateinit var service: AlignmentService
+
+    private val initiator = reqUser(1L, "admin")
+    private val reqAlice = reqUser(10L, "alice")
+    private val reqBob = reqUser(11L, "bob")
+    private val reqCarol = reqUser(12L, "carol")
+
+    private fun reqUser(id: Long, username: String) = User(
+        id = id,
+        username = username,
+        email = "$username@example.com",
+        passwordHash = "x",
+        roles = mutableSetOf(User.Role.REQ)
+    )
+
+    @BeforeEach
+    fun setUp() {
+        alignmentSessionRepository = mockk()
+        alignmentReviewerRepository = mockk()
+        alignmentSnapshotRepository = mockk()
+        requirementReviewRepository = mockk()
+        reviewDecisionRepository = mockk()
+        releaseRepository = mockk()
+        requirementSnapshotRepository = mockk()
+        requirementRepository = mockk()
+        userRepository = mockk()
+        releaseService = mockk()
+
+        service = AlignmentService(
+            alignmentSessionRepository,
+            alignmentReviewerRepository,
+            alignmentSnapshotRepository,
+            requirementReviewRepository,
+            reviewDecisionRepository,
+            releaseRepository,
+            requirementSnapshotRepository,
+            requirementRepository,
+            userRepository,
+            releaseService
+        )
+
+        val release = Release(id = 100L, version = "1.0.0", name = "Test Release")
+
+        every { releaseRepository.findById(100L) } returns Optional.of(release)
+        every { alignmentSessionRepository.hasOpenSession(100L) } returns false
+        every { userRepository.findById(1L) } returns Optional.of(initiator)
+        every { userRepository.findByRolesContaining(User.Role.REQ) } returns listOf(reqAlice, reqBob, reqCarol)
+        every { releaseRepository.findByStatus(Release.ReleaseStatus.ACTIVE) } returns emptyList()
+        every { alignmentSessionRepository.save(any()) } answers { firstArg<AlignmentSession>().also { it.id = 500L } }
+        every { alignmentSessionRepository.update(any()) } answers { firstArg() }
+        every { requirementRepository.findCurrentRequirements() } returns emptyList()
+        every { alignmentSnapshotRepository.saveAll(any<List<com.secman.domain.AlignmentSnapshot>>()) } answers { firstArg() }
+        every { alignmentReviewerRepository.save(any()) } answers { firstArg<AlignmentReviewer>() }
+        every { releaseRepository.update(any<Release>()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `enrolls all REQ users when no reviewer selection is given`() {
+        val result = service.startAlignment(100L, 1L)
+
+        assertEquals(3, result.reviewers.size)
+        assertEquals(setOf(10L, 11L, 12L), result.reviewers.map { it.user.id }.toSet())
+    }
+
+    @Test
+    fun `enrolls only the selected subset of REQ users`() {
+        val result = service.startAlignment(100L, 1L, reviewerUserIds = listOf(10L, 12L))
+
+        assertEquals(2, result.reviewers.size)
+        assertEquals(setOf(10L, 12L), result.reviewers.map { it.user.id }.toSet())
+        verify(exactly = 2) { alignmentReviewerRepository.save(any()) }
+    }
+
+    @Test
+    fun `deduplicates repeated reviewer IDs`() {
+        val result = service.startAlignment(100L, 1L, reviewerUserIds = listOf(11L, 11L, 11L))
+
+        assertEquals(1, result.reviewers.size)
+        assertEquals(11L, result.reviewers.single().user.id)
+    }
+
+    @Test
+    fun `rejects empty reviewer selection`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            service.startAlignment(100L, 1L, reviewerUserIds = emptyList())
+        }
+        assertTrue(ex.message!!.contains("At least one reviewer"))
+    }
+
+    @Test
+    fun `rejects reviewer IDs that do not exist or lack the REQ role`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            service.startAlignment(100L, 1L, reviewerUserIds = listOf(10L, 999L))
+        }
+        assertTrue(ex.message!!.contains("999"))
+    }
+
+    @Test
+    fun `fails when no REQ users exist regardless of selection`() {
+        every { userRepository.findByRolesContaining(User.Role.REQ) } returns emptyList()
+
+        assertThrows<IllegalStateException> {
+            service.startAlignment(100L, 1L, reviewerUserIds = listOf(10L))
+        }
+    }
+
+    @Test
+    fun `invalid selection does not enroll any reviewers`() {
+        assertThrows<IllegalArgumentException> {
+            service.startAlignment(100L, 1L, reviewerUserIds = listOf(999L))
+        }
+        verify(exactly = 0) { alignmentReviewerRepository.save(any()) }
+    }
+}

--- a/src/frontend/src/components/ReleaseStatusActions.tsx
+++ b/src/frontend/src/components/ReleaseStatusActions.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { releaseService, type Release, type AlignmentStatus } from '../services/releaseService';
+import { releaseService, type Release, type AlignmentStatus, type EligibleReviewer } from '../services/releaseService';
 import { hasRole } from '../utils/auth';
 
 interface ReleaseStatusActionsProps {
@@ -157,6 +157,9 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
     const [hasChanges, setHasChanges] = useState<boolean | null>(null);
     const [alignmentStatus, setAlignmentStatus] = useState<AlignmentStatus | null>(null);
     const [reviewAll, setReviewAll] = useState(false);
+    const [eligibleReviewers, setEligibleReviewers] = useState<EligibleReviewer[]>([]);
+    const [selectedReviewerIds, setSelectedReviewerIds] = useState<Set<number>>(new Set());
+    const [reviewersLoadError, setReviewersLoadError] = useState<string | null>(null);
 
     // Check user permissions
     const canManageStatus = typeof window !== 'undefined' && hasRole(['ADMIN', 'RELEASE_MANAGER']);
@@ -179,6 +182,23 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
         }
     }, [release.id, release.status, canManageStatus]);
 
+    // Load eligible reviewers when the alignment modal opens (default: all selected)
+    useEffect(() => {
+        if (showAlignmentModal) {
+            setReviewersLoadError(null);
+            releaseService.getEligibleReviewers()
+                .then(result => {
+                    setEligibleReviewers(result.reviewers);
+                    setSelectedReviewerIds(new Set(result.reviewers.map(r => r.id)));
+                })
+                .catch(err => {
+                    setEligibleReviewers([]);
+                    setSelectedReviewerIds(new Set());
+                    setReviewersLoadError(err instanceof Error ? err.message : 'Failed to load reviewers');
+                });
+        }
+    }, [showAlignmentModal]);
+
     // Only show actions if user has permission
     if (!canManageStatus) {
         return null;
@@ -197,7 +217,12 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
         setError(null);
 
         try {
-            const result = await releaseService.startAlignment(release.id, reviewAll);
+            const allSelected = selectedReviewerIds.size === eligibleReviewers.length;
+            const result = await releaseService.startAlignment(
+                release.id,
+                reviewAll,
+                allSelected ? undefined : Array.from(selectedReviewerIds)
+            );
 
             // Notify parent
             onAlignmentStart?.();
@@ -246,7 +271,20 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
             setShowAlignmentModal(false);
             setReviewAll(false);
             setError(null);
+            setReviewersLoadError(null);
         }
+    };
+
+    const toggleReviewer = (id: number) => {
+        setSelectedReviewerIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
     };
 
     return (
@@ -383,12 +421,62 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
                                         </div>
                                     </div>
 
+                                    <div className="mb-3">
+                                        <div className="d-flex justify-content-between align-items-center">
+                                            <label className="form-label fw-semibold mb-0">Reviewers</label>
+                                            <div className="btn-group btn-group-sm">
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-outline-secondary"
+                                                    onClick={() => setSelectedReviewerIds(new Set(eligibleReviewers.map(r => r.id)))}
+                                                    disabled={eligibleReviewers.length === 0}
+                                                >
+                                                    Select all
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className="btn btn-outline-secondary"
+                                                    onClick={() => setSelectedReviewerIds(new Set())}
+                                                    disabled={eligibleReviewers.length === 0}
+                                                >
+                                                    Clear
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <small className="d-block text-muted mb-2">
+                                            Select who receives a review request ({selectedReviewerIds.size} of {eligibleReviewers.length} selected)
+                                        </small>
+                                        {reviewersLoadError && (
+                                            <div className="alert alert-warning py-2 mb-2">{reviewersLoadError}</div>
+                                        )}
+                                        <div className="border rounded p-2" style={{ maxHeight: '200px', overflowY: 'auto' }}>
+                                            {eligibleReviewers.length === 0 && !reviewersLoadError && (
+                                                <small className="text-muted">No users with REQ role available</small>
+                                            )}
+                                            {eligibleReviewers.map(reviewer => (
+                                                <div className="form-check" key={reviewer.id}>
+                                                    <input
+                                                        type="checkbox"
+                                                        className="form-check-input"
+                                                        id={`reviewer-${reviewer.id}`}
+                                                        checked={selectedReviewerIds.has(reviewer.id)}
+                                                        onChange={() => toggleReviewer(reviewer.id)}
+                                                    />
+                                                    <label className="form-check-label" htmlFor={`reviewer-${reviewer.id}`}>
+                                                        {reviewer.username}
+                                                        <small className="text-muted ms-2">{reviewer.email}</small>
+                                                    </label>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+
                                     <p className="text-muted">
                                         This will:
                                     </p>
                                     <ul className="text-muted">
                                         <li>Change release status to ALIGNMENT</li>
-                                        <li>Send email notifications to all users with REQ role</li>
+                                        <li>Send email notifications to the selected reviewers</li>
                                         <li>Allow reviewers to submit feedback on requirement changes</li>
                                     </ul>
                                 </div>
@@ -405,7 +493,7 @@ export const ReleaseStatusActions: React.FC<ReleaseStatusActionsProps> = ({
                                         type="button"
                                         className="btn btn-primary"
                                         onClick={handleStartAlignment}
-                                        disabled={isLoading}
+                                        disabled={isLoading || selectedReviewerIds.size === 0}
                                     >
                                         {isLoading ? (
                                             <>

--- a/src/frontend/src/services/releaseService.ts
+++ b/src/frontend/src/services/releaseService.ts
@@ -102,6 +102,12 @@ export interface AlignmentStatus {
     assessments: AssessmentCounts;
 }
 
+export interface EligibleReviewer {
+    id: number;
+    username: string;
+    email: string;
+}
+
 export interface AlignmentStartResult {
     success: boolean;
     message: string;
@@ -390,19 +396,35 @@ export const releaseService = {
     },
 
     /**
+     * Get users eligible to be selected as alignment reviewers (REQ-role users)
+     *
+     * @returns List of eligible reviewers
+     */
+    async getEligibleReviewers(): Promise<{ reviewers: EligibleReviewer[]; totalCount: number }> {
+        const response = await authenticatedFetch('/api/alignment/eligible-reviewers');
+
+        if (!response.ok) {
+            throw new Error(`Failed to load eligible reviewers: ${response.statusText}`);
+        }
+
+        return response.json();
+    },
+
+    /**
      * Start alignment process for a PREPARATION release
      *
      * @param releaseId Release ID
      * @param reviewAll If true, include all requirements (not just changed ones)
+     * @param reviewerUserIds Optional subset of REQ-role user IDs to enroll as reviewers (default: all)
      * @returns Alignment start result with session details
      */
-    async startAlignment(releaseId: number, reviewAll: boolean = false): Promise<AlignmentStartResult> {
+    async startAlignment(releaseId: number, reviewAll: boolean = false, reviewerUserIds?: number[]): Promise<AlignmentStartResult> {
         const response = await authenticatedFetch(`/api/releases/${releaseId}/alignment/start`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ reviewAll }),
+            body: JSON.stringify({ reviewAll, reviewerUserIds: reviewerUserIds ?? null }),
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary

Evaluation of the requirement release review flow showed that "sending a release to several people for review" already exists as the **Alignment Process** (`POST /api/releases/{id}/alignment/start` → per-reviewer token emails → OK/CHANGE/NOGO assessments → admin decisions → finalize/activate), but the reviewer set was hardcoded: **every** REQ-role user was always enrolled. This PR makes the reviewer set selectable while keeping the existing behavior as the default.

## Changes

**Backend**
- `AlignmentService.startAlignment` accepts an optional `reviewerUserIds` list. `null` keeps the current behavior (all REQ users); a provided list must be a non-empty subset of REQ-role users (validated, deduplicated, resolved before any session state is written).
- New `GET /api/alignment/eligible-reviewers` (ADMIN/RELEASE_MANAGER) returns the selectable REQ users for the UI.
- `StartAlignmentRequest` gains `reviewerUserIds`.

**MCP**
- `start_alignment` tool gains an optional `reviewer_user_ids` array parameter (docs updated in `docs/MCP.md`).

**Frontend**
- The "Start Alignment" modal in `ReleaseStatusActions.tsx` now shows a reviewer multi-select (all REQ users pre-selected, select-all/clear buttons, live count, start disabled when nothing is selected). `releaseService.ts` gains `getEligibleReviewers()` and passes the selection through.

**Tests**
- `AlignmentServiceReviewerSelectionTest`: default enrollment, subset selection, deduplication, empty-selection rejection, unknown/non-REQ ID rejection, no-REQ-users failure, and no-partial-writes on invalid selection.

## Verification

- Frontend: `npm ci && npm run build` exits 0; `tsc --noEmit` reports no errors in the changed files (7 pre-existing errors in unrelated components).
- Backend: `./gradlew build` and the backend/E2E gates could **not** be run in this sandbox — the session's network policy blocks Gradle distribution and Maven Central downloads, and `pass-cli`/MariaDB are unavailable. The Kotlin changes were desk-checked against the entity/repository signatures; please run `./gradlew build`, `/e2ejs`, and `/e2evulnexception` locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AeCsFAGh7CVzchkgYNZcc

---
_Generated by [Claude Code](https://claude.ai/code/session_011AeCsFAGh7CVzchkgYNZcc)_