### PR TITLE
Docker: split 3-container flow for macOS + AWS EKS/Fargate deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ Full reference (SMTP, OAuth retry, memory tuning, debug logging, vuln settings):
 | [docs/E2E_EXCEPTION_WORKFLOW_TEST.md](docs/E2E_EXCEPTION_WORKFLOW_TEST.md) | Vuln-exception MCP E2E |
 | [docs/SKILLS_AND_AGENTS.md](docs/SKILLS_AND_AGENTS.md) | Claude Code skills + sub-agents wired to this repo |
 | [docs/PASS_CLI.md](docs/PASS_CLI.md) | `pass-cli` (Proton Pass) secret resolution |
-| [docker/README.md](docker/README.md) | Docker deployment: Compose (bundled DB or RDS), single-container, multi-container |
+| [docker/README.md](docker/README.md) | Docker deployment: Compose (bundled DB or RDS), single-container, split 3-container (macOS), Kubernetes |
 | [docs/DOCKER_AWS.md](docs/DOCKER_AWS.md) | All-in-one AWS image: ECS/Fargate, Secrets Manager, RDS |
+| [docs/DOCKER_EKS.md](docs/DOCKER_EKS.md) | Kubernetes on AWS EKS/Fargate: manifests, ALB, External Secrets Operator, RDS |
 | [INSTALL.md](INSTALL.md) | Step-by-step install |
 
 ## Workflow

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,24 @@
 # Secman Docker Deployment
 
-This directory holds three ways to run Secman in Docker. Pick the one that
-fits:
+This directory holds four ways to run Secman in Docker/Kubernetes. Pick the
+one that fits:
 
 | Setup | Files | Best for | Database |
 |-------|-------|----------|----------|
 | **Compose (all-in-one)** | `docker-compose.yml`, `compose-up.sh`, `.env.example` | Fastest local/demo start; mirrors the AWS image | **Bundled MariaDB container OR external RDS** (toggle) |
-| **Single-container (AWS)** | `docker/aws/` | ECS/Fargate + Secrets Manager | External RDS / MariaDB |
-| **Multi-container scripts** | `build-all.sh`, `start-*.sh` | Separate backend/frontend/db containers, no compose | Bundled MariaDB container |
+| **Compose (split, 3 containers)** | `docker-compose.split.yaml`, `compose-up-split.sh` | Real separate frontend/backend/db containers, e.g. **macOS local dev** | Bundled MariaDB container |
+| **Single-container (AWS ECS/Fargate)** | `docker/aws/` | ECS/Fargate + Secrets Manager | External RDS / MariaDB |
+| **Kubernetes (AWS EKS/Fargate)** | `docker/eks/` | EKS + Fargate + External Secrets Operator | External RDS |
+
+Manual `start-*.sh` scripts (no compose) are also still available — see
+[Option 3](#option-3--split-three-container-topology) — as a throwaway/demo
+fallback for the split topology.
 
 > Deploying to AWS ECS/Fargate? The full reference is
-> [docs/DOCKER_AWS.md](../docs/DOCKER_AWS.md).
+> [docs/DOCKER_AWS.md](../docs/DOCKER_AWS.md). Deploying to AWS EKS/Fargate
+> (Kubernetes)? See [docs/DOCKER_EKS.md](../docs/DOCKER_EKS.md). Running
+> somewhere other than AWS? See [Suggestions](#suggestions--other-deployment-targets)
+> below.
 
 ---
 
@@ -59,7 +67,7 @@ Tear down: `docker compose -f docker/docker-compose.yml --profile local-db down`
 
 ---
 
-## Option 2 — Single-container AWS image
+## Option 2 — Single-container AWS image (ECS/Fargate)
 
 The same all-in-one image, deployed to AWS ECS/Fargate behind an ALB with
 secrets in AWS Secrets Manager and the database on RDS. Build, push, and task
@@ -68,9 +76,12 @@ definition instructions live in
 
 ---
 
-## Option 3 — Multi-container scripts (no docker-compose)
+## Option 3 — Split, three-container topology
 
-Three standalone Docker containers for running the full Secman stack.
+Three real, separate containers: database, backend (Micronaut), frontend
+(nginx + Astro SSR). This is the option to reach for on **macOS** — closest
+to a genuine local prod-like stack — or anywhere you specifically want the
+three pieces isolated rather than bundled into one image.
 
 ## Architecture
 
@@ -86,8 +97,8 @@ Three standalone Docker containers for running the full Secman stack.
 │                            │                     │
 │                    ┌───────┴──────┐              │
 │                    │secman-frontend│              │
-│                    │ Nginx + SSL  │              │
-│                    │ :8443        │              │
+│                    │ Nginx + Astro │              │
+│                    │ SSR :8443    │              │
 │                    └──────────────┘              │
 │                                                  │
 │          Docker Network: secman-net              │
@@ -98,148 +109,79 @@ Three standalone Docker containers for running the full Secman stack.
 |-----------|-------|------|-------------|
 | `secman-db` | `secman-db` | 3307 → 3306 | MariaDB 11.4, persistent volume |
 | `secman-backend` | `secman-backend` | 8080 | Kotlin/Micronaut REST API |
-| `secman-frontend` | `secman-frontend` | **8443** (HTTPS) | Nginx reverse proxy + static assets |
+| `secman-frontend` | `secman-frontend` | **8443** (HTTPS) | Nginx (TLS + static assets) + Astro SSR Node server |
 
-## Prerequisites
+### Recommended: `compose-up-split.sh` (real secrets)
 
-- Docker 20.10+ installed and running
-- ~2GB free disk space for images
-- Ports 8443, 8080, 3307 available
+```bash
+# Builds the backend JAR, builds all three images, and brings up the stack.
+# Generates docker/.env (same file the all-in-one flow uses) with fresh
+# secrets on first run — nothing is hardcoded.
+./docker/compose-up-split.sh
 
-## Quick Start
+# Open https://localhost:8443 (accept the self-signed certificate warning)
+
+# Get the auto-generated admin password
+docker logs secman-backend 2>&1 | grep "Password:"
+```
+
+Raw compose (no wrapper):
+```bash
+cp docker/.env.example docker/.env            # then edit secrets
+docker compose -f docker/docker-compose.split.yaml --env-file docker/.env up --build
+```
+
+Tear down: `docker compose -f docker/docker-compose.split.yaml --env-file docker/.env down` (add `-v` to also drop the `secman-split-db-data` volume).
+
+### Fallback: manual scripts (throwaway/demo only)
+
+No compose, no `.env` file — every secret must be exported by hand, every
+time. Nothing is stored, so this is fine for a five-minute smoke test but
+not for anything you'd come back to.
 
 ```bash
 # 1. Build all images
 ./docker/build-all.sh
 
-# 2. Start everything
+# 2. Export secrets (no defaults — the scripts refuse to start without these)
+export SECMAN_DB_ROOT_PASSWORD="$(openssl rand -hex 12)"
+export SECMAN_DB_PASSWORD="$(openssl rand -hex 12)"
+export SECMAN_JWT_SECRET="$(openssl rand -base64 32)"
+export SECMAN_ENCRYPTION_PASSWORD="$(openssl rand -hex 32)"
+export SECMAN_ENCRYPTION_SALT="$(openssl rand -hex 8)"
+
+# 3. Start everything
 ./docker/start-all.sh
 
-# 3. Open https://localhost:8443
-#    (Accept self-signed certificate warning)
-
-# 4. Get the auto-generated admin password
-docker logs secman-backend 2>&1 | grep "Password:"
-
-# 5. Login with username: admin
+# 4. Open https://localhost:8443, get the admin password as above
 ```
 
-## Scripts Reference
+#### Scripts Reference
 
 | Script | Description |
 |--------|-------------|
 | `build-all.sh` | Build all three Docker images |
-| `start-all.sh` | Start all containers in order (DB → backend → frontend) |
-| `start-database.sh` | Start only the database container |
-| `start-backend.sh` | Start only the backend container |
+| `start-all.sh` | Start all containers in order (DB → backend → frontend) — requires the exported secrets above |
+| `start-database.sh` | Start only the database container — requires `SECMAN_DB_ROOT_PASSWORD`, `SECMAN_DB_PASSWORD` |
+| `start-backend.sh` | Start only the backend container — requires `SECMAN_DB_PASSWORD`, `SECMAN_JWT_SECRET`, `SECMAN_ENCRYPTION_PASSWORD`, `SECMAN_ENCRYPTION_SALT` |
 | `start-frontend.sh` | Start only the frontend container |
 | `stop-all.sh` | Stop all containers (preserves data) |
 | `stop-all.sh --purge` | Stop all containers and delete data volume + network |
 | `test-docker.sh` | Full integration test (build, start, login, verify, cleanup) |
 | `test-docker.sh --keep` | Same as above but leave containers running after test |
 
-## Individual Container Management
-
-### Database
-
-```bash
-# Start
-./docker/start-database.sh
-
-# Connect to MariaDB
-docker exec -it secman-db mariadb -usecman -psecman-docker-pw secman
-
-# View logs
-docker logs -f secman-db
-
-# Reset (delete all data)
-./docker/stop-all.sh --purge
-```
-
-### Backend
-
-```bash
-# Start (requires database)
-./docker/start-backend.sh
-
-# View logs (includes admin password on first run)
-docker logs -f secman-backend
-
-# Get admin password
-docker logs secman-backend 2>&1 | grep "Password:"
-
-# Check health
-curl -s http://localhost:8080/health
-```
-
-### Frontend
-
-```bash
-# Start (requires backend)
-./docker/start-frontend.sh
-
-# Access
-open https://localhost:8443
-
-# View Nginx logs
-docker logs -f secman-frontend
-```
-
-## Configuration
-
-Environment variables can be set before running the start scripts:
-
-### Database
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SECMAN_DB_ROOT_PASSWORD` | `secman-root-pw` | MariaDB root password |
-| `SECMAN_DB_PASSWORD` | `secman-docker-pw` | Application DB password |
-
-### Backend
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SECMAN_DB_PASSWORD` | `secman-docker-pw` | Must match database password |
-| `SECMAN_JWT_SECRET` | (built-in default) | JWT signing secret (min 256 bits) |
-
-### Example: Custom passwords
-
-```bash
-export SECMAN_DB_PASSWORD="my-strong-password"
-export SECMAN_JWT_SECRET="my-custom-jwt-secret-that-is-at-least-256-bits-long-for-hs256-algo"
-./docker/start-all.sh
-```
-
-## Integration Test
-
-The test script validates the entire Docker stack end-to-end:
-
-```bash
-# Run full test (builds, starts, tests, cleans up)
-./docker/test-docker.sh
-
-# Run test and keep containers running
-./docker/test-docker.sh --keep
-```
-
-**What it tests:**
-1. All three images build successfully
-2. Containers start and pass health checks
-3. Default admin user is created automatically
-4. Login via REST API returns a valid JWT token
-5. Authenticated API calls work through the Nginx proxy
-6. Database has tables (Flyway/Hibernate migrations ran)
+`SECMAN_DB_PASSWORD`/`SECMAN_JWT_SECRET`/`SECMAN_ENCRYPTION_PASSWORD`/`SECMAN_ENCRYPTION_SALT` must be **exported before** calling `start-backend.sh`, and `SECMAN_DB_PASSWORD` must match what `start-database.sh` was started with. There are intentionally no built-in defaults — a "just works" default password is exactly what ends up in a real deployment by accident. `SECMAN_ENCRYPTION_PASSWORD`/`SALT` are especially important to set for real use: unset, the backend falls back to a well-known constant in `application.yml` that would silently "encrypt" stored OAuth secrets/API keys with a public value.
 
 ## Data Persistence
 
-- Database data is stored in Docker volume `secman-db-data`
-- Stopping containers preserves data; next start resumes with existing data
-- Use `./docker/stop-all.sh --purge` to delete all data and start fresh
+- Compose flow: data lives in the `secman-split-db-data` volume (distinct from the all-in-one flow's `secman-db-data` — don't run both flows against the same volume concurrently).
+- Manual-script flow: data lives in the `secman-db-data` volume.
+- Stopping containers preserves data; next start resumes with existing data.
+- Use `./docker/stop-all.sh --purge` (or `docker compose ... down -v`) to delete all data and start fresh.
 
 ## Networking
 
-All containers communicate via the `secman-net` Docker bridge network:
+All containers communicate via the `secman-net` Docker bridge network (manual scripts) or the compose-managed network (compose flow):
 - Frontend resolves `secman-backend` by container name
 - Backend resolves `secman-db` by container name
 - No host networking required
@@ -278,10 +220,67 @@ docker logs secman-backend 2>&1 | grep -A5 "ADMIN"
 ```
 
 ### Port conflicts
-If ports 8443, 8080, or 3307 are in use, stop the conflicting services or edit the port mappings in the respective start scripts.
+If ports 8443, 8080, or 3307 are in use, stop the conflicting services or edit the port mappings in the respective start scripts / `docker-compose.split.yaml`.
 
 ### Reset everything
 ```bash
 ./docker/stop-all.sh --purge
 ./docker/start-all.sh
+# or, compose flow:
+docker compose -f docker/docker-compose.split.yaml --env-file docker/.env down -v
+./docker/compose-up-split.sh
 ```
+
+---
+
+## Option 4 — Kubernetes (AWS EKS/Fargate)
+
+Frontend + backend run as Kubernetes Deployments on EKS Fargate (serverless,
+no nodes to manage), behind an ALB provisioned by the AWS Load Balancer
+Controller; the database is Amazon RDS. Secrets come from AWS Secrets
+Manager via the External Secrets Operator — nothing in plaintext in any
+manifest. Manifests, the eksctl cluster config, and the build/deploy scripts
+live in `docker/eks/`. Full step-by-step runbook:
+[docs/DOCKER_EKS.md](../docs/DOCKER_EKS.md).
+
+---
+
+## macOS notes
+
+- **Docker Desktop for Mac** is the default choice; **Colima** (`brew
+  install colima docker` + `colima start`) is a lighter, free alternative if
+  you don't need Docker Desktop's GUI/licensing.
+- **Apple Silicon (M-series)**: images build natively as `arm64`. If you
+  want parity with AWS Fargate (which defaults to `x86_64`), add
+  `--platform linux/amd64` to any `docker build`/`docker compose build`
+  invocation — this is slower (emulated) but confirms the image behaves
+  correctly on the architecture that will actually run in AWS.
+- **Memory**: the backend build stage compiles Kotlin inside the container
+  and needs **~4 GB RAM**. In Docker Desktop, raise the VM memory limit
+  (Settings → Resources) before running `compose-up-split.sh` or
+  `build-all.sh` for the first time.
+- **Volumes**: the database uses a named Docker volume
+  (`secman-split-db-data` / `secman-db-data`), not a bind mount — named
+  volumes avoid the significant I/O overhead of Docker Desktop's bind-mount
+  file sharing on macOS, which matters for MariaDB's write pattern.
+
+---
+
+## Suggestions — other deployment targets
+
+### Non-AWS
+
+| Option | When it fits | Notes |
+|---|---|---|
+| **Plain `docker compose` on a VPS** (Hetzner, DigitalOcean, ...) | Small team, single host is enough | Put [Traefik](https://traefik.io/) or [Caddy](https://caddyserver.com/) in front for automatic Let's Encrypt TLS instead of the self-signed cert; add [Watchtower](https://containrrr.dev/watchtower/) to auto-pull new image tags. `docker-compose.split.yaml` works as-is — swap the frontend's self-signed cert for a Traefik/Caddy-terminated one. |
+| **k3s / k3d** | Want Kubernetes without EKS's cost/complexity, or want to rehearse the EKS manifests locally first | `docker/eks/*.yaml` manifests are largely reusable: swap the `Ingress` class (`alb` → `traefik` or `nginx`), and swap the `ExternalSecret`'s backend (AWS Secrets Manager → a local `SecretStore`, e.g. backed by a Kubernetes `Secret` or Vault). Good staging ground before a real EKS deploy. |
+| **Docker Swarm** | Multi-host but Kubernetes feels like overkill | The same three images work as a `docker stack deploy` with a `docker-compose.split.yaml`-derived stack file (add `deploy:` blocks); much less operational surface than K8s for the same 3-container topology. |
+| **Backups (any of the above)** | Any self-hosted MariaDB container | Cron + `mariadb-dump` + [restic](https://restic.net/) or `rclone` to S3-compatible object storage (AWS S3, Backblaze B2, MinIO, ...). None of the options above include automated backups — RDS (see AWS options) is the only one with that built in. |
+
+### AWS
+
+| Option | When it fits | Notes |
+|---|---|---|
+| **ECS/Fargate** (Option 2, already implemented) | Default recommendation unless you're already standardizing on Kubernetes elsewhere | Simplest AWS option here — no cluster control plane, no CSI/IRSA-per-addon complexity. See `docs/DOCKER_AWS.md`. |
+| **EKS Fargate** (Option 4) | Standardizing on Kubernetes across other services, or want K8s-native tooling (kubectl, Helm charts, GitOps) | Serverless per-pod billing like ECS/Fargate, but with EKS's control-plane cost (~$0.10/hr) and the extra moving parts (AWS Load Balancer Controller, External Secrets Operator, IRSA) on top. See `docs/DOCKER_EKS.md`. |
+| **EKS with managed node groups** | Need features Fargate doesn't support — DaemonSets, `hostPort`, persistent EBS volumes for an in-cluster database instead of RDS, GPU nodes | More ops overhead (patch/size the nodes yourself, or use Karpenter/Cluster Autoscaler) in exchange for full Kubernetes feature support. `docs/DOCKER_EKS.md` has an appendix on running the database as an EBS-backed StatefulSet on a node group instead of RDS. |

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -14,14 +14,17 @@ COPY docker/backend/app.jar app.jar
 # Backend port
 EXPOSE 8080
 
-# Environment defaults for Docker networking
+# Environment defaults for Docker networking (non-secret only — see below).
 ENV DB_CONNECT=jdbc:mariadb://secman-db:3306/secman
 ENV DB_USERNAME=secman
-ENV DB_PASSWORD=secman-docker-pw
-ENV JWT_SECRET=docker-secman-jwt-secret-must-be-at-least-256-bits-long-for-hs256
 ENV SECMAN_AUTH_COOKIE_SECURE=false
 ENV FRONTEND_URL=https://localhost:8443
 ENV SECMAN_BACKEND_URL=https://localhost:8443
+
+# Security-sensitive vars (DB_PASSWORD, JWT_SECRET, SECMAN_ENCRYPTION_PASSWORD,
+# SECMAN_ENCRYPTION_SALT, ...) intentionally have NO baked default — a dev
+# fallback here would eventually leak into a real deployment. Inject them at
+# `docker run -e` / compose `env_file` time. See docker/README.md.
 
 # Disable Flyway on fresh Docker databases — Hibernate auto-DDL creates the full schema.
 # Flyway migrations assume pre-existing tables (created by Hibernate on existing deployments).

--- a/docker/compose-up-split.sh
+++ b/docker/compose-up-split.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# =============================================================================
+# Secman Docker Compose launcher — split (three-container) topology
+# =============================================================================
+# Brings up the database, backend, and frontend as three separate containers
+# via docker compose, building the images locally first.
+#
+#   ./docker/compose-up-split.sh
+#
+# On first run it creates docker/.env from docker/.env.example and fills in
+# freshly generated secrets (JWT, encryption password/salt, DB passwords) —
+# the same .env file used by ./docker/compose-up.sh (the all-in-one flow).
+# Review docker/.env before using it for anything real.
+#
+# Extra args are forwarded to `docker compose up`, e.g.:
+#   ./docker/compose-up-split.sh -d --build
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+ENV_EXAMPLE="$SCRIPT_DIR/.env.example"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.split.yaml"
+
+# Pick a compose implementation (v2 plugin preferred, fall back to v1).
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "✗ Neither 'docker compose' nor 'docker-compose' is available." >&2
+  exit 1
+fi
+
+# --- Ensure docker/.env exists with fresh secrets (shared with compose-up.sh)
+source "$SCRIPT_DIR/generate-env.sh"
+secman_ensure_env_file "$ENV_FILE" "$ENV_EXAMPLE"
+
+# --- Build the backend fat JAR (the backend image copies a pre-built jar —
+# see docker/backend/Dockerfile) --------------------------------------------
+echo "[compose-up-split] Building backend JAR..."
+( cd "$PROJECT_ROOT" && ./gradlew :backendng:shadowJar -x test --no-daemon )
+cp "$PROJECT_ROOT"/src/backendng/build/libs/*-all.jar "$SCRIPT_DIR/backend/app.jar"
+
+echo "[compose-up-split] Running: ${COMPOSE[*]} -f $COMPOSE_FILE --env-file $ENV_FILE up --build ${*:-}"
+exec "${COMPOSE[@]}" -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up --build "$@"

--- a/docker/compose-up.sh
+++ b/docker/compose-up.sh
@@ -57,51 +57,9 @@ else
 fi
 
 # --- Generate docker/.env with fresh secrets on first run --------------------
-gen() {
-  # A portable random secret generator: openssl if present, else /dev/urandom.
-  local kind="$1"
-  if command -v openssl >/dev/null 2>&1; then
-    case "$kind" in
-      b64_32) openssl rand -base64 32 ;;
-      hex_32) openssl rand -hex 32 ;;
-      hex_8)  openssl rand -hex 8 ;;
-      hex_12) openssl rand -hex 12 ;;
-    esac
-  else
-    case "$kind" in
-      b64_32) head -c 32 /dev/urandom | base64 ;;
-      hex_32) head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
-      hex_8)  head -c 8  /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
-      hex_12) head -c 12 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
-    esac
-  fi
-}
-
-if [[ ! -f "$ENV_FILE" ]]; then
-  echo "[compose-up] docker/.env not found — creating it from .env.example with fresh secrets."
-  cp "$ENV_EXAMPLE" "$ENV_FILE"
-
-  JWT="$(gen b64_32)"
-  ENC_PW="$(gen hex_32)"
-  ENC_SALT="$(gen hex_8)"
-  DB_PW="$(gen hex_12)"
-  DB_ROOT_PW="$(gen hex_12)"
-
-  # sed -i portability (GNU vs BSD)
-  sedi() { if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi; }
-  set_kv() { sedi "s|^$1=.*|$1=$2|" "$ENV_FILE"; }
-
-  set_kv JWT_SECRET "$JWT"
-  set_kv SECMAN_ENCRYPTION_PASSWORD "$ENC_PW"
-  set_kv SECMAN_ENCRYPTION_SALT "$ENC_SALT"
-  set_kv DB_PASSWORD "$DB_PW"
-  set_kv DB_ROOT_PASSWORD "$DB_ROOT_PW"
-
-  echo "[compose-up] Wrote $ENV_FILE. Review it (URLs, DB_CONNECT, SMTP, etc.) before production use."
-  if [[ "$MODE" == "rds" ]]; then
-    echo "[compose-up] RDS mode: edit DB_CONNECT/DB_USERNAME/DB_PASSWORD in docker/.env to match your RDS instance."
-  fi
-fi
+# Shared with compose-up-split.sh so both flows read/write the same secrets.
+source "$SCRIPT_DIR/generate-env.sh"
+secman_ensure_env_file "$ENV_FILE" "$ENV_EXAMPLE" "$MODE"
 
 # --- Launch ------------------------------------------------------------------
 ARGS=(-f "$COMPOSE_FILE")

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -5,11 +5,14 @@ FROM mariadb:11.4
 LABEL maintainer="secman"
 LABEL description="Secman MariaDB database container"
 
-# Environment defaults (override at runtime)
-ENV MYSQL_ROOT_PASSWORD=secman-root-pw
+# Non-secret defaults (override at runtime).
 ENV MYSQL_DATABASE=secman
 ENV MYSQL_USER=secman
-ENV MYSQL_PASSWORD=secman-docker-pw
+
+# MYSQL_ROOT_PASSWORD / MYSQL_PASSWORD intentionally have NO baked default —
+# a dev fallback here would eventually leak into a real deployment. The
+# upstream mariadb image refuses to start without one of these set anyway.
+# Inject them at `docker run -e` / compose `env_file` time. See docker/README.md.
 
 # Copy initialization SQL (runs on first container start only)
 COPY init.sql /docker-entrypoint-initdb.d/01-init.sql

--- a/docker/docker-compose.split.yaml
+++ b/docker/docker-compose.split.yaml
@@ -1,0 +1,79 @@
+# Secman — Docker Compose for the split (three-container) topology
+# =============================================================================
+# Three real containers: database, backend (Micronaut), frontend (nginx +
+# Astro SSR). This is the compose equivalent of the manual
+# start-database.sh/start-backend.sh/start-frontend.sh scripts, but reads
+# secrets from ./.env instead of falling back to weak baked-in defaults.
+#
+# Configuration is read from ./.env (copy .env.example -> .env first, or let
+# ./compose-up-split.sh generate one with fresh secrets — the same .env file
+# used by docker-compose.yml, the all-in-one flow). See docker/README.md.
+#
+# Convenience wrapper:  ./docker/compose-up-split.sh
+# Raw compose:  docker compose -f docker/docker-compose.split.yaml --env-file docker/.env up
+#
+# Only DB_PASSWORD/JWT_SECRET/SECMAN_ENCRYPTION_PASSWORD/SECMAN_ENCRYPTION_SALT
+# are passed through explicitly below (not the whole .env via `env_file:`) —
+# FRONTEND_URL/SECMAN_BACKEND_URL/DB_CONNECT in .env are tuned for the
+# all-in-one flow's port (8080) and would be wrong for this flow's frontend
+# port (8443); the split images already bake in the correct defaults for
+# this topology (see docker/backend/Dockerfile, docker/frontend/nginx.conf).
+# =============================================================================
+
+services:
+  db:
+    build:
+      context: database
+    image: secman-db:latest
+    container_name: secman-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?DB_ROOT_PASSWORD must be set in docker/.env}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set in docker/.env}
+      MYSQL_DATABASE: ${DB_NAME:-secman}
+      MYSQL_USER: ${DB_USERNAME:-secman}
+    volumes:
+      - secman-split-db-data:/var/lib/mysql
+    ports:
+      # Exposed for host-side inspection only; the app reaches it via the
+      # compose network as host `secman-db`.
+      - "${DB_HOST_PORT:-3307}:3306"
+
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/backend/Dockerfile
+    image: secman-backend:latest
+    container_name: secman-backend
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set in docker/.env}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must be set in docker/.env}
+      SECMAN_ENCRYPTION_PASSWORD: ${SECMAN_ENCRYPTION_PASSWORD:?SECMAN_ENCRYPTION_PASSWORD must be set in docker/.env}
+      SECMAN_ENCRYPTION_SALT: ${SECMAN_ENCRYPTION_SALT:?SECMAN_ENCRYPTION_SALT must be set in docker/.env}
+      FLYWAY_DATASOURCES_DEFAULT_ENABLED: ${FLYWAY_DATASOURCES_DEFAULT_ENABLED:-false}
+    ports:
+      - "8080:8080"
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: docker/frontend/Dockerfile
+    image: secman-frontend:latest
+    container_name: secman-frontend
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "8443:8443"
+
+volumes:
+  secman-split-db-data:
+    # Deliberately a different volume than the all-in-one flow's
+    # secman-db-data — running both flows against the same volume
+    # concurrently risks two MariaDB instances writing the same data dir.
+    name: secman-split-db-data

--- a/docker/eks/build-push.sh
+++ b/docker/eks/build-push.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# =============================================================================
+# Secman EKS — build the backend/frontend images and push them to ECR
+# =============================================================================
+#   export AWS_REGION=eu-central-1
+#   ./docker/eks/build-push.sh
+#
+# Apple Silicon (build for x86 Fargate, the default architecture):
+#   export BUILD_PLATFORM=linux/amd64
+#   ./docker/eks/build-push.sh
+#
+# After pushing, update the `image:` field in deployment-backend.yaml and
+# deployment-frontend.yaml (or set IMAGE_TAG to a pinned tag, e.g. a git SHA,
+# instead of the default `latest` for an auditable rollback trail).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${AWS_REGION:?Set AWS_REGION, e.g. export AWS_REGION=eu-central-1}"
+ACCOUNT_ID="${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}"
+TAG="${IMAGE_TAG:-latest}"
+REGISTRY="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+
+PLATFORM_FLAG=()
+if [[ -n "${BUILD_PLATFORM:-}" ]]; then
+  PLATFORM_FLAG=(--platform "$BUILD_PLATFORM")
+fi
+
+echo "[build-push] Building backend JAR..."
+( cd "$PROJECT_ROOT" && ./gradlew :backendng:shadowJar -x test --no-daemon )
+cp "$PROJECT_ROOT"/src/backendng/build/libs/*-all.jar "$PROJECT_ROOT/docker/backend/app.jar"
+
+echo "[build-push] Authenticating docker to ECR ($REGISTRY)..."
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$REGISTRY"
+
+for repo in secman-backend secman-frontend; do
+  aws ecr describe-repositories --repository-names "$repo" --region "$AWS_REGION" >/dev/null 2>&1 \
+    || aws ecr create-repository --repository-name "$repo" --region "$AWS_REGION" >/dev/null
+done
+
+echo "[build-push] Building secman-backend..."
+docker build "${PLATFORM_FLAG[@]}" -f "$PROJECT_ROOT/docker/backend/Dockerfile" \
+  -t "$REGISTRY/secman-backend:$TAG" "$PROJECT_ROOT"
+docker push "$REGISTRY/secman-backend:$TAG"
+
+echo "[build-push] Building secman-frontend..."
+docker build "${PLATFORM_FLAG[@]}" -f "$PROJECT_ROOT/docker/frontend/Dockerfile" \
+  -t "$REGISTRY/secman-frontend:$TAG" "$PROJECT_ROOT"
+docker push "$REGISTRY/secman-frontend:$TAG"
+
+echo ""
+echo "[build-push] Pushed:"
+echo "  $REGISTRY/secman-backend:$TAG"
+echo "  $REGISTRY/secman-frontend:$TAG"
+echo ""
+echo "Update the image: field in docker/eks/deployment-backend.yaml and"
+echo "docker/eks/deployment-frontend.yaml with these references, then re-run"
+echo "docker/eks/deploy.sh."

--- a/docker/eks/cluster-up.sh
+++ b/docker/eks/cluster-up.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# Secman EKS — create the cluster from docker/eks/cluster.yaml
+# =============================================================================
+# Provisions a real, billable EKS control plane + Fargate profile. Takes
+# roughly 15-20 minutes. See docs/DOCKER_EKS.md for what to do before and
+# after (VPC prerequisites, IRSA roles, add-on installs).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v eksctl >/dev/null 2>&1; then
+  echo "✗ eksctl not found. Install it first: https://eksctl.io/installation/" >&2
+  exit 1
+fi
+
+echo "This will run: eksctl create cluster -f $SCRIPT_DIR/cluster.yaml"
+echo "That creates real, billable AWS resources (EKS control plane + Fargate profile)."
+read -rp "Continue? [y/N] " CONFIRM
+[[ "$CONFIRM" == "y" || "$CONFIRM" == "Y" ]] || { echo "Aborted."; exit 1; }
+
+eksctl create cluster -f "$SCRIPT_DIR/cluster.yaml"

--- a/docker/eks/cluster.yaml
+++ b/docker/eks/cluster.yaml
@@ -1,0 +1,34 @@
+# eksctl cluster config — creates an EKS cluster with a Fargate profile.
+# Not applied automatically by anything in this repo (creates real, billable
+# AWS resources) — run via docker/eks/cluster-up.sh when you're ready.
+#
+#   eksctl create cluster -f docker/eks/cluster.yaml
+#
+# Replace REPLACE_WITH_AWS_REGION before use. See docs/DOCKER_EKS.md.
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: secman
+  region: REPLACE_WITH_AWS_REGION
+  version: "1.31"
+
+# Fargate runs the pods matching these namespace selectors — no EC2 nodes to
+# patch, size, or scale. `kube-system` is required so CoreDNS itself lands
+# on Fargate (eksctl patches the coredns Deployment for this automatically).
+fargateProfiles:
+  - name: secman
+    selectors:
+      - namespace: secman
+      - namespace: kube-system
+
+# Required for IRSA (IAM Roles for Service Accounts) — used by the AWS Load
+# Balancer Controller and the External Secrets Operator ServiceAccount
+# (docker/eks/serviceaccount.yaml) to assume least-privilege IAM roles
+# without any static AWS keys in the cluster.
+iam:
+  withOIDC: true
+
+cloudWatch:
+  clusterLogging:
+    enableTypes: ["api", "audit", "authenticator"]

--- a/docker/eks/configmap.yaml
+++ b/docker/eks/configmap.yaml
@@ -1,0 +1,23 @@
+# Non-secret backend configuration. Secrets live in externalsecret.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: secman-config
+  namespace: secman
+data:
+  # RDS MariaDB 11.4 endpoint — see docs/DOCKER_EKS.md Step 3.
+  DB_CONNECT: "jdbc:mariadb://REPLACE_WITH_RDS_ENDPOINT:3306/secman"
+  DB_USERNAME: "secman"
+  # Public HTTPS hostname (ALB) — drives CORS, OAuth callbacks, email links.
+  FRONTEND_URL: "https://REPLACE_WITH_PUBLIC_HOSTNAME"
+  SECMAN_BACKEND_URL: "https://REPLACE_WITH_PUBLIC_HOSTNAME"
+  # TLS terminates at the ALB (re-encrypted to the frontend pod, see
+  # ingress.yaml) — the auth cookie must still be marked Secure.
+  SECMAN_AUTH_COOKIE_SECURE: "true"
+  # false = fresh RDS database: Hibernate auto-creates the schema on first
+  # boot. Set true once the schema is Flyway-managed (existing deployment).
+  FLYWAY_DATASOURCES_DEFAULT_ENABLED: "false"
+  # 75% is safe here (unlike docker/aws/Dockerfile's 45%): this Deployment
+  # runs ONLY the JVM in its container — no nginx/node sharing the cgroup.
+  # Tune together with deployment-backend.yaml's resources.limits.memory.
+  JAVA_OPTS: "-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=25.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/secman-backend-oom.hprof -XX:+ExitOnOutOfMemoryError"

--- a/docker/eks/deploy.sh
+++ b/docker/eks/deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# =============================================================================
+# Secman EKS — apply manifests, wait for rollout, print the ALB hostname
+# =============================================================================
+#   ./docker/eks/deploy.sh
+#
+# Assumes: the cluster exists (cluster-up.sh), the AWS Load Balancer
+# Controller + External Secrets Operator are installed (docs/DOCKER_EKS.md),
+# secrets-setup.sh has run, and every REPLACE_WITH_* placeholder in
+# docker/eks/*.yaml has been filled in (RDS endpoint, ECR image refs, ACM
+# cert ARN, IRSA role ARN).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if grep -rl 'REPLACE_WITH_' "$SCRIPT_DIR"/*.yaml >/dev/null 2>&1; then
+  echo "✗ Unfilled REPLACE_WITH_* placeholders remain in docker/eks/*.yaml:" >&2
+  grep -rl 'REPLACE_WITH_' "$SCRIPT_DIR"/*.yaml >&2
+  echo "Fill these in (RDS endpoint, ECR image refs, ACM cert ARN, IRSA role ARN) before deploying." >&2
+  exit 1
+fi
+
+echo "[deploy] kubectl apply -k $SCRIPT_DIR"
+kubectl apply -k "$SCRIPT_DIR"
+
+echo "[deploy] Waiting for rollout..."
+kubectl -n secman rollout status deployment/secman-backend --timeout=300s
+kubectl -n secman rollout status deployment/secman-frontend --timeout=300s
+
+echo "[deploy] Waiting for the ALB hostname (can take a few minutes on first apply)..."
+HOSTNAME=""
+for _ in $(seq 1 60); do
+  HOSTNAME=$(kubectl -n secman get ingress secman -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+  [[ -n "$HOSTNAME" ]] && break
+  sleep 5
+done
+
+if [[ -n "$HOSTNAME" ]]; then
+  echo "[deploy] ALB hostname: $HOSTNAME"
+  echo "[deploy] Point your DNS record at this hostname, then verify: curl -sk https://$HOSTNAME/health"
+else
+  echo "[deploy] ALB hostname not yet assigned — check: kubectl -n secman describe ingress secman"
+fi

--- a/docker/eks/deployment-backend.yaml
+++ b/docker/eks/deployment-backend.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secman-backend
+  namespace: secman
+  labels:
+    app: secman-backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: secman-backend
+  template:
+    metadata:
+      labels:
+        app: secman-backend
+    spec:
+      containers:
+        - name: secman-backend
+          # Pushed by docker/eks/build-push.sh from docker/backend/Dockerfile.
+          image: REPLACE_WITH_ACCOUNT_ID.dkr.ecr.REPLACE_WITH_AWS_REGION.amazonaws.com/secman-backend:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: secman-config
+            - secretRef:
+                name: secman-secrets
+          # Fargate requires requests to size the pod. limits == requests
+          # keeps JAVA_OPTS's MaxRAMPercentage math (configmap.yaml) predictable.
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 6

--- a/docker/eks/deployment-frontend.yaml
+++ b/docker/eks/deployment-frontend.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secman-frontend
+  namespace: secman
+  labels:
+    app: secman-frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: secman-frontend
+  template:
+    metadata:
+      labels:
+        app: secman-frontend
+    spec:
+      containers:
+        - name: secman-frontend
+          # Pushed by docker/eks/build-push.sh from docker/frontend/Dockerfile
+          # (nginx + Astro SSR Node server, same image used by
+          # docker-compose.split.yaml — see docker/frontend/entrypoint.sh).
+          image: REPLACE_WITH_ACCOUNT_ID.dkr.ecr.REPLACE_WITH_AWS_REGION.amazonaws.com/secman-frontend:latest
+          ports:
+            - containerPort: 8443
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/docker/eks/externalsecret.yaml
+++ b/docker/eks/externalsecret.yaml
@@ -1,0 +1,39 @@
+# Syncs the same secman/* AWS Secrets Manager entries used by the ECS
+# runbook (docs/DOCKER_AWS_DEPLOY_RUNBOOK.md Step 5 / docker/eks/secrets-setup.sh)
+# into a native Kubernetes Secret, consumed via envFrom in
+# deployment-backend.yaml. Re-synced every refreshInterval — rotate a value
+# in Secrets Manager and it propagates without a manifest change.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: secman-secrets
+  namespace: secman
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: secman-secrets-manager
+    kind: SecretStore
+  target:
+    name: secman-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: secman/db-password
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: secman/jwt-secret
+    - secretKey: SECMAN_ENCRYPTION_PASSWORD
+      remoteRef:
+        key: secman/enc-password
+    - secretKey: SECMAN_ENCRYPTION_SALT
+      remoteRef:
+        key: secman/enc-salt
+    # Optional — only if the corresponding feature/secret is in use.
+    # Uncomment and create the secret first (secrets-setup.sh --optional):
+    # - secretKey: SMTP_PASSWORD
+    #   remoteRef:
+    #     key: secman/smtp-password
+    # - secretKey: OPENROUTER_API_KEY
+    #   remoteRef:
+    #     key: secman/openrouter-key

--- a/docker/eks/hpa-backend.yaml
+++ b/docker/eks/hpa-backend.yaml
@@ -1,0 +1,22 @@
+# Optional. Requires the metrics-server add-on in-cluster — without it this
+# HPA object applies cleanly but never scales (metrics stay "unknown").
+# See docs/DOCKER_EKS.md.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: secman-backend
+  namespace: secman
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: secman-backend
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/docker/eks/hpa-frontend.yaml
+++ b/docker/eks/hpa-frontend.yaml
@@ -1,0 +1,20 @@
+# Optional — see hpa-backend.yaml.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: secman-frontend
+  namespace: secman
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: secman-frontend
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/docker/eks/ingress.yaml
+++ b/docker/eks/ingress.yaml
@@ -1,0 +1,41 @@
+# Requires the AWS Load Balancer Controller installed in-cluster (Helm chart
+# `eks/aws-load-balancer-controller`) — see docs/DOCKER_EKS.md. Provisions an
+# internet-facing ALB that terminates public TLS with an ACM certificate and
+# re-encrypts (backend-protocol HTTPS) to the frontend pod's self-signed cert
+# on :8443 — the ALB does not validate that cert (normal for HTTPS target
+# groups), so this stays TLS end-to-end without extra cert management.
+#
+# Everything routes to the frontend Service; the frontend's own nginx keeps
+# doing the /api, /oauth, /mcp, /health routing to the backend internally —
+# same single source of routing truth as docker compose, see
+# docker/frontend/nginx.conf.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: secman
+  namespace: secman
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:REPLACE_WITH_AWS_REGION:REPLACE_WITH_ACCOUNT_ID:certificate/REPLACE_WITH_CERT_ID"
+    alb.ingress.kubernetes.io/backend-protocol: HTTPS
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
+    # The backend takes ~60-90s to boot (same as ECS) — a generous grace
+    # period keeps the ALB from cycling targets during a rolling deploy.
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: "5"
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: secman-frontend
+                port:
+                  number: 8443

--- a/docker/eks/kustomization.yaml
+++ b/docker/eks/kustomization.yaml
@@ -1,0 +1,17 @@
+# kubectl apply -k docker/eks/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: secman
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - configmap.yaml
+  - secretstore.yaml
+  - externalsecret.yaml
+  - deployment-backend.yaml
+  - service-backend.yaml
+  - deployment-frontend.yaml
+  - service-frontend.yaml
+  - ingress.yaml
+  - hpa-backend.yaml
+  - hpa-frontend.yaml

--- a/docker/eks/namespace.yaml
+++ b/docker/eks/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secman
+  labels:
+    app.kubernetes.io/name: secman

--- a/docker/eks/secrets-setup.sh
+++ b/docker/eks/secrets-setup.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# =============================================================================
+# Secman EKS — create AWS Secrets Manager secrets + the IRSA role that lets
+# External Secrets Operator read them
+# =============================================================================
+#   export AWS_REGION=eu-central-1
+#   export EKS_CLUSTER_NAME=secman        # must match docker/eks/cluster.yaml
+#   ./docker/eks/secrets-setup.sh
+#   ./docker/eks/secrets-setup.sh --optional   # also prompts for SMTP/OpenRouter
+#
+# Idempotent — skips secrets/policies that already exist. Uses the same
+# secman/* secret names as docs/DOCKER_AWS_DEPLOY_RUNBOOK.md (Step 5), so an
+# ECS deployment and this EKS deployment can share one set of secrets.
+#
+# Requires: the EKS cluster already exists with iam.withOIDC: true (see
+# docker/eks/cluster.yaml / cluster-up.sh) — the OIDC provider must be
+# associated before the IRSA trust policy below can reference it.
+# =============================================================================
+
+set -euo pipefail
+
+: "${AWS_REGION:?Set AWS_REGION}"
+: "${EKS_CLUSTER_NAME:?Set EKS_CLUSTER_NAME (must match docker/eks/cluster.yaml metadata.name)}"
+ACCOUNT_ID="${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}"
+
+create_secret_if_missing() {
+  local name="$1" value="$2"
+  if aws secretsmanager describe-secret --secret-id "$name" --region "$AWS_REGION" >/dev/null 2>&1; then
+    echo "[secrets-setup] $name already exists — skipping."
+  else
+    aws secretsmanager create-secret --name "$name" --secret-string "$value" --region "$AWS_REGION" >/dev/null
+    echo "[secrets-setup] Created $name."
+  fi
+}
+
+echo "[secrets-setup] Creating secman/* secrets in Secrets Manager ($AWS_REGION)..."
+read -rsp "RDS password for the 'secman' DB user (Step 3 of docs/DOCKER_EKS.md): " DB_PW; echo
+create_secret_if_missing secman/db-password "$DB_PW"
+create_secret_if_missing secman/jwt-secret "$(openssl rand -base64 32)"
+create_secret_if_missing secman/enc-password "$(openssl rand -hex 32)"
+create_secret_if_missing secman/enc-salt "$(openssl rand -hex 8)"
+
+if [[ "${1:-}" == "--optional" ]]; then
+  read -rsp "SMTP password (blank to skip): " SMTP_PW; echo
+  [[ -n "$SMTP_PW" ]] && create_secret_if_missing secman/smtp-password "$SMTP_PW"
+  read -rsp "OpenRouter API key (blank to skip): " OR_KEY; echo
+  [[ -n "$OR_KEY" ]] && create_secret_if_missing secman/openrouter-key "$OR_KEY"
+fi
+
+echo "[secrets-setup] Creating IAM policy scoped to secman/* secrets..."
+POLICY_FILE="$(mktemp)"
+cat > "$POLICY_FILE" <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+    "Resource": "arn:aws:secretsmanager:$AWS_REGION:$ACCOUNT_ID:secret:secman/*"
+  }]
+}
+JSON
+
+aws iam create-policy \
+  --policy-name secmanExternalSecretsPolicy \
+  --policy-document "file://$POLICY_FILE" >/dev/null 2>&1 \
+  || echo "[secrets-setup] Policy secmanExternalSecretsPolicy already exists — skipping."
+rm -f "$POLICY_FILE"
+
+echo "[secrets-setup] Creating IRSA role for the secman-external-secrets ServiceAccount..."
+OIDC_ISSUER=$(aws eks describe-cluster --name "$EKS_CLUSTER_NAME" --region "$AWS_REGION" \
+  --query "cluster.identity.oidc.issuer" --output text)
+OIDC_ID="${OIDC_ISSUER#https://}"
+OIDC_PROVIDER_ARN="arn:aws:iam::$ACCOUNT_ID:oidc-provider/$OIDC_ID"
+
+TRUST_FILE="$(mktemp)"
+cat > "$TRUST_FILE" <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "$OIDC_PROVIDER_ARN" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "$OIDC_ID:sub": "system:serviceaccount:secman:secman-external-secrets",
+        "$OIDC_ID:aud": "sts.amazonaws.com"
+      }
+    }
+  }]
+}
+JSON
+
+aws iam create-role \
+  --role-name secmanExternalSecretsRole \
+  --assume-role-policy-document "file://$TRUST_FILE" >/dev/null 2>&1 \
+  || echo "[secrets-setup] Role secmanExternalSecretsRole already exists — trust policy NOT updated, delete+re-run if the OIDC provider changed."
+rm -f "$TRUST_FILE"
+
+aws iam attach-role-policy \
+  --role-name secmanExternalSecretsRole \
+  --policy-arn "arn:aws:iam::$ACCOUNT_ID:policy/secmanExternalSecretsPolicy"
+
+echo ""
+echo "[secrets-setup] Done. Set this role ARN in docker/eks/serviceaccount.yaml"
+echo "(eks.amazonaws.com/role-arn annotation):"
+echo "  arn:aws:iam::$ACCOUNT_ID:role/secmanExternalSecretsRole"

--- a/docker/eks/secretstore.yaml
+++ b/docker/eks/secretstore.yaml
@@ -1,0 +1,16 @@
+# External Secrets Operator must already be installed in the cluster (Helm
+# chart `external-secrets/external-secrets`) — see docs/DOCKER_EKS.md.
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: secman-secrets-manager
+  namespace: secman
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: REPLACE_WITH_AWS_REGION
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: secman-external-secrets

--- a/docker/eks/service-backend.yaml
+++ b/docker/eks/service-backend.yaml
@@ -1,0 +1,14 @@
+# Name matters: docker/frontend/nginx.conf proxies /api,/oauth,/mcp,/health
+# to `secman-backend:8080` verbatim (same DNS name used in docker compose) —
+# do not rename this Service without also updating nginx.conf.
+apiVersion: v1
+kind: Service
+metadata:
+  name: secman-backend
+  namespace: secman
+spec:
+  selector:
+    app: secman-backend
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/docker/eks/service-frontend.yaml
+++ b/docker/eks/service-frontend.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: secman-frontend
+  namespace: secman
+spec:
+  selector:
+    app: secman-frontend
+  ports:
+    - port: 8443
+      targetPort: 8443

--- a/docker/eks/serviceaccount.yaml
+++ b/docker/eks/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# IRSA-annotated ServiceAccount used by the External Secrets Operator
+# SecretStore (secretstore.yaml) to read AWS Secrets Manager without any
+# static AWS keys in the cluster. The role is created by
+# docker/eks/secrets-setup.sh — replace the placeholder ARN after running it.
+#
+# Extend this pattern (a new ServiceAccount + IRSA role) if the backend
+# itself ever needs direct AWS API access (e.g. S3 for user-mapping imports,
+# docs/S3_USER_MAPPING_IMPORT.md) — do not widen this role's permissions for
+# that; it should stay scoped to `secman/*` secrets only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secman-external-secrets
+  namespace: secman
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::REPLACE_WITH_ACCOUNT_ID:role/secmanExternalSecretsRole"

--- a/docker/eks/teardown.sh
+++ b/docker/eks/teardown.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# =============================================================================
+# Secman EKS — tear down the app, optionally the whole cluster
+# =============================================================================
+#   ./docker/eks/teardown.sh                   # delete only the app (this kustomization)
+#   ./docker/eks/teardown.sh --delete-cluster   # also delete the EKS cluster
+#
+# Cluster deletion is irreversible and removes billable AWS resources —
+# gated behind an explicit flag and a typed confirmation, never silent.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[teardown] kubectl delete -k $SCRIPT_DIR"
+kubectl delete -k "$SCRIPT_DIR" --ignore-not-found
+
+if [[ "${1:-}" == "--delete-cluster" ]]; then
+  CLUSTER_NAME=$(awk '/^metadata:/{f=1} f && /name:/{print $2; exit}' "$SCRIPT_DIR/cluster.yaml")
+  echo "[teardown] About to delete the ENTIRE EKS cluster '$CLUSTER_NAME' ($SCRIPT_DIR/cluster.yaml)."
+  echo "[teardown] This is irreversible and removes the control plane + Fargate profile."
+  read -rp "Type the cluster name to confirm: " CONFIRM_NAME
+  if [[ "$CONFIRM_NAME" != "$CLUSTER_NAME" ]]; then
+    echo "[teardown] Name did not match '$CLUSTER_NAME' — aborting cluster deletion."
+    exit 1
+  fi
+  eksctl delete cluster -f "$SCRIPT_DIR/cluster.yaml"
+fi

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,5 +1,13 @@
 # Secman Frontend Container
-# Multi-stage build: Node build → Nginx with SSL
+# Multi-stage build: Node build → Nginx + Node SSR server, both supervised
+# by docker/frontend/entrypoint.sh.
+#
+# Astro is configured with `output: "server"` (astro.config.mjs) — it is NOT
+# a static site. The build produces:
+#   dist/client/  static assets (served directly by nginx)
+#   dist/server/  the SSR entry point (must be run by Node — nginx alone
+#                 cannot render these pages). This runtime stage runs both,
+#                 same pattern as docker/aws/Dockerfile's entrypoint.
 FROM node:22-alpine AS builder
 
 WORKDIR /build
@@ -13,17 +21,23 @@ RUN npm ci --production=false
 # Copy frontend source
 COPY src/frontend/ ./
 
-# Build the Astro site
-RUN npm run build
+# Build the Astro site (dist/client + dist/server), then drop devDependencies —
+# the standalone Node adapter externalizes some packages, so production
+# node_modules must ship alongside dist/server for those to resolve at runtime.
+RUN npm run build \
+ && npm prune --omit=dev
 
-# --- Runtime stage: Nginx ---
-FROM nginx:1.27-alpine
+# --- Runtime stage: Nginx + Node SSR, both supervised ---
+# node:22-alpine (not nginx:1.27-alpine) so the SSR server runs the exact
+# same Node version it was built/pruned against; nginx is installed via apk.
+FROM node:22-alpine
 
 LABEL maintainer="secman"
-LABEL description="Secman frontend with Nginx reverse proxy (HTTPS)"
+LABEL description="Secman frontend: Nginx (TLS + static assets) + Astro SSR Node server"
 
-# Install openssl for self-signed cert generation
-RUN apk add --no-cache openssl curl
+# nginx + openssl (self-signed cert) + curl (HEALTHCHECK) + bash (entrypoint
+# uses `wait -n`, which Alpine's default busybox ash does not support)
+RUN apk add --no-cache nginx openssl curl bash
 
 # Create SSL directory
 RUN mkdir -p /etc/nginx/ssl
@@ -38,12 +52,20 @@ RUN openssl req -x509 -nodes -days 3650 \
 # Copy Nginx configuration
 COPY docker/frontend/nginx.conf /etc/nginx/nginx.conf
 
-# Copy built frontend assets from builder
-# Astro with Node adapter builds to dist/client (static) and dist/server (SSR)
-# For Nginx we serve the client assets statically and proxy SSR to backend
-COPY --from=builder /build/dist/client /usr/share/nginx/html
+# Astro build output (server + client) and production node_modules — same
+# layout as docker/aws/Dockerfile so entry.mjs resolves its dependencies via
+# Node's directory walk-up to /app/node_modules.
+WORKDIR /app
+COPY --from=builder /build/dist /app/frontend
+COPY --from=builder /build/node_modules /app/node_modules
+COPY --from=builder /build/package.json /app/package.json
+
+COPY docker/frontend/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8443
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=6 --start-period=10s \
+HEALTHCHECK --interval=10s --timeout=5s --retries=6 --start-period=15s \
   CMD curl -kf https://localhost:8443/ || exit 1
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/frontend/entrypoint.sh
+++ b/docker/frontend/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Secman frontend container entrypoint.
+# Starts the Astro SSR Node server and nginx, then exits as soon as EITHER
+# dies — the orchestrator (docker run --restart / compose / Kubernetes)
+# restarts the container rather than running with a half-broken frontend.
+# Same pattern as docker/aws/entrypoint.sh, trimmed to two processes.
+set -u
+
+echo "[entrypoint] starting Astro SSR server on 127.0.0.1:4321"
+# Bound to loopback: only nginx is reachable from outside the container.
+HOST=127.0.0.1 PORT=4321 node /app/frontend/server/entry.mjs &
+SSR_PID=$!
+
+echo "[entrypoint] starting nginx on :8443"
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+term() {
+    echo "[entrypoint] caught signal, shutting down"
+    kill "$NGINX_PID" "$SSR_PID" 2>/dev/null
+    wait
+    exit 0
+}
+trap term TERM INT
+
+# Exit when the first child exits; propagate a failure exit code.
+wait -n
+STATUS=$?
+echo "[entrypoint] a service exited (status $STATUS) — stopping container"
+kill "$NGINX_PID" "$SSR_PID" 2>/dev/null
+wait
+exit "$STATUS"

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -24,9 +24,16 @@ http {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
     gzip_min_length 1000;
 
-    # Upstream backend
+    # Upstream backend — same DNS name in docker compose (service `backend`
+    # aliased `secman-backend`, see docker-compose.split.yaml) and in EKS
+    # (Kubernetes Service `secman-backend`), so this file needs no templating.
     upstream backend {
         server secman-backend:8080;
+    }
+
+    # Astro SSR server, started by entrypoint.sh in this same container.
+    upstream frontend_ssr {
+        server 127.0.0.1:4321;
     }
 
     # Redirect HTTP to HTTPS
@@ -52,14 +59,18 @@ http {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-        # API requests → backend
+        # API requests → backend.
+        # proxy_buffering off + a long read timeout keep the SSE endpoints
+        # (/api/exception-badge-updates, /api/.../progress) streaming.
         location /api/ {
             proxy_pass http://backend;
+            proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 120s;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
             proxy_connect_timeout 10s;
         }
 
@@ -72,13 +83,15 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # MCP requests → backend
+        # MCP (streamable HTTP / JSON-RPC) → backend
         location /mcp {
             proxy_pass http://backend;
+            proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
             proxy_read_timeout 300s;
         }
 
@@ -87,18 +100,33 @@ http {
             proxy_pass http://backend;
         }
 
-        # Static frontend assets
-        location / {
-            root /usr/share/nginx/html;
-            index index.html;
-            try_files $uri $uri/ /index.html;
+        # Hashed immutable build assets straight from disk
+        location /_astro/ {
+            root /app/frontend/client;
+            expires 30d;
+            add_header Cache-Control "public, immutable";
         }
 
-        # Cache static assets
+        # Other static files (favicon, fonts, images placed in public/)
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-            root /usr/share/nginx/html;
+            root /app/frontend/client;
             expires 7d;
-            add_header Cache-Control "public, immutable";
+            add_header Cache-Control "public";
+            try_files $uri @ssr;
+        }
+
+        # Everything else: server-side rendered pages (Astro is `output:
+        # "server"` — there is no static index.html to fall back to).
+        location / {
+            try_files /nonexistent @ssr;
+        }
+
+        location @ssr {
+            proxy_pass http://frontend_ssr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }

--- a/docker/generate-env.sh
+++ b/docker/generate-env.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# =============================================================================
+# Secman Docker — shared secret-generation helper
+# =============================================================================
+# Sourced by docker/compose-up.sh and docker/compose-up-split.sh — not meant
+# to be run directly.
+#
+#   source "$SCRIPT_DIR/generate-env.sh"
+#   secman_ensure_env_file "$ENV_FILE" "$ENV_EXAMPLE" "$MODE"
+#
+# Creates $ENV_FILE from $ENV_EXAMPLE (if missing) with freshly generated
+# secrets (JWT, encryption password/salt, DB passwords). No-op if $ENV_FILE
+# already exists — both callers share this one file, so a secret generated
+# for one flow is reused by the other instead of being regenerated.
+# =============================================================================
+
+# A portable random secret generator: openssl if present, else /dev/urandom.
+secman_gen() {
+  local kind="$1"
+  if command -v openssl >/dev/null 2>&1; then
+    case "$kind" in
+      b64_32) openssl rand -base64 32 ;;
+      hex_32) openssl rand -hex 32 ;;
+      hex_8)  openssl rand -hex 8 ;;
+      hex_12) openssl rand -hex 12 ;;
+    esac
+  else
+    case "$kind" in
+      b64_32) head -c 32 /dev/urandom | base64 ;;
+      hex_32) head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+      hex_8)  head -c 8  /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+      hex_12) head -c 12 /dev/urandom | od -An -tx1 | tr -d ' \n' ;;
+    esac
+  fi
+}
+
+# sed -i portability (GNU vs BSD/macOS)
+secman_sedi() {
+  if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
+}
+
+secman_ensure_env_file() {
+  local env_file="$1" env_example="$2" mode="${3:-}"
+
+  if [[ -f "$env_file" ]]; then
+    return 0
+  fi
+
+  echo "[generate-env] $env_file not found — creating it from $(basename "$env_example") with fresh secrets."
+  cp "$env_example" "$env_file"
+
+  local jwt enc_pw enc_salt db_pw db_root_pw
+  jwt="$(secman_gen b64_32)"
+  enc_pw="$(secman_gen hex_32)"
+  enc_salt="$(secman_gen hex_8)"
+  db_pw="$(secman_gen hex_12)"
+  db_root_pw="$(secman_gen hex_12)"
+
+  set_kv() { secman_sedi "s|^$1=.*|$1=$2|" "$env_file"; }
+
+  set_kv JWT_SECRET "$jwt"
+  set_kv SECMAN_ENCRYPTION_PASSWORD "$enc_pw"
+  set_kv SECMAN_ENCRYPTION_SALT "$enc_salt"
+  set_kv DB_PASSWORD "$db_pw"
+  set_kv DB_ROOT_PASSWORD "$db_root_pw"
+
+  echo "[generate-env] Wrote $env_file. Review it (URLs, DB_CONNECT, SMTP, etc.) before production use."
+  if [[ "$mode" == "rds" ]]; then
+    echo "[generate-env] RDS mode: edit DB_CONNECT/DB_USERNAME/DB_PASSWORD in $env_file to match your RDS instance."
+  fi
+}

--- a/docker/start-backend.sh
+++ b/docker/start-backend.sh
@@ -11,9 +11,16 @@ set -euo pipefail
 CONTAINER_NAME="secman-backend"
 NETWORK_NAME="secman-net"
 
-# Configurable via environment
-DB_PASSWORD="${SECMAN_DB_PASSWORD:-secman-docker-pw}"
-JWT_SECRET="${SECMAN_JWT_SECRET:-docker-secman-jwt-secret-must-be-at-least-256-bits-long-for-hs256}"
+# Required — no baked-in default. DB_PASSWORD/JWT_SECRET avoid shipping a
+# well-known password; SECMAN_ENCRYPTION_PASSWORD/SALT avoid the equally
+# well-known application.yml fallback ("SecManDefaultEncryptionPassword2024")
+# that encrypts stored credentials (OAuth secrets, API keys) when unset.
+: "${SECMAN_DB_PASSWORD:?Set SECMAN_DB_PASSWORD to the same value used by start-database.sh}"
+: "${SECMAN_JWT_SECRET:?Set SECMAN_JWT_SECRET, e.g. export SECMAN_JWT_SECRET=\$(openssl rand -base64 32)}"
+: "${SECMAN_ENCRYPTION_PASSWORD:?Set SECMAN_ENCRYPTION_PASSWORD, e.g. export SECMAN_ENCRYPTION_PASSWORD=\$(openssl rand -hex 32)}"
+: "${SECMAN_ENCRYPTION_SALT:?Set SECMAN_ENCRYPTION_SALT (exactly 16 hex chars), e.g. export SECMAN_ENCRYPTION_SALT=\$(openssl rand -hex 8)}"
+DB_PASSWORD="$SECMAN_DB_PASSWORD"
+JWT_SECRET="$SECMAN_JWT_SECRET"
 
 echo "[backend] Starting $CONTAINER_NAME..."
 
@@ -40,6 +47,8 @@ docker run -d \
   -e DB_USERNAME=secman \
   -e DB_PASSWORD="$DB_PASSWORD" \
   -e JWT_SECRET="$JWT_SECRET" \
+  -e SECMAN_ENCRYPTION_PASSWORD="$SECMAN_ENCRYPTION_PASSWORD" \
+  -e SECMAN_ENCRYPTION_SALT="$SECMAN_ENCRYPTION_SALT" \
   -e SECMAN_AUTH_COOKIE_SECURE=false \
   -e FRONTEND_URL="https://localhost:8443" \
   -e SECMAN_BACKEND_URL="https://localhost:8443" \

--- a/docker/start-database.sh
+++ b/docker/start-database.sh
@@ -12,9 +12,11 @@ CONTAINER_NAME="secman-db"
 NETWORK_NAME="secman-net"
 VOLUME_NAME="secman-db-data"
 
-# Configurable via environment
-DB_ROOT_PASSWORD="${SECMAN_DB_ROOT_PASSWORD:-secman-root-pw}"
-DB_PASSWORD="${SECMAN_DB_PASSWORD:-secman-docker-pw}"
+# Required — no baked-in default (avoids shipping a well-known password).
+: "${SECMAN_DB_ROOT_PASSWORD:?Set SECMAN_DB_ROOT_PASSWORD, e.g. export SECMAN_DB_ROOT_PASSWORD=\$(openssl rand -hex 12)}"
+: "${SECMAN_DB_PASSWORD:?Set SECMAN_DB_PASSWORD, e.g. export SECMAN_DB_PASSWORD=\$(openssl rand -hex 12)}"
+DB_ROOT_PASSWORD="$SECMAN_DB_ROOT_PASSWORD"
+DB_PASSWORD="$SECMAN_DB_PASSWORD"
 
 echo "[database] Starting $CONTAINER_NAME..."
 

--- a/docs/DOCKER_EKS.md
+++ b/docs/DOCKER_EKS.md
@@ -1,0 +1,342 @@
+# Deploying Secman to AWS EKS/Fargate — Step-by-Step Runbook
+
+A single, sequential, copy-paste procedure for getting Secman running on
+**Amazon EKS with Fargate**: two Kubernetes Deployments (frontend, backend)
+on serverless Fargate compute, fronted by an ALB, with the database on
+**Amazon RDS** and secrets synced from **AWS Secrets Manager** via the
+**External Secrets Operator**.
+
+This is the Kubernetes-native counterpart to
+[docs/DOCKER_AWS_DEPLOY_RUNBOOK.md](DOCKER_AWS_DEPLOY_RUNBOOK.md) (which
+deploys the same app to ECS/Fargate instead). Read
+[EKS vs ECS/Fargate](#eks-vs-ecsfargate) first if you haven't already decided
+which one you want — for most Secman-only deployments, **ECS/Fargate is the
+simpler default**; use this runbook if you're standardizing on Kubernetes.
+
+```
+                                     ┌────────────────── EKS Fargate ──────────────────┐
+ALB (TLS :443, ACM cert)  ─────────► │  Deployment: secman-frontend (nginx + Astro SSR) │
+  re-encrypts HTTPS to :8443         │    Service: secman-frontend :8443                │
+                                     │       │                                          │
+                                     │       ▼ (nginx proxies /api,/oauth,/mcp,/health)  │
+                                     │  Deployment: secman-backend (Micronaut)           │
+                                     │    Service: secman-backend :8080                  │
+                                     └───────┼──────────────────────────────────────────┘
+                                             ▼
+                                     Amazon RDS (MariaDB 11.4)
+
+External Secrets Operator syncs secman/* AWS Secrets Manager entries into a
+native `secman-secrets` Kubernetes Secret (IRSA, no static AWS keys).
+```
+
+---
+
+## Step 0 — Prerequisites
+
+- **Tools**: `aws` CLI v2, `eksctl`, `kubectl`, `helm`, `docker`, `openssl`.
+- **A VPC** with private subnets (for the Fargate pods and RDS) and public
+  subnets (for the ALB) — same requirement as the ECS runbook's Step 0.
+- **An ACM certificate** for your public hostname (e.g. `secman.example.com`)
+  in the deployment region.
+- **Build host RAM**: the backend JAR build needs ~4 GB (same Gradle/Kotlin
+  compile as every other Secman image).
+
+Set these shell variables once and reuse them throughout:
+
+```bash
+export AWS_REGION=eu-central-1
+export EKS_CLUSTER_NAME=secman
+export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export PUBLIC_URL=https://secman.example.com   # your real public hostname
+```
+
+---
+
+## Step 1 — Build and push the images
+
+```bash
+docker/eks/build-push.sh
+```
+
+Builds the backend JAR, builds `docker/backend/Dockerfile` and
+`docker/frontend/Dockerfile` (the same split images used by
+`docker-compose.split.yaml` for local/macOS use — see `docker/README.md`),
+and pushes both to ECR (`secman-backend`, `secman-frontend`).
+
+**Apple Silicon**: Fargate defaults to x86_64 — `export
+BUILD_PLATFORM=linux/amd64` before running the script, or run Fargate on
+ARM64 (add `runtimePlatform: { cpuArchitecture: ARM64 }` per-pod isn't a
+thing in K8s the way it is in ECS task defs; instead set
+`spec.template.spec.nodeSelector.kubernetes.io/arch: arm64` in
+`deployment-*.yaml` if you build ARM64 images and want Fargate to match).
+
+---
+
+## Step 2 — Provision the database (RDS MariaDB)
+
+Identical to the ECS runbook's Step 3: an RDS **MariaDB 11.4** instance
+(`db.t3.small` to start), an **empty** `secman` database (Hibernate
+auto-DDL creates the schema on first boot — leave
+`FLYWAY_DATASOURCES_DEFAULT_ENABLED=false`), and a security group that will
+allow inbound 3306 from the EKS pods' security group (Fargate pods get their
+own ENI/security group via `awsvpc`-style networking — the exact SG is
+determined by the cluster's Fargate pod execution role/subnet config; the
+simplest approach is to allow the whole VPC CIDR on 3306, or the specific
+subnets the Fargate profile uses).
+
+```
+jdbc:mariadb://mydb.xyz.eu-central-1.rds.amazonaws.com:3306/secman
+```
+
+---
+
+## Step 3 — Create the cluster
+
+```bash
+# Edit docker/eks/cluster.yaml: set region to $AWS_REGION.
+docker/eks/cluster-up.sh
+```
+
+Creates the EKS control plane + a Fargate profile scoped to the `secman` and
+`kube-system` namespaces, and associates an OIDC provider (`iam.withOIDC:
+true`) for IRSA. Takes ~15-20 minutes.
+
+**Fargate constraint to know up front**: pods only schedule into namespaces
+matched by a Fargate profile. Every add-on below (`aws-load-balancer-controller`,
+`external-secrets`) is installed into `kube-system` specifically so it lands
+on Fargate too — installing an add-on into its own namespace (a common Helm
+chart default) will leave it permanently `Pending` on a Fargate-only
+cluster, since there are no EC2 nodes to fall back to.
+
+---
+
+## Step 4 — Install cluster add-ons
+
+### AWS Load Balancer Controller (provisions the ALB from `Ingress`)
+
+```bash
+curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.9.0/docs/install/iam_policy.json
+aws iam create-policy --policy-name AWSLoadBalancerControllerIAMPolicy \
+  --policy-document file://iam_policy.json
+
+eksctl create iamserviceaccount \
+  --cluster "$EKS_CLUSTER_NAME" --region "$AWS_REGION" \
+  --namespace kube-system --name aws-load-balancer-controller \
+  --attach-policy-arn "arn:aws:iam::$ACCOUNT_ID:policy/AWSLoadBalancerControllerIAMPolicy" \
+  --approve
+
+helm repo add eks https://aws.github.io/eks-charts && helm repo update
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName="$EKS_CLUSTER_NAME" \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller
+```
+
+### External Secrets Operator (syncs Secrets Manager → Kubernetes Secret)
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io && helm repo update
+# -n kube-system (not --create-namespace into its own namespace) — see the
+# Fargate constraint above.
+helm install external-secrets external-secrets/external-secrets -n kube-system
+```
+
+Verify both are running (should be `Running`, not `Pending`):
+
+```bash
+kubectl -n kube-system get pods -l app.kubernetes.io/name=aws-load-balancer-controller
+kubectl -n kube-system get pods -l app.kubernetes.io/name=external-secrets
+```
+
+---
+
+## Step 5 — Create secrets and the ESO IRSA role
+
+```bash
+docker/eks/secrets-setup.sh
+# or, to also set SMTP/OpenRouter secrets:
+docker/eks/secrets-setup.sh --optional
+```
+
+Creates the same `secman/db-password`, `secman/jwt-secret`,
+`secman/enc-password`, `secman/enc-salt` secrets in Secrets Manager as the
+ECS runbook (Step 4 there), an IAM policy scoped to `secman/*`, and an IRSA
+role (`secmanExternalSecretsRole`) trusting the cluster's OIDC provider for
+the `system:serviceaccount:secman:secman-external-secrets` identity.
+
+> ⚠️ **Never rotate** `SECMAN_ENCRYPTION_PASSWORD` (`enc-password`) or
+> `SECMAN_ENCRYPTION_SALT` (`enc-salt`) after data exists — same warning as
+> the ECS runbook.
+
+---
+
+## Step 6 — Fill in the manifest placeholders
+
+Every `REPLACE_WITH_*` token in `docker/eks/*.yaml` needs a real value:
+
+| File | Placeholder | Value |
+|---|---|---|
+| `configmap.yaml` | `DB_CONNECT` | the RDS JDBC URL from Step 2 |
+| `configmap.yaml` | `FRONTEND_URL`, `SECMAN_BACKEND_URL` | `$PUBLIC_URL` |
+| `serviceaccount.yaml` | `role-arn` | the role ARN printed by `secrets-setup.sh` |
+| `secretstore.yaml` | `region` | `$AWS_REGION` |
+| `deployment-backend.yaml`, `deployment-frontend.yaml` | `image:` | the ECR image URIs printed by `build-push.sh` |
+| `ingress.yaml` | `certificate-arn` | your ACM certificate ARN |
+
+`docker/eks/deploy.sh` refuses to run while any `REPLACE_WITH_*` token
+remains, so it's safe to just try it and fix whatever it flags.
+
+---
+
+## Step 7 — Deploy
+
+```bash
+docker/eks/deploy.sh
+```
+
+Applies `docker/eks/` via `kubectl apply -k`, waits for both Deployments to
+roll out, and polls for the ALB hostname (provisioning the ALB itself can
+take a few minutes on first apply). Point your DNS record (`secman.example.com`)
+at the printed hostname.
+
+---
+
+## Step 8 — Verify
+
+```bash
+kubectl -n secman get pods                 # both Deployments Running
+kubectl -n secman get externalsecret        # secman-secrets: SecretSynced
+kubectl -n secman describe ingress secman   # ALB provisioned, target groups healthy
+curl -s "$PUBLIC_URL/health"                # => {"status":"UP"}
+```
+
+Then open `$PUBLIC_URL/` in a browser and log in.
+
+---
+
+## Updating to a new version
+
+```bash
+export IMAGE_TAG=$(git rev-parse --short HEAD)   # or any tag scheme you prefer
+docker/eks/build-push.sh
+# update image: in deployment-backend.yaml / deployment-frontend.yaml to $IMAGE_TAG
+docker/eks/deploy.sh
+```
+
+Kubernetes does a rolling replacement of each Deployment; the ALB only shifts
+traffic to a new pod once its readiness probe passes. Pinning an immutable
+tag (a git SHA, not `:latest`) is safer for auditable rollbacks — the same
+guidance as the ECS runbook.
+
+---
+
+## Fargate constraints
+
+- **No persistent volumes.** Fargate pods get ephemeral storage only — no
+  EBS-backed `PersistentVolume`. This is *why* the database is RDS here
+  rather than a third in-cluster container; see [Appendix A](#appendix-a-running-the-database-in-cluster-instead-of-rds)
+  if you specifically want the database as a real container anyway.
+- **No privileged pods, no `hostPort`, no `hostNetwork`.** None of this
+  app's manifests use them, so this is a non-issue here — just don't add any.
+- **`resources.requests` is mandatory**, not advisory — Fargate uses it to
+  pick a supported vCPU/memory combination for the pod. `limits == requests`
+  in this repo's manifests keeps `JAVA_OPTS`'s `MaxRAMPercentage` math
+  (`configmap.yaml`) predictable.
+- **Namespace-scoped scheduling.** A pod only runs on Fargate if its
+  namespace matches a Fargate profile selector (Step 3's constraint,
+  affects any future add-on you install too).
+- **Subnet/ENI sizing.** Each Fargate pod gets its own ENI; make sure the
+  subnets in your Fargate profile have enough free IPs for
+  `replicas × (frontend + backend)` plus headroom for rolling deploys.
+
+---
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Add-on pod stuck `Pending` forever | Its namespace isn't matched by the Fargate profile (Step 3) — Fargate has no node to fall back to |
+| `kubectl apply -k` fails with a `REPLACE_WITH_*` error from `deploy.sh` | Fill in the placeholder table in Step 6 |
+| Backend pod `CrashLoopBackOff` | `kubectl -n secman logs deploy/secman-backend` — almost always DB unreachable (`DB_CONNECT`, RDS security group) or a malformed `JAVA_OPTS` |
+| `ExternalSecret` status isn't `SecretSynced` | `kubectl -n secman describe externalsecret secman-secrets` — usually the IRSA role ARN in `serviceaccount.yaml` is wrong, or the trust policy's namespace/name doesn't match `system:serviceaccount:secman:secman-external-secrets` |
+| ALB never gets a hostname | `kubectl -n kube-system logs deploy/aws-load-balancer-controller` — usually a missing ACM cert ARN, or the controller's IAM policy is missing a permission |
+| `502`/`504` from the ALB | Backend still booting (raise `initialDelaySeconds` on `deployment-backend.yaml`'s probes) or crashed — check backend logs |
+| Pages render but API calls return 401 | `SECMAN_AUTH_COOKIE_SECURE=true` while reaching the app over plain HTTP — go through the HTTPS ALB |
+| OAuth callback loops / wrong redirect, or emails contain `localhost` links | `FRONTEND_URL`/`SECMAN_BACKEND_URL` in `configmap.yaml` must be `$PUBLIC_URL`, not `localhost` |
+
+---
+
+## EKS vs ECS/Fargate
+
+Both run the exact same images and both are "serverless" (no EC2 instances
+to patch). The difference is entirely in operational surface:
+
+| | ECS/Fargate (`docs/DOCKER_AWS.md`) | EKS/Fargate (this doc) |
+|---|---|---|
+| Control plane cost | None (ECS control plane is free) | ~$0.10/hr per cluster |
+| Extra components to run | None — task def + ALB is the whole stack | AWS Load Balancer Controller, External Secrets Operator (both need installing/upgrading) |
+| Secrets | Directly in the task definition's `secrets` block | Via `ExternalSecret`/`SecretStore` CRDs (one more layer) |
+| Tooling | AWS CLI / Console | kubectl, Helm, eksctl — useful if you already run other K8s workloads |
+| Best fit | Secman is your only (or first) container workload on AWS | You're already standardizing infrastructure on Kubernetes |
+
+**Recommendation**: stay on ECS/Fargate unless you have another reason to
+run Kubernetes — EKS adds real operational surface (IRSA per add-on, add-on
+version upgrades, one more control plane to reason about) for an equivalent
+running workload.
+
+---
+
+## Appendix A — Running the database in-cluster instead of RDS
+
+Fargate cannot back a stateful `MariaDB` pod with persistent storage (see
+[Fargate constraints](#fargate-constraints)), so a genuine third
+"database container" that survives pod restarts needs a small **managed EC2
+node group** in the same cluster, running alongside the Fargate profile:
+
+```
+Cluster
+├── Fargate profile (namespace: secman)
+│    ├── Deployment: secman-frontend
+│    └── Deployment: secman-backend
+└── Managed node group (e.g. 1-2 × t3.small, EBS gp3)
+     └── StatefulSet: secman-db (MariaDB 11.4, PVC via the EBS CSI driver)
+```
+
+This repo's default manifests don't ship this — RDS is simpler and has
+better durability/backup/patching built in — but if you want it:
+
+1. Add a managed node group to `docker/eks/cluster.yaml` (`nodeGroups:`),
+   sized for MariaDB's working set.
+2. Install the [EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
+   add-on (`eksctl create addon --name aws-ebs-csi-driver ...`) with its own
+   IRSA role.
+3. Add a `StatefulSet` (reuse `docker/database/Dockerfile`'s image) with a
+   `volumeClaimTemplate` requesting a `gp3` `StorageClass`, and a headless
+   `Service` for stable DNS (`secman-db-0.secman-db.secman.svc.cluster.local`).
+4. Point `configmap.yaml`'s `DB_CONNECT` at that service instead of RDS, and
+   drop the RDS provisioning step (Step 2) entirely.
+5. Take EBS volume snapshots on a schedule (there is no RDS-style automated
+   backup here) — see the backup suggestion in `docker/README.md`'s
+   [Suggestions](../docker/README.md#suggestions--other-deployment-targets) section.
+
+---
+
+## Appendix B — Optional feature secrets/config
+
+Add these to `configmap.yaml` (non-secret) or as extra `ExternalSecret` data
+entries pulling from a new `secman/*` Secrets Manager entry (secret) — see
+`docs/ENVIRONMENT.md` for the full catalog:
+
+| Purpose | Variables |
+|---|---|
+| E-mail notifications | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` (secret), `SMTP_FROM_ADDRESS`, `SMTP_ENABLE_TLS` |
+| AI-assisted risk assessment | `OPENROUTER_API_KEY` (secret) + `AI_RISK_ASSESSMENT_ENABLED=true` |
+| CrowdStrike Falcon | `FALCON_CLIENT_ID`, `FALCON_CLIENT_SECRET` (secret), `FALCON_CLOUD_REGION` |
+
+---
+
+*See also: `docker/README.md` (all Docker/Kubernetes options + non-AWS
+suggestions), `docs/DOCKER_AWS.md` + `docs/DOCKER_AWS_DEPLOY_RUNBOOK.md`
+(the ECS/Fargate equivalent), `docs/ENVIRONMENT.md` (full variable
+catalog), `docs/AWS_SECRETS_SETUP.md`.*


### PR DESCRIPTION
## Summary

- **Hardened `docker/backend` and `docker/database` Dockerfiles** — dropped baked-in default secrets (`DB_PASSWORD`, `JWT_SECRET`, `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD`) so credentials always have to be injected at runtime rather than falling back to well-known values.
- **Fixed `docker/frontend` to actually serve SSR** — it previously only served the static Astro client build via nginx, even though `astro.config.mjs` uses `output: "server"`. It now runs the Astro Node SSR server alongside nginx (new `entrypoint.sh`, same supervision pattern as `docker/aws/entrypoint.sh`), with `nginx.conf` gaining the `@ssr` fallback route.
- **New split (3-container) Docker Compose flow for macOS/local dev** — `docker/docker-compose.split.yaml` + `docker/compose-up-split.sh` bring up real, separate database/backend/frontend containers, sharing the same `docker/.env` secrets file the existing all-in-one compose flow uses. Extracted the secret-generation logic into `docker/generate-env.sh` so both flows reuse it.
- **Manual `start-database.sh`/`start-backend.sh` scripts now require secrets** instead of silently defaulting to weak passwords, including `SECMAN_ENCRYPTION_PASSWORD`/`SECMAN_ENCRYPTION_SALT` (previously never set by these scripts, so the backend silently fell back to a well-known constant in `application.yml`).
- **New AWS EKS/Fargate deployment** (`docker/eks/`) — Kubernetes manifests (namespace, ConfigMap, `ExternalSecret`/`SecretStore` pulling from AWS Secrets Manager via IRSA, backend + frontend Deployments/Services on Fargate, ALB `Ingress`, optional HPAs, `kustomization.yaml`), an eksctl cluster config, and `build-push.sh`/`secrets-setup.sh`/`cluster-up.sh`/`deploy.sh`/`teardown.sh` scripts. The database is Amazon RDS (Fargate pods have no persistent-volume support for a real in-cluster stateful DB).
- **`docs/DOCKER_EKS.md`** — step-by-step EKS/Fargate runbook mirroring `docs/DOCKER_AWS_DEPLOY_RUNBOOK.md`'s style, with Fargate-specific constraints, an EKS-vs-ECS/Fargate comparison (recommendation: stay on ECS/Fargate unless standardizing on Kubernetes), and an appendix on running the database in-cluster on a managed node group instead of RDS.
- **`docker/README.md`** — documents the new split-compose flow, macOS-specific notes (Colima, Apple Silicon build flags, memory sizing for the Gradle build stage), and a Suggestions section comparing non-AWS (VPS + Traefik/Caddy + Watchtower, k3s/k3d, Docker Swarm) and AWS (EKS Fargate vs EKS managed node groups vs ECS/Fargate) deployment targets.

All new Kubernetes/compose files use the `.yaml` extension (not `.yml`) — `.gitignore` blanket-ignores `*.yml` except two explicit exceptions, so this avoids fighting that.

## Test plan

- [x] YAML syntax validated for all new Kubernetes manifests and the split compose file (`python3 -c "yaml.safe_load_all(...)"`).
- [x] `docker compose -f docker/docker-compose.split.yaml --env-file <test.env> config` resolves correctly, and the `${VAR:?...}` required-secret checks fire as expected when a secret is missing.
- [x] All modified/new shell scripts pass `bash -n` syntax checks.
- [x] Verified every path a Dockerfile/compose build context references actually exists (`docker/database/init.sql`, `src/frontend/package.json`, etc.), and confirmed `src/frontend/astro.config.mjs` uses `@astrojs/node` in `standalone` mode (so `dist/server/entry.mjs` is the correct SSR entry point referenced by the new `entrypoint.sh`).
- [ ] **Not run**: actual `docker build`/`docker compose up` of the three images. This sandbox's network policy blocks Docker Hub (`registry-1.docker.io` returns 403 via the proxy), so the `mariadb:11.4` / `node:22-alpine` base images can't be pulled here. No `kubectl`/`kustomize`/`eksctl` binaries are available in this sandbox either, so the EKS manifests are validated for YAML syntax only, not applied against a real (or dry-run) cluster.
- No `src/` application code changed, so the repo's `/e2ejs`/`/e2evulnexception` gates don't apply (doc/infra-only per CLAUDE.md's exemption clause).

Given the last point, a real Docker build (`./docker/compose-up-split.sh`) and an `eksctl create cluster` + `kubectl apply -k docker/eks/ --dry-run=client` pass in an environment with registry/cluster access would be worth doing before this goes to a live deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpRiGi6tsaAZL4Jw64mTHp)_