### PR TITLE
Fix SSRF in application register GitHub URL check

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ApplicationRegisterController.kt
@@ -115,11 +115,23 @@ open class ApplicationRegisterController(
             if (uri.scheme != "https" && uri.scheme != "http") {
                 return HttpResponse.ok(mapOf("reachable" to false, "reason" to "URL must use http or https"))
             }
+            // SECURITY: This endpoint is reachable by any authenticated user and was
+            // previously an open SSRF proxy — it would issue a server-side HTTP request
+            // to ANY attacker-supplied host (including cloud metadata endpoints like
+            // 169.254.169.254 and internal-only services), returning reachability/status
+            // as an oracle. Since this check exists only to validate GitHub repository
+            // URLs, restrict the target host to github.com.
+            val host = uri.host?.lowercase()
+            if (host != "github.com" && host != "www.github.com") {
+                return HttpResponse.ok(mapOf("reachable" to false, "reason" to "Only github.com URLs are supported"))
+            }
             val connection = uri.toURL().openConnection() as HttpURLConnection
             connection.requestMethod = "HEAD"
             connection.connectTimeout = 5000
             connection.readTimeout = 5000
-            connection.instanceFollowRedirects = true
+            // Do not follow redirects server-side: a redirect target is outside our
+            // host allowlist check and would reopen the SSRF this fix closes.
+            connection.instanceFollowRedirects = false
             connection.setRequestProperty("User-Agent", "SecMan/1.0")
             val status = connection.responseCode
             connection.disconnect()


### PR DESCRIPTION
## Summary

Automated security review of the full codebase (backend, frontend, CLI, MCP tools), scoped to OWASP Top 10 HIGH/CRITICAL findings only.

### Finding: SSRF in `GET /api/applications/check-github-url`

**What**: `ApplicationRegisterController.checkGithubUrl` took an arbitrary `url` query parameter from any authenticated user and made a server-side HTTP `HEAD` request to it (only the scheme was checked — `http`/`https`), returning the reachability and status code back to the caller.

**Why it matters**: Any authenticated user (not just ADMIN/SECCHAMPION) could use the backend as an SSRF oracle to probe internal-only network services and cloud metadata endpoints (e.g. `http://169.254.169.254/latest/meta-data/`) that the backend host can reach but the caller cannot reach directly — a classic OWASP SSRF pattern, and particularly sensitive here given the platform's AWS-account integrations.

**Fix**: Since the endpoint exists solely to validate GitHub repository URLs (see `ApplicationRegister.tsx`'s "check reachability" button for the repo URL field), the target host is now restricted to `github.com` / `www.github.com`, and server-side redirect following is disabled (a redirect response could otherwise point the request at a host outside the allowlist, reopening the same issue). Scheme validation is unchanged.

## Impact

- Before: any authenticated user → arbitrary internal/external host probing via the backend.
- After: the endpoint only reaches `github.com`, matching its intended purpose.

## Verification

- `./gradlew :backendng:compileKotlin` could not be run in this sandbox — the pinned Gradle 9.6.1 wrapper distribution is blocked by the environment's egress policy (`services.gradle.org` is not allow-listed) and the system-installed Gradle (8.14.3) cannot resolve the Kotlin 2.4.10 plugin without network access to Gradle Plugin Portal/Maven. The change was reviewed manually instead — it uses only symbols already imported in the file (`URI`, `HttpURLConnection`) and follows existing patterns in the same function.
- `./scripts/startbackenddev.sh` was not run (requires `pass-cli` + MariaDB, unavailable in this sandbox).
- No `extensions/` client calls this endpoint (`grep -rn 'check-github-url' extensions` — no matches), so there is no contract-drift to flag.
- Frontend was not touched.

## Scope note

This was a full-codebase review, not a diff review. Other areas checked and found sound: `@Secured` coverage across all backend controllers, MCP `X-MCP-User-Email` delegation + per-tool access-control enforcement (`McpExecutionContext`/`AssetFilterService` parity), native/JPQL SQL query parameterization, XXE hardening in the Nmap/Masscan XML parsers, JWT signing/alg validation, `secman_auth` cookie flags, CORS configuration, file-upload path-traversal guards, and config-secret masking (Falcon/GitHub App/Email/Translation configs) before serialization. No other HIGH/CRITICAL findings were confirmed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013aaRA93UiwvjHaQMhoAd2U)_