### PR TITLE
Make startpage KPI cards configurable per user

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/DashboardPreferenceController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/DashboardPreferenceController.kt
@@ -1,0 +1,118 @@
+package com.secman.controller
+
+import com.secman.domain.DashboardPreference
+import com.secman.repository.DashboardPreferenceRepository
+import io.micronaut.http.annotation.*
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.inject.Singleton
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+/**
+ * Controller for managing per-user home dashboard KPI card visibility preferences
+ */
+@Singleton
+@Controller("/api/dashboard-preferences")
+@Secured(SecurityRule.IS_AUTHENTICATED)
+open class DashboardPreferenceController(
+    private val dashboardPreferenceRepository: DashboardPreferenceRepository
+) {
+    private val logger = LoggerFactory.getLogger(DashboardPreferenceController::class.java)
+
+    /**
+     * Get current user's dashboard KPI preferences
+     * Returns default values (both KPIs visible) if no preferences exist
+     */
+    @Get
+    fun getUserPreferences(authentication: Authentication): DashboardPreferenceResponse {
+        val userId = getUserIdFromAuthentication(authentication)
+
+        val preference = dashboardPreferenceRepository.findByUserId(userId)
+            .orElseGet {
+                // Return defaults if not found
+                DashboardPreference(userId = userId)
+            }
+
+        return DashboardPreferenceResponse.from(preference)
+    }
+
+    /**
+     * Update current user's dashboard KPI preferences
+     */
+    @Put
+    open fun updateUserPreferences(
+        @Valid @Body request: UpdatePreferenceRequest,
+        authentication: Authentication
+    ): DashboardPreferenceResponse {
+        val userId = getUserIdFromAuthentication(authentication)
+
+        val existing = dashboardPreferenceRepository.findByUserId(userId)
+
+        val preference = if (existing.isPresent) {
+            // Update existing
+            val updated = existing.get().copy(
+                showAwsCleanServerKpi = request.showAwsCleanServerKpi,
+                showEdrCoverageKpi = request.showEdrCoverageKpi,
+                updatedAt = Instant.now()
+            )
+            dashboardPreferenceRepository.update(updated)
+            updated
+        } else {
+            // Create new
+            val newPref = DashboardPreference(
+                userId = userId,
+                showAwsCleanServerKpi = request.showAwsCleanServerKpi,
+                showEdrCoverageKpi = request.showEdrCoverageKpi
+            )
+            dashboardPreferenceRepository.save(newPref)
+        }
+
+        logger.info("Updated dashboard preferences for user $userId: showAwsCleanServerKpi=${request.showAwsCleanServerKpi}, showEdrCoverageKpi=${request.showEdrCoverageKpi}")
+
+        return DashboardPreferenceResponse.from(preference)
+    }
+
+    @Serdeable
+    data class UpdatePreferenceRequest(
+        val showAwsCleanServerKpi: Boolean,
+        val showEdrCoverageKpi: Boolean
+    )
+
+    @Serdeable
+    data class DashboardPreferenceResponse(
+        val id: Long?,
+        val userId: Long,
+        val showAwsCleanServerKpi: Boolean,
+        val showEdrCoverageKpi: Boolean,
+        val createdAt: Instant,
+        val updatedAt: Instant
+    ) {
+        companion object {
+            fun from(preference: DashboardPreference) = DashboardPreferenceResponse(
+                id = preference.id,
+                userId = preference.userId,
+                showAwsCleanServerKpi = preference.showAwsCleanServerKpi,
+                showEdrCoverageKpi = preference.showEdrCoverageKpi,
+                createdAt = preference.createdAt,
+                updatedAt = preference.updatedAt
+            )
+        }
+    }
+
+    /**
+     * Extract user ID from authentication object
+     */
+    private fun getUserIdFromAuthentication(authentication: Authentication): Long {
+        val userId = authentication.attributes["userId"]
+        return when (userId) {
+            is Long -> userId
+            is Int -> userId.toLong()
+            is String -> userId.toLong()
+            else -> throw IllegalStateException("Unable to determine user ID from authentication")
+        }
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/DashboardPreference.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/DashboardPreference.kt
@@ -1,0 +1,35 @@
+package com.secman.domain
+
+import jakarta.persistence.*
+import java.time.Instant
+
+/**
+ * Stores per-user visibility preferences for home dashboard security KPI cards
+ */
+@Entity
+@Table(name = "dashboard_preference")
+data class DashboardPreference(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    val userId: Long,
+
+    @Column(name = "show_aws_clean_server_kpi", nullable = false)
+    val showAwsCleanServerKpi: Boolean = true,
+
+    @Column(name = "show_edr_coverage_kpi", nullable = false)
+    val showEdrCoverageKpi: Boolean = true,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now()
+) {
+    @PreUpdate
+    fun preUpdate() {
+        updatedAt = Instant.now()
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/repository/DashboardPreferenceRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/DashboardPreferenceRepository.kt
@@ -1,0 +1,17 @@
+package com.secman.repository
+
+import com.secman.domain.DashboardPreference
+import io.micronaut.data.annotation.Repository
+import io.micronaut.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+/**
+ * Repository for DashboardPreference entity
+ */
+@Repository
+interface DashboardPreferenceRepository : JpaRepository<DashboardPreference, Long> {
+    /**
+     * Find dashboard KPI visibility preference by user ID
+     */
+    fun findByUserId(userId: Long): Optional<DashboardPreference>
+}

--- a/src/backendng/src/test/kotlin/com/secman/controller/DashboardPreferenceControllerTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/DashboardPreferenceControllerTest.kt
@@ -1,0 +1,121 @@
+package com.secman.controller
+
+import com.secman.repository.DashboardPreferenceRepository
+import com.secman.repository.UserRepository
+import com.secman.testutil.BaseIntegrationTest
+import com.secman.testutil.TestAuthHelper
+import com.secman.testutil.TestDataFactory
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Dashboard Preference Controller Tests")
+class DashboardPreferenceControllerTest : BaseIntegrationTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var dashboardPreferenceRepository: DashboardPreferenceRepository
+
+    private lateinit var username: String
+
+    @BeforeEach
+    fun setupUser() {
+        val suffix = System.nanoTime()
+        username = "dashboard-pref-user-$suffix"
+        userRepository.save(TestDataFactory.createRegularUser(
+            username = username,
+            email = "$username@test.com"
+        ))
+    }
+
+    @Test
+    fun `get returns defaults when no preference row exists`() {
+        val token = TestAuthHelper.getAuthToken(client, username)
+
+        val response = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/dashboard-preferences").bearerAuth(token),
+            DashboardPreferenceController.DashboardPreferenceResponse::class.java
+        )
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        val body = response.body()!!
+        assertThat(body.showAwsCleanServerKpi).isTrue()
+        assertThat(body.showEdrCoverageKpi).isTrue()
+    }
+
+    @Test
+    fun `put persists preference and get returns persisted values`() {
+        val token = TestAuthHelper.getAuthToken(client, username)
+
+        val putResponse = client.toBlocking().exchange(
+            HttpRequest.PUT(
+                "/api/dashboard-preferences",
+                DashboardPreferenceController.UpdatePreferenceRequest(
+                    showAwsCleanServerKpi = false,
+                    showEdrCoverageKpi = true
+                )
+            ).bearerAuth(token),
+            DashboardPreferenceController.DashboardPreferenceResponse::class.java
+        )
+
+        assertThat(putResponse.status).isEqualTo(HttpStatus.OK)
+        assertThat(putResponse.body()!!.showAwsCleanServerKpi).isFalse()
+        assertThat(putResponse.body()!!.showEdrCoverageKpi).isTrue()
+
+        val getResponse = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/dashboard-preferences").bearerAuth(token),
+            DashboardPreferenceController.DashboardPreferenceResponse::class.java
+        )
+
+        assertThat(getResponse.body()!!.showAwsCleanServerKpi).isFalse()
+        assertThat(getResponse.body()!!.showEdrCoverageKpi).isTrue()
+    }
+
+    @Test
+    fun `put twice updates the existing row instead of creating a duplicate`() {
+        val token = TestAuthHelper.getAuthToken(client, username)
+
+        client.toBlocking().exchange(
+            HttpRequest.PUT(
+                "/api/dashboard-preferences",
+                DashboardPreferenceController.UpdatePreferenceRequest(
+                    showAwsCleanServerKpi = false,
+                    showEdrCoverageKpi = false
+                )
+            ).bearerAuth(token),
+            DashboardPreferenceController.DashboardPreferenceResponse::class.java
+        )
+
+        val secondResponse = client.toBlocking().exchange(
+            HttpRequest.PUT(
+                "/api/dashboard-preferences",
+                DashboardPreferenceController.UpdatePreferenceRequest(
+                    showAwsCleanServerKpi = true,
+                    showEdrCoverageKpi = false
+                )
+            ).bearerAuth(token),
+            DashboardPreferenceController.DashboardPreferenceResponse::class.java
+        )
+
+        assertThat(secondResponse.body()!!.showAwsCleanServerKpi).isTrue()
+        assertThat(secondResponse.body()!!.showEdrCoverageKpi).isFalse()
+
+        val user = userRepository.findByUsername(username).get()
+        val rows = dashboardPreferenceRepository.findByUserId(user.id!!)
+        assertThat(rows).isPresent
+        assertThat(rows.get().showAwsCleanServerKpi).isTrue()
+        assertThat(rows.get().showEdrCoverageKpi).isFalse()
+    }
+}

--- a/src/frontend/src/components/HomeStatisticsDashboard.tsx
+++ b/src/frontend/src/components/HomeStatisticsDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { authenticatedGet, getUser, hasRole } from '../utils/auth';
 import { formatServerDate } from '../utils/dateUtils';
+import { getDashboardPreferences } from '../services/dashboardPreferenceService';
 
 type StatItem = {
   label: string;
@@ -98,12 +99,12 @@ const HomeStatisticsDashboard: React.FC = () => {
   const [stats, setStats] = useState<DashboardState>(initialState);
   const [userName, setUserName] = useState('there');
   const [isAdmin, setIsAdmin] = useState(false);
-  const [showSecurityKpis, setShowAwsCleanServerKpi] = useState(false);
+  const [showAwsCleanServerKpiCard, setShowAwsCleanServerKpiCard] = useState(false);
+  const [showEdrCoverageKpiCard, setShowEdrCoverageKpiCard] = useState(false);
 
   useEffect(() => {
     setUserName(getUser()?.username ?? 'there');
     setIsAdmin(hasRole('ADMIN'));
-    setShowAwsCleanServerKpi(hasRole(['ADMIN', 'SECCHAMPION']));
 
     const load = async () => {
       const next: DashboardState = { ...initialState };
@@ -152,6 +153,20 @@ const HomeStatisticsDashboard: React.FC = () => {
       }
 
       if (hasRole(['ADMIN', 'SECCHAMPION'])) {
+        // Default both KPI cards to visible; only hide one if the preference fetch
+        // succeeds and explicitly says so. A failed preference fetch must not blank
+        // either KPI card.
+        setShowAwsCleanServerKpiCard(true);
+        setShowEdrCoverageKpiCard(true);
+
+        try {
+          const prefs = await getDashboardPreferences();
+          setShowAwsCleanServerKpiCard(prefs.showAwsCleanServerKpi);
+          setShowEdrCoverageKpiCard(prefs.showEdrCoverageKpi);
+        } catch (error) {
+          console.warn('Failed to load dashboard KPI visibility preferences:', error);
+        }
+
         try {
           const kpiResp = await authenticatedGet('/api/dashboard/aws-clean-server-kpi');
           if (kpiResp.ok) {
@@ -233,13 +248,15 @@ const HomeStatisticsDashboard: React.FC = () => {
     });
   }
 
-  if (showSecurityKpis) {
+  if (showAwsCleanServerKpiCard) {
     cards.push({
       label: 'AWS Servers Without Old Vulnerabilities',
       value: formatAwsCleanServerKpi(stats.awsCleanServerKpi),
       subtitle: 'Share of AWS servers with no vulnerability older than 30 days',
       icon: 'bi-cloud-check'
     });
+  }
+  if (showEdrCoverageKpiCard) {
     cards.push({
       label: 'EC2 Instances With CrowdStrike Installed',
       value: formatEdrCoverageKpi(stats.edrCoverageKpi),

--- a/src/frontend/src/components/UserProfile.tsx
+++ b/src/frontend/src/components/UserProfile.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react';
 import userProfileService from '../services/userProfileService';
 import type { UserProfileData } from '../services/userProfileService';
 import PasskeyManagement from './PasskeyManagement';
+import { getDashboardPreferences, updateDashboardPreferences } from '../services/dashboardPreferenceService';
+import type { DashboardPreference } from '../services/dashboardPreferenceService';
+import { hasRole } from '../utils/auth';
 
 /**
  * User Profile Component
@@ -27,6 +30,12 @@ export default function UserProfile() {
   const [mfaLoading, setMfaLoading] = useState(false);
   const [mfaError, setMfaError] = useState<string | null>(null);
 
+  // Dashboard KPI preferences (ADMIN/SECCHAMPION only)
+  const [dashboardPrefsVisible, setDashboardPrefsVisible] = useState(false);
+  const [dashboardPrefs, setDashboardPrefs] = useState<DashboardPreference | null>(null);
+  const [dashboardPrefsLoading, setDashboardPrefsLoading] = useState(false);
+  const [dashboardPrefsError, setDashboardPrefsError] = useState<string | null>(null);
+
   // Password change state (Feature 051)
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -47,6 +56,10 @@ export default function UserProfile() {
       const data = await userProfileService.getProfile();
       setProfile(data);
       await fetchMfaStatus();
+      if (hasRole(['ADMIN', 'SECCHAMPION'])) {
+        setDashboardPrefsVisible(true);
+        await fetchDashboardPreferences();
+      }
     } catch (err: any) {
       const errorMessage = err.response?.data?.message || 'Failed to load profile. Please try again.';
       setError(errorMessage);
@@ -75,6 +88,36 @@ export default function UserProfile() {
       setMfaError(errorMessage);
     } finally {
       setMfaLoading(false);
+    }
+  };
+
+  const fetchDashboardPreferences = async () => {
+    try {
+      const prefs = await getDashboardPreferences();
+      setDashboardPrefs(prefs);
+    } catch (err: any) {
+      console.error('Failed to fetch dashboard preferences', err);
+    }
+  };
+
+  const handleDashboardKpiToggle = async (
+    field: 'showAwsCleanServerKpi' | 'showEdrCoverageKpi',
+    value: boolean
+  ) => {
+    if (!dashboardPrefs) return;
+    try {
+      setDashboardPrefsLoading(true);
+      setDashboardPrefsError(null);
+      const updated = await updateDashboardPreferences({
+        showAwsCleanServerKpi: field === 'showAwsCleanServerKpi' ? value : dashboardPrefs.showAwsCleanServerKpi,
+        showEdrCoverageKpi: field === 'showEdrCoverageKpi' ? value : dashboardPrefs.showEdrCoverageKpi
+      });
+      setDashboardPrefs(updated);
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.message || 'Failed to update dashboard preferences';
+      setDashboardPrefsError(errorMessage);
+    } finally {
+      setDashboardPrefsLoading(false);
     }
   };
 
@@ -339,6 +382,61 @@ export default function UserProfile() {
           )}
         </div>
       </div>
+
+      {/* Dashboard KPI Preferences Card */}
+      {dashboardPrefsVisible && dashboardPrefs && (
+        <div className="card mt-3">
+          <div className="card-body">
+            <h5 className="card-title">Dashboard KPI Preferences</h5>
+            <p className="text-muted small">
+              Choose which security KPI cards appear on your home dashboard.
+            </p>
+
+            <div className="d-flex align-items-center justify-content-between mb-3">
+              <div>
+                <h6 className="mb-0">AWS Servers Without Old Vulnerabilities</h6>
+              </div>
+              <div className="form-check form-switch">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="showAwsCleanServerKpiToggle"
+                  checked={dashboardPrefs.showAwsCleanServerKpi}
+                  onChange={(e) => handleDashboardKpiToggle('showAwsCleanServerKpi', e.target.checked)}
+                  disabled={dashboardPrefsLoading}
+                  style={{ cursor: dashboardPrefsLoading ? 'wait' : 'pointer', width: '3rem', height: '1.5rem' }}
+                />
+              </div>
+            </div>
+
+            <div className="d-flex align-items-center justify-content-between">
+              <div>
+                <h6 className="mb-0">EC2 Instances With CrowdStrike Installed</h6>
+              </div>
+              <div className="form-check form-switch">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="showEdrCoverageKpiToggle"
+                  checked={dashboardPrefs.showEdrCoverageKpi}
+                  onChange={(e) => handleDashboardKpiToggle('showEdrCoverageKpi', e.target.checked)}
+                  disabled={dashboardPrefsLoading}
+                  style={{ cursor: dashboardPrefsLoading ? 'wait' : 'pointer', width: '3rem', height: '1.5rem' }}
+                />
+              </div>
+            </div>
+
+            {dashboardPrefsError && (
+              <div className="alert alert-danger mt-3 mb-0" role="alert">
+                <i className="bi bi-exclamation-triangle-fill me-2"></i>
+                {dashboardPrefsError}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/services/dashboardPreferenceService.ts
+++ b/src/frontend/src/services/dashboardPreferenceService.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+
+// API base URL - always use relative URLs to go through Astro's proxy and avoid CORS issues
+const API_BASE_URL = import.meta.env.PUBLIC_API_URL || '';
+
+export interface DashboardPreference {
+  id: number | null;
+  userId: number;
+  showAwsCleanServerKpi: boolean;
+  showEdrCoverageKpi: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateDashboardPreferenceRequest {
+  showAwsCleanServerKpi: boolean;
+  showEdrCoverageKpi: boolean;
+}
+
+/**
+ * Get current user's home dashboard KPI visibility preferences
+ */
+export async function getDashboardPreferences(): Promise<DashboardPreference> {
+  const response = await axios.get(`${API_BASE_URL}/api/dashboard-preferences`);
+  return response.data;
+}
+
+/**
+ * Update current user's home dashboard KPI visibility preferences
+ */
+export async function updateDashboardPreferences(
+  request: UpdateDashboardPreferenceRequest
+): Promise<DashboardPreference> {
+  const response = await axios.put(
+    `${API_BASE_URL}/api/dashboard-preferences`,
+    request,
+    {
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- Admins/SECCHAMPIONs previously always saw both home-dashboard KPI cards (CrowdStrike/EDR coverage and the AWS clean-server / patch-management KPI) together, with no way to hide either one individually.
- Adds a new per-user `DashboardPreference` (entity + repository + `GET`/`PUT /api/dashboard-preferences` controller), modeled directly on the existing `NotificationPreference` pattern. Defaults both KPIs to visible so existing users see no behavior change unless they opt to hide one.
- Adds a "Dashboard KPI Preferences" card to the profile page (visible only to ADMIN/SECCHAMPION) with an independent toggle per KPI.
- Wires the preference into `HomeStatisticsDashboard.tsx`: each KPI card is now gated by role **and** the user's preference (previously a single shared `showSecurityKpis` flag gated both together).

## Test plan
- [x] `cd src/frontend && npm run build` — clean (exit 0)
- [x] New backend integration test `DashboardPreferenceControllerTest` covering GET defaults, PUT persistence, and upsert-not-duplicate behavior
- [ ] `./gradlew build` — **not run**: this sandbox's network policy blocks downloading the pinned Gradle 9.x distribution (`services.gradle.org` returns 403) and no local JDK 25 toolchain is available, so the backend build could not be verified in this environment. The new Kotlin files closely mirror `NotificationPreferenceController`/`NotificationPreference`/`NotificationPreferenceRepository`, which are known to compile against this exact stack.
- [ ] `./scripts/startbackenddev.sh` clean start — not verified for the same reason
- [ ] `/e2ejs` — not run in this environment
- [ ] Manual smoke test (toggle each KPI checkbox on `/profile`, confirm dashboard reflects it and persists across reload)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqVcT1qJkYBzkhaTzM9Kd4)_