### PR TITLE
Security: fix workgroup listing IDOR, AI job cross-assessment access, nmap arg injection

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/AiSuggestionController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AiSuggestionController.kt
@@ -62,7 +62,7 @@ open class AiSuggestionController(
         authentication: Authentication
     ): HttpResponse<AiJobStatusDto> {
         ownershipGuard.check(id, authentication)
-        val status = jobService.getJobStatus(jobId)
+        val status = jobService.getJobStatus(jobId, id)
             ?: throw HttpStatusException(HttpStatus.NOT_FOUND, "AI job $jobId not found")
         return HttpResponse.ok(status)
     }
@@ -74,7 +74,7 @@ open class AiSuggestionController(
         authentication: Authentication
     ): HttpResponse<Void> {
         ownershipGuard.check(id, authentication)
-        val cancelled = jobService.cancelJob(jobId)
+        val cancelled = jobService.cancelJob(jobId, id)
         return if (cancelled) HttpResponse.noContent()
         else HttpResponse.status(HttpStatus.CONFLICT)
     }
@@ -98,7 +98,7 @@ open class AiSuggestionController(
         authentication: Authentication
     ): Publisher<Event<JobProgressEvent>> {
         ownershipGuard.check(id, authentication)
-        return jobService.getProgressStream(jobId).map { ev ->
+        return jobService.getProgressStream(jobId, id).map { ev ->
             Event.of(ev).id(ev.jobId.toString()).name(ev.type.lowercase())
         }
     }

--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAdDomainController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAdDomainController.kt
@@ -33,7 +33,10 @@ open class WorkgroupAdDomainController(
     }
 
     @Get(produces = [MediaType.APPLICATION_JSON])
-    open fun list(@PathVariable workgroupId: Long): HttpResponse<List<WorkgroupAdDomainDto>> {
+    open fun list(@PathVariable workgroupId: Long, authentication: Authentication): HttpResponse<List<WorkgroupAdDomainDto>> {
+        if (!isMemberOrAdmin(workgroupId, authentication)) {
+            return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
+        }
         return try {
             HttpResponse.ok(service.list(workgroupId).map(WorkgroupAdDomainDto::from))
         } catch (e: IllegalArgumentException) {

--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAwsAccountController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAwsAccountController.kt
@@ -48,7 +48,10 @@ open class WorkgroupAwsAccountController(
     }
 
     @Get(produces = [MediaType.APPLICATION_JSON])
-    open fun list(@PathVariable workgroupId: Long): HttpResponse<List<WorkgroupAwsAccountDto>> {
+    open fun list(@PathVariable workgroupId: Long, authentication: Authentication): HttpResponse<List<WorkgroupAwsAccountDto>> {
+        if (!isMemberOrAdmin(workgroupId, authentication)) {
+            return HttpResponse.status(io.micronaut.http.HttpStatus.FORBIDDEN)
+        }
         return try {
             val rows = service.list(workgroupId).map(WorkgroupAwsAccountDto::from)
             HttpResponse.ok(rows)

--- a/src/backendng/src/main/kotlin/com/secman/service/AiSuggestionJobService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/AiSuggestionJobService.kt
@@ -472,8 +472,9 @@ open class AiSuggestionJobService(
     // --- Query / control surface (called from controller) -------------------
 
     @Transactional
-    open fun getJobStatus(jobId: Long): AiJobStatusDto? {
+    open fun getJobStatus(jobId: Long, expectedAssessmentId: Long): AiJobStatusDto? {
         val j = aiJobRepository.findById(jobId).orElse(null) ?: return null
+        if (j.riskAssessmentId != expectedAssessmentId) return null
         return AiJobStatusDto(
             id = j.id!!, status = j.status, model = j.model, scope = j.scope.name,
             totalCount = j.totalCount, completedCount = j.completedCount, failedCount = j.failedCount,
@@ -510,8 +511,9 @@ open class AiSuggestionJobService(
     }
 
     @Transactional
-    open fun cancelJob(jobId: Long): Boolean {
+    open fun cancelJob(jobId: Long, expectedAssessmentId: Long): Boolean {
         val j = aiJobRepository.findById(jobId).orElse(null) ?: return false
+        if (j.riskAssessmentId != expectedAssessmentId) return false
         if (j.status.isTerminal()) return false
         j.status = AiSuggestionJobStatus.CANCELLED
         j.finishedAt = LocalDateTime.now()
@@ -528,7 +530,9 @@ open class AiSuggestionJobService(
      * a single job. Returns an empty stream if the job is unknown or already
      * terminal (the controller follows up with the cached job status).
      */
-    fun getProgressStream(jobId: Long): Flux<JobProgressEvent> {
+    fun getProgressStream(jobId: Long, expectedAssessmentId: Long): Flux<JobProgressEvent> {
+        val j = aiJobRepository.findById(jobId).orElse(null) ?: return Flux.empty()
+        if (j.riskAssessmentId != expectedAssessmentId) return Flux.empty()
         val sink = progressSinks[jobId] ?: return Flux.empty()
         return sink.asFlux()
     }

--- a/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAdDomainControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAdDomainControllerAuthorizationTest.kt
@@ -1,0 +1,79 @@
+package com.secman.controller
+
+import com.secman.domain.User
+import com.secman.domain.Workgroup
+import com.secman.repository.UserRepository
+import com.secman.repository.WorkgroupRepository
+import com.secman.service.WorkgroupAdDomainService
+import io.micronaut.http.HttpStatus
+import io.micronaut.security.authentication.Authentication
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+/**
+ * Regression coverage for the `list` endpoint's authorization: it must be
+ * member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
+ * documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ */
+class WorkgroupAdDomainControllerAuthorizationTest {
+
+    private lateinit var service: WorkgroupAdDomainService
+    private lateinit var userRepository: UserRepository
+    private lateinit var workgroupRepository: WorkgroupRepository
+    private lateinit var controller: WorkgroupAdDomainController
+
+    private val member = User(id = 1L, username = "member", email = "member@example.com", passwordHash = "x")
+    private val outsider = User(id = 2L, username = "outsider", email = "outsider@example.com", passwordHash = "x")
+    private val admin = User(id = 3L, username = "admin", email = "admin@example.com", passwordHash = "x")
+
+    @BeforeEach
+    fun setUp() {
+        service = mockk()
+        userRepository = mockk()
+        workgroupRepository = mockk()
+        controller = WorkgroupAdDomainController(service, userRepository, workgroupRepository)
+
+        every { userRepository.findByUsername(member.username) } returns Optional.of(member)
+        every { userRepository.findByUsername(outsider.username) } returns Optional.of(outsider)
+        every { userRepository.findByUsername(admin.username) } returns Optional.of(admin)
+    }
+
+    @Test
+    fun `non-member non-admin cannot list workgroup ad domains`() {
+        val workgroup = Workgroup(id = 20L, name = "wg-20", createdBy = member, users = mutableSetOf(member))
+        every { workgroupRepository.findById(20L) } returns Optional.of(workgroup)
+
+        val response = controller.list(20L, auth(outsider))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+    }
+
+    @Test
+    fun `member can list their workgroup ad domains`() {
+        val workgroup = Workgroup(id = 21L, name = "wg-21", createdBy = member, users = mutableSetOf(member))
+        every { workgroupRepository.findById(21L) } returns Optional.of(workgroup)
+        every { service.list(21L) } returns emptyList()
+
+        val response = controller.list(21L, auth(member))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    @Test
+    fun `admin can list any workgroup ad domains`() {
+        every { service.list(22L) } returns emptyList()
+
+        val response = controller.list(22L, auth(admin, roles = setOf("ADMIN")))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    private fun auth(user: User, roles: Set<String> = setOf("USER")): Authentication = mockk {
+        every { name } returns user.username
+        every { this@mockk.roles } returns roles
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAwsAccountControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAwsAccountControllerAuthorizationTest.kt
@@ -1,0 +1,79 @@
+package com.secman.controller
+
+import com.secman.domain.User
+import com.secman.domain.Workgroup
+import com.secman.repository.UserRepository
+import com.secman.repository.WorkgroupRepository
+import com.secman.service.WorkgroupAwsAccountService
+import io.micronaut.http.HttpStatus
+import io.micronaut.security.authentication.Authentication
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+/**
+ * Regression coverage for the `list` endpoint's authorization: it must be
+ * member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
+ * documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ */
+class WorkgroupAwsAccountControllerAuthorizationTest {
+
+    private lateinit var service: WorkgroupAwsAccountService
+    private lateinit var userRepository: UserRepository
+    private lateinit var workgroupRepository: WorkgroupRepository
+    private lateinit var controller: WorkgroupAwsAccountController
+
+    private val member = User(id = 1L, username = "member", email = "member@example.com", passwordHash = "x")
+    private val outsider = User(id = 2L, username = "outsider", email = "outsider@example.com", passwordHash = "x")
+    private val admin = User(id = 3L, username = "admin", email = "admin@example.com", passwordHash = "x")
+
+    @BeforeEach
+    fun setUp() {
+        service = mockk()
+        userRepository = mockk()
+        workgroupRepository = mockk()
+        controller = WorkgroupAwsAccountController(service, userRepository, workgroupRepository)
+
+        every { userRepository.findByUsername(member.username) } returns Optional.of(member)
+        every { userRepository.findByUsername(outsider.username) } returns Optional.of(outsider)
+        every { userRepository.findByUsername(admin.username) } returns Optional.of(admin)
+    }
+
+    @Test
+    fun `non-member non-admin cannot list workgroup aws accounts`() {
+        val workgroup = Workgroup(id = 10L, name = "wg-10", createdBy = member, users = mutableSetOf(member))
+        every { workgroupRepository.findById(10L) } returns Optional.of(workgroup)
+
+        val response = controller.list(10L, auth(outsider))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+    }
+
+    @Test
+    fun `member can list their workgroup aws accounts`() {
+        val workgroup = Workgroup(id = 11L, name = "wg-11", createdBy = member, users = mutableSetOf(member))
+        every { workgroupRepository.findById(11L) } returns Optional.of(workgroup)
+        every { service.list(11L) } returns emptyList()
+
+        val response = controller.list(11L, auth(member))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    @Test
+    fun `admin can list any workgroup aws accounts`() {
+        every { service.list(12L) } returns emptyList()
+
+        val response = controller.list(12L, auth(admin, roles = setOf("ADMIN")))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    private fun auth(user: User, roles: Set<String> = setOf("USER")): Authentication = mockk {
+        every { name } returns user.username
+        every { this@mockk.roles } returns roles
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/service/PortScanCliService.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/service/PortScanCliService.kt
@@ -23,6 +23,16 @@ class PortScanCliService(
 ) {
     private val log = LoggerFactory.getLogger(PortScanCliService::class.java)
 
+    companion object {
+        // IPv4 dotted-quad or IPv6 (hex groups + colons, optionally zone/scope id).
+        // Deliberately excludes '-' and any other character nmap could interpret
+        // as a flag, so a malicious Asset.ip value can never be parsed as an
+        // extra nmap argument.
+        private val VALID_SCAN_TARGET = Regex(
+            "^(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|[0-9a-fA-F:]+)$"
+        )
+    }
+
     data class AssetTarget(
         val id: Long,
         val name: String,
@@ -101,6 +111,19 @@ class PortScanCliService(
         ports: String?,
         outputFile: File
     ): NmapScanResult {
+        // Asset.ip is free-text and not format-validated at creation time, so a
+        // value starting with '-' would otherwise be parsed by nmap as an extra
+        // flag (argument injection) rather than as the scan target.
+        if (!VALID_SCAN_TARGET.matches(ip)) {
+            log.error("Refusing to scan invalid or unsafe target: {}", ip)
+            return NmapScanResult(
+                success = false,
+                exitCode = -1,
+                outputFile = null,
+                errorOutput = "Target is not a valid IPv4/IPv6 address: $ip"
+            )
+        }
+
         val command = mutableListOf(nmapPath)
         command.add("-oX")
         command.add(outputFile.absolutePath)

--- a/src/cli/src/test/kotlin/com/secman/cli/service/PortScanCliServiceTest.kt
+++ b/src/cli/src/test/kotlin/com/secman/cli/service/PortScanCliServiceTest.kt
@@ -1,0 +1,45 @@
+package com.secman.cli.service
+
+import io.micronaut.http.client.HttpClient
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Asset.ip is free-text and not format-validated at creation time (backend
+ * `AssetController`), so `runNmapScan` must itself refuse to pass a value
+ * that nmap would parse as an extra flag instead of a scan target.
+ */
+class PortScanCliServiceTest {
+
+    private val service = PortScanCliService(mockk<HttpClient>(), mockk<CliHttpClient>())
+
+    @Test
+    fun `refuses target that looks like an nmap flag`() {
+        val result = service.runNmapScan(
+            nmapPath = "/usr/bin/nmap",
+            nmapArgs = emptyList(),
+            ip = "--script=http-slowloris,dos",
+            ports = null,
+            outputFile = File.createTempFile("nmap-test", ".xml").apply { deleteOnExit() }
+        )
+
+        assertFalse(result.success)
+        assertEquals(-1, result.exitCode)
+    }
+
+    @Test
+    fun `refuses target with leading dash`() {
+        val result = service.runNmapScan(
+            nmapPath = "/usr/bin/nmap",
+            nmapArgs = emptyList(),
+            ip = "-oN/tmp/pwned",
+            ports = null,
+            outputFile = File.createTempFile("nmap-test", ".xml").apply { deleteOnExit() }
+        )
+
+        assertFalse(result.success)
+    }
+}


### PR DESCRIPTION
## Summary

Automated security review found three HIGH findings, all fixed here:

- **IDOR — workgroup AWS-account/AD-domain listing.** CLAUDE.md documents `GET /api/workgroups/{id}/aws-accounts` and `.../ad-domains` as "ADMIN/member-scoped". The `POST`/`DELETE` handlers on both controllers correctly call the existing `isMemberOrAdmin(workgroupId, authentication)` guard, but the `GET`/`list` handler on both had **no such check** — the underlying service only verified the workgroup exists, not that the caller belongs to it. Any authenticated user could enumerate small sequential workgroup IDs and read another team's AWS account IDs / AD domain names. Fixed by adding the same `isMemberOrAdmin` check the sibling mutation handlers already use, in `WorkgroupAwsAccountController.list` and `WorkgroupAdDomainController.list`. (The MCP tool equivalents were already correctly `ADMIN`-gated and are unaffected.)
- **IDOR — AI risk-assessment job status/cancel/SSE, cross-assessment.** `AiSuggestionController`'s job endpoints verify the caller owns the risk assessment in the URL path (`ownershipGuard.check(id, ...)`), but then look up the job by a bare `jobId` with **no check that the job belongs to that assessment**. A SECCHAMPION who owns any one assessment could pass the ownership check for their own assessment and then supply a `jobId` belonging to a completely different assessment — disclosing its model/cost/status, or cancelling another team's running AI job. `getJobStatus`/`cancelJob`/`getProgressStream` now take the expected assessment id and verify `job.riskAssessmentId` matches before returning anything (mirrors the existing `getJobStatus(jobId, username)` pattern already used by `ExportJobService`/`CrowdStrikeReconcileJobService`).
- **Argument injection — nmap via unvalidated `Asset.ip`.** `POST /api/assets` is open to any authenticated user and accepts an arbitrary `ip` string with no format validation. `PortScanCliService.runNmapScan` appends it straight to the nmap argv (list-form `ProcessBuilder`, so no shell injection, but nmap itself parses a `-`-prefixed argument as a flag). A low-privileged user could set `ip` to a value starting with `-` and `networkZone=EXTERNAL`, making the asset eligible for `GET /api/assets/internet-facing` (ADMIN-only, feeds the CLI port-scan workflow) — so when an ADMIN later runs `secman port-scan`, nmap parses the injected flag (extra scripts, alternate output paths, `-iL` reading arbitrary local files) instead of a target. Fixed by rejecting any target that isn't a plain IPv4/IPv6 address before building the nmap command.

## Build verification note

This sandbox's outbound network policy blocks the Gradle wrapper's distribution download (`services.gradle.org` returns 403 through the proxy), so **`./gradlew build` could not be run here**, and neither could the mandatory `./scripts/startbackenddev.sh` / `/e2ejs` / `/e2evulnexception` gates from this repo's CLAUDE.md. Every change was instead verified by:
- Manual code reading of the exact call sites and surrounding logic.
- Confirming the fix pattern already compiles elsewhere in this codebase — e.g. `return HttpResponse.status(HttpStatus.FORBIDDEN)` inside a method with a concrete `HttpResponse<T>` return type (not `HttpResponse<*>`) is the exact same pattern already used in `OutdatedAssetController.getOutdatedAssets`.
- Grepping for every other call site of the changed service method signatures (`getJobStatus`/`cancelJob`/`getProgressStream`) to confirm no other caller was missed.
- Grepping existing tests for anything asserting the old (vulnerable) behavior — none found.

**CI must run the full `./gradlew build` + startup + `/e2ejs` + `/e2evulnexception` gates before merge.** I could not perform that verification in this environment.

## Test plan

- [x] Added `WorkgroupAwsAccountControllerAuthorizationTest` / `WorkgroupAdDomainControllerAuthorizationTest` (pure Mockk unit tests, same style as the existing `WorkgroupAuthorizationTest`): non-member/non-admin gets 403, member gets 200, admin gets 200 for any workgroup.
- [x] Added `PortScanCliServiceTest`: an nmap-flag-shaped or `-`-prefixed target is refused before `ProcessBuilder` is invoked.
- [ ] `./gradlew build` — **not run**, see note above.
- [ ] `./scripts/startbackenddev.sh` clean start — **not run**, see note above.
- [ ] `/e2ejs`, `/e2evulnexception` — **not run**, see note above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvwKAm4gsirkGJw4ZcqR1e)_