### PR TITLE
Cascade standards deletion when admin deletes all requirements

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
@@ -398,11 +398,22 @@ open class RequirementController(
     @Secured("ADMIN")
     open fun deleteAllRequirements(): HttpResponse<*> {
         try {
-            // Delete all requirements (cascade will handle relationships)
+            val requirementCount = requirementRepository.count()
+            val normCount = normRepository.count()
+
+            // Delete all requirements (cascade will handle join-table relationships)
             requirementRepository.deleteAll()
+            // Delete all standards/norms too, now that no requirement references them
+            normRepository.deleteAll()
             // Reset the REQ-NNN sequence so the next imported requirement starts at REQ-001
             requirementIdService.resetSequence()
-            return HttpResponse.ok(mapOf("message" to "All requirements deleted successfully"))
+
+            return HttpResponse.ok(mapOf(
+                "message" to "All requirements and standards deleted successfully",
+                "deletedCount" to requirementCount,
+                "deletedRequirements" to requirementCount,
+                "deletedNorms" to normCount
+            ))
         } catch (e: Exception) {
             return HttpResponse.serverError<Any>().body(mapOf("error" to "An internal error occurred"))
         }

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAllRequirementsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/DeleteAllRequirementsTool.kt
@@ -2,6 +2,7 @@ package com.secman.mcp.tools
 
 import com.secman.domain.McpOperation
 import com.secman.dto.mcp.McpExecutionContext
+import com.secman.repository.NormRepository
 import com.secman.repository.RequirementRepository
 import com.secman.service.RequirementIdService
 import jakarta.inject.Inject
@@ -13,11 +14,13 @@ import jakarta.transaction.Transactional
  * Feature: 057-cli-mcp-requirements
  *
  * ADMIN role is required and confirmation flag must be true.
- * Returns the count of deleted requirements.
+ * Also deletes all standards/norms, since they only exist to be attached
+ * to requirements. Returns the count of deleted requirements and norms.
  */
 @Singleton
 open class DeleteAllRequirementsTool(
     @Inject private val requirementRepository: RequirementRepository,
+    @Inject private val normRepository: NormRepository,
     @Inject private val requirementIdService: RequirementIdService
 ) : McpTool {
 
@@ -60,16 +63,20 @@ open class DeleteAllRequirementsTool(
         try {
             // Count before delete for response
             val count = requirementRepository.count()
+            val normCount = normRepository.count()
 
             // Delete all requirements
             requirementRepository.deleteAll()
+            // Delete all standards/norms too, now that no requirement references them
+            normRepository.deleteAll()
             // Reset the REQ-NNN sequence so the next imported requirement starts at REQ-001
             requirementIdService.resetSequence()
 
             val result = mapOf(
                 "success" to true,
                 "deletedCount" to count,
-                "message" to "Deleted $count requirements"
+                "deletedNormCount" to normCount,
+                "message" to "Deleted $count requirements and $normCount standards"
             )
 
             return McpToolResult.success(result)

--- a/src/backendng/src/test/kotlin/com/secman/controller/RequirementDeleteAllIntegrationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/RequirementDeleteAllIntegrationTest.kt
@@ -1,0 +1,104 @@
+package com.secman.controller
+
+import com.secman.domain.Norm
+import com.secman.domain.Requirement
+import com.secman.domain.User
+import com.secman.repository.NormRepository
+import com.secman.repository.RequirementRepository
+import com.secman.repository.UserRepository
+import com.secman.testutil.BaseIntegrationTest
+import com.secman.testutil.TestAuthHelper
+import com.secman.testutil.TestDataFactory
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for admin "delete all requirements" also removing all standards (norms),
+ * since norms only exist to be attached to requirements.
+ */
+@MicronautTest(environments = ["test"], transactional = false)
+class RequirementDeleteAllIntegrationTest : BaseIntegrationTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var requirementRepository: RequirementRepository
+
+    @Inject
+    lateinit var normRepository: NormRepository
+
+    private lateinit var adminUser: User
+    private lateinit var reqUser: User
+
+    @BeforeEach
+    fun setUp() {
+        val suffix = System.nanoTime()
+        adminUser = userRepository.save(TestDataFactory.createAdminUser("reqdel-admin-$suffix", "reqdel-admin-$suffix@test.com"))
+        reqUser = userRepository.save(TestDataFactory.createUserWithRoles("reqdel-req-$suffix", "reqdel-req-$suffix@test.com", User.Role.USER, User.Role.REQ))
+
+        requirementRepository.deleteAll()
+        normRepository.deleteAll()
+    }
+
+    @Test
+    fun `admin delete-all requirements also deletes all norms`() {
+        val norm = normRepository.save(Norm(name = "ISO 27001-${System.nanoTime()}", version = "2022"))
+        requirementRepository.save(
+            Requirement(
+                internalId = "REQ-DELALL-${System.nanoTime()}",
+                shortreq = "Test requirement",
+                norms = mutableSetOf(norm)
+            )
+        )
+
+        assertThat(requirementRepository.count()).isEqualTo(1)
+        assertThat(normRepository.count()).isEqualTo(1)
+
+        val adminToken = TestAuthHelper.getAuthToken(client, adminUser.username)
+        val response = client.toBlocking().exchange(
+            HttpRequest.DELETE<Any>("/api/requirements/all").bearerAuth(adminToken),
+            Map::class.java
+        )
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        assertThat(response.body()!!["deletedRequirements"]).isEqualTo(1)
+        assertThat(response.body()!!["deletedNorms"]).isEqualTo(1)
+
+        assertThat(requirementRepository.count()).isEqualTo(0)
+        assertThat(normRepository.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `non-admin cannot delete all requirements`() {
+        requirementRepository.save(
+            Requirement(
+                internalId = "REQ-DELALL-${System.nanoTime()}",
+                shortreq = "Test requirement"
+            )
+        )
+
+        val reqToken = TestAuthHelper.getAuthToken(client, reqUser.username)
+
+        val exception = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.DELETE<Any>("/api/requirements/all").bearerAuth(reqToken),
+                Map::class.java
+            )
+        }
+        assertThat(exception.status).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(requirementRepository.count()).isEqualTo(1)
+    }
+}

--- a/src/frontend/src/components/RequirementManagement.tsx
+++ b/src/frontend/src/components/RequirementManagement.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useEffect } from 'react';
-import { authenticatedGet, authenticatedPost, authenticatedPut, authenticatedDelete } from '../utils/auth';
+import { authenticatedGet, authenticatedPost, authenticatedPut, authenticatedDelete, getUser } from '../utils/auth';
+import { isAdmin } from '../utils/permissions';
 import ReleaseIndicator from './ReleaseIndicator';
 import ReleaseSelector from './ReleaseSelector';
 import HtmlEditor from './admin/HtmlEditor';
@@ -44,6 +45,7 @@ interface Release {
 }
 
 export default function RequirementManagement() {
+    const currentUserIsAdmin = isAdmin(getUser()?.roles);
     const [requirements, setRequirements] = useState<Requirement[]>([]);
     const [filteredRequirements, setFilteredRequirements] = useState<Requirement[]>([]);
     const [allUseCases, setAllUseCases] = useState<UseCase[]>([]); // To store all available use cases
@@ -383,7 +385,7 @@ export default function RequirementManagement() {
             const data = await response.json();
 
             if (response.ok) {
-                setDeleteSuccess(`Successfully deleted ${data.deletedCount} requirements.`);
+                setDeleteSuccess(`Successfully deleted ${data.deletedRequirements ?? data.deletedCount} requirements and ${data.deletedNorms ?? 0} standards.`);
                 setShowSecondDeleteModal(false);
                 setConfirmationText('');
                 fetchRequirements();
@@ -605,11 +607,11 @@ export default function RequirementManagement() {
                                         )}
                                     </button>
                                 )}
-                                {requirements.length > 0 && (
+                                {currentUserIsAdmin && requirements.length > 0 && (
                                     <button
                                         className="btn btn-outline-warning"
                                         onClick={() => setShowFirstDeleteModal(true)}
-                                        title="Delete all requirements"
+                                        title="Delete all requirements and standards (ADMIN only)"
                                         disabled={isDeleting || isMappingInProgress}
                                     >
                                         Delete All Requirements
@@ -1143,11 +1145,12 @@ export default function RequirementManagement() {
                             </div>
                             <div className="modal-body">
                                 <div className="alert alert-danger">
-                                    <strong>Warning:</strong> You are about to delete all requirements!
+                                    <strong>Warning:</strong> You are about to delete all requirements and all standards!
                                 </div>
                                 <p><strong>This action will:</strong></p>
                                 <ul>
                                     <li>Delete all <strong>{requirements.length}</strong> requirements</li>
+                                    <li>Delete all standards (norms), e.g. ISO 27001, IEC 62443</li>
                                     <li>Remove all associated relationships (use case and norm associations)</li>
                                     <li>Cannot be undone</li>
                                 </ul>
@@ -1180,7 +1183,7 @@ export default function RequirementManagement() {
                                 <div className="alert alert-danger">
                                     <strong>FINAL WARNING:</strong> This action is irreversible!
                                 </div>
-                                <p>To confirm deletion of all <strong>{requirements.length}</strong> requirements, type <strong>DELETE ALL</strong> in the box below:</p>
+                                <p>To confirm deletion of all <strong>{requirements.length}</strong> requirements and all standards, type <strong>DELETE ALL</strong> in the box below:</p>
                                 
                                 {deleteError && <div className="alert alert-danger">{deleteError}</div>}
                                 

--- a/src/frontend/src/components/RequirementsAdmin.tsx
+++ b/src/frontend/src/components/RequirementsAdmin.tsx
@@ -133,7 +133,7 @@ const RequirementsAdmin = () => {
             const data = await response.json();
 
             if (response.ok) {
-                setDeleteSuccess(`Successfully deleted ${data.deletedCount} requirements.`);
+                setDeleteSuccess(`Successfully deleted ${data.deletedRequirements ?? data.deletedCount} requirements and ${data.deletedNorms ?? 0} standards.`);
                 setRequirementsCount(0);
                 setShowSecondModal(false);
                 setConfirmationText('');
@@ -233,8 +233,8 @@ const RequirementsAdmin = () => {
                 <div className="card-body">
                     <h6>Delete All Requirements</h6>
                     <p className="text-muted">
-                        This action will permanently delete all requirements from the system. 
-                        This cannot be undone and will also remove all associated relationships.
+                        This action will permanently delete all requirements and all standards (norms)
+                        from the system. This cannot be undone and will also remove all associated relationships.
                     </p>
                     <button 
                         className="btn btn-danger"
@@ -266,12 +266,13 @@ const RequirementsAdmin = () => {
                             </div>
                             <div className="modal-body">
                                 <div className="alert alert-danger">
-                                    <strong>Warning:</strong> You are about to delete all requirements!
+                                    <strong>Warning:</strong> You are about to delete all requirements and all standards!
                                 </div>
                                 <p><strong>This action will:</strong></p>
                                 <ul>
                                     <li>Delete all <strong>{requirementsCount}</strong> requirements</li>
-                                    <li>Remove all associated relationships (use case associations)</li>
+                                    <li>Delete all standards (norms), e.g. ISO 27001, IEC 62443</li>
+                                    <li>Remove all associated relationships (use case and norm associations)</li>
                                     <li>Cannot be undone</li>
                                 </ul>
                                 <p className="mb-0">Are you sure you want to continue?</p>
@@ -303,7 +304,7 @@ const RequirementsAdmin = () => {
                                 <div className="alert alert-danger">
                                     <strong>FINAL WARNING:</strong> This action is irreversible!
                                 </div>
-                                <p>To confirm deletion of all <strong>{requirementsCount}</strong> requirements, type <strong>DELETE ALL</strong> in the box below:</p>
+                                <p>To confirm deletion of all <strong>{requirementsCount}</strong> requirements and all standards, type <strong>DELETE ALL</strong> in the box below:</p>
                                 
                                 {deleteError && <div className="alert alert-danger">{deleteError}</div>}
                                 


### PR DESCRIPTION
## Summary

- Admin "delete all requirements" (both `/admin/requirements` and the general `/requirements` page) now also deletes all standards (norms) in the same transaction.
- `DELETE /api/requirements/all` and the `delete_all_requirements` MCP tool count and delete `Requirement`s first (so no requirement still references a norm), then delete all `Norm`s, and return both counts.

## Changes

- `RequirementController.deleteAllRequirements` (`DELETE /api/requirements/all`, `@Secured("ADMIN")`): now also calls `normRepository.deleteAll()`, and returns `deletedRequirements`/`deletedNorms` (plus `deletedCount` for backward compatibility, which was previously unset).
- `DeleteAllRequirementsTool` (MCP `delete_all_requirements`): mirrors the same behavior, now injects `NormRepository` and reports `deletedNormCount`.
- `RequirementsAdmin.tsx` (admin page) and `RequirementManagement.tsx` (general requirements page): confirmation modal copy now discloses that standards are deleted too, and the success message reports both counts.
- `RequirementManagement.tsx`: the "Delete All Requirements" button is now gated to ADMIN in the UI (`isAdmin()` from `utils/permissions.ts`), matching the backend's ADMIN-only enforcement — previously any REQ/SECCHAMPION viewer could see the button and only get a 403 after two confirmation steps.
- Release snapshots (`RequirementSnapshot`) are unaffected — they store their own copy of requirement/norm data and have no FK to `Requirement` or `Norm`.

## Testing

- [ ] `./gradlew build` is clean — **not run**: this session's egress policy blocks `services.gradle.org`, `plugins.gradle.org`, and `repo.maven.apache.org` (confirmed via the agent proxy status endpoint), so the Gradle build could not be executed here. Changes were reviewed manually against existing repository/controller patterns.
- [ ] `./scripts/startbackenddev.sh` starts cleanly — not run, same network restriction blocks dependency resolution.
- [x] `cd src/frontend && npm install && npm run build` exits 0 (used `npm install` instead of `npm ci` — the committed lockfile is already out of sync with the registry on `main`, unrelated to this change)
- [x] New integration test added: `RequirementDeleteAllIntegrationTest` (admin delete-all removes both requirements and norms and returns their counts; non-admin gets 403) — not executed locally (needs `TEST_DB_*` + reachable MariaDB), added for CI/reviewer verification.
- [ ] `/e2ejs` — not run in this session
- [ ] `/e2evulnexception` — not run in this session

## Backend contract changes

- [x] N/A — no backend contract changes (path/method/roles unchanged; response gains new fields, doesn't rename/remove any existing ones)

## Security

- [x] RBAC enforced at controller (`@Secured("ADMIN")`, unchanged) and now also in the UI on the general requirements page
- [x] No new input surface — deletion driven entirely by existing repository calls
- [x] No secrets hardcoded

## Related issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPXnQFCins1L65mZQFTest)_