### PR TITLE
Fix e2e-aws* test releases never getting cleaned up

### DIFF
--- a/scripts/test/test-e2e-aws-account-owner-email.sh
+++ b/scripts/test/test-e2e-aws-account-owner-email.sh
@@ -439,8 +439,10 @@ cleanup() {
         '(if type == "array" then . else (.content // []) end)[]? | select(.name == $n) | .id' 2>/dev/null \
         | while read -r r_id; do
             [[ -n "$r_id" ]] || continue
-            api DELETE "/api/releases/${r_id}?force=true" >/dev/null 2>&1 \
-                || api DELETE "/api/releases/${r_id}" >/dev/null 2>&1 || true
+            api DELETE "/api/releases/${r_id}?force=true" >/dev/null 2>&1
+            if [[ ! "$(api_status)" =~ ^2 ]]; then
+                log_warn "Could not delete release id=${r_id} (name=${SEEDED_RELEASE_NAME}, HTTP $(api_status)) — left in place"
+            fi
         done
 
     local reqs

--- a/scripts/test/test-e2e-aws-account-risk-assessment.sh
+++ b/scripts/test/test-e2e-aws-account-risk-assessment.sh
@@ -228,12 +228,27 @@ cleanup() {
         done
 
     # Release (also drops its requirement snapshots).
+    #
+    # Matched by NAME ($RELEASE_NAME, constant across runs), never by this run's own
+    # $RELEASE_VERSION (a fresh timestamp each run). A version-only match can only ever
+    # catch the release THIS run just created, so any release orphaned by an earlier
+    # interrupted run (different version, same name) would never be swept up, and the
+    # e2e-awsra-release rows would pile up release over release exactly like the
+    # e2e-awsmail-release pile this cleanup pattern was copied from.
+    #
+    # force=true is required: setup_testbed() always sets its release ACTIVE, and the
+    # backend refuses to delete an ACTIVE release unless force=true actually bypasses
+    # that guard (see DELETE /api/releases/{id} in ReleaseController.kt).
     local releases
     releases=$(api GET "/api/releases" || echo '[]')
-    echo "$releases" | jq -r --arg v "$RELEASE_VERSION" \
-        '(if type == "array" then . else (.content // []) end)[]? | select(.version == $v) | .id' 2>/dev/null \
+    echo "$releases" | jq -r --arg n "$RELEASE_NAME" \
+        '(if type == "array" then . else (.content // []) end)[]? | select(.name == $n) | .id' 2>/dev/null \
         | while read -r r_id; do
-            [[ -n "$r_id" ]] && api DELETE "/api/releases/${r_id}" >/dev/null || true
+            [[ -n "$r_id" ]] || continue
+            api DELETE "/api/releases/${r_id}?force=true" >/dev/null 2>&1 || true
+            if [[ ! "$API_STATUS" =~ ^2 ]]; then
+                log_warn "Could not delete release id=${r_id} (name=${RELEASE_NAME}, HTTP ${API_STATUS}) — left in place"
+            fi
         done
 
     # Requirements, use case, users — all prefix-scoped.

--- a/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ReleaseController.kt
@@ -159,18 +159,37 @@ open class ReleaseController(
     /**
      * DELETE /api/releases/{id} - Delete release
      * Authorization: ADMIN or REQADMIN only
+     * `force=true` (ADMIN only) bypasses the ACTIVE-release guard — same escape hatch
+     * `DELETE /api/releases/all` already offers in bulk, exposed here per-release for
+     * callers (e.g. E2E test cleanup) that must remove a specific release regardless
+     * of its status.
      */
     @Delete("/{id}")
     @Secured("ADMIN", "REQADMIN")
-    fun deleteRelease(@PathVariable id: Long): HttpResponse<Void> {
-        logger.info("Deleting release: $id")
+    fun deleteRelease(
+        @PathVariable id: Long,
+        @QueryValue(defaultValue = "false") force: Boolean,
+        authentication: Authentication
+    ): HttpResponse<*> {
+        logger.info("Deleting release: $id (force=$force)")
+
+        if (force && !authentication.roles.contains("ADMIN")) {
+            return HttpResponse.status<Map<String, Any>>(HttpStatus.FORBIDDEN).body(
+                mapOf("error" to "Forbidden", "message" to "force=true requires the ADMIN role")
+            )
+        }
 
         try {
-            releaseService.deleteRelease(id)
-            return HttpResponse.noContent()
+            releaseService.deleteRelease(id, force)
+            return HttpResponse.noContent<Void>()
         } catch (e: NoSuchElementException) {
             logger.warn("Release not found for deletion: $id")
-            return HttpResponse.notFound()
+            return HttpResponse.notFound<Void>()
+        } catch (e: IllegalStateException) {
+            logger.warn("Release deletion refused: ${e.message}")
+            return HttpResponse.status<Map<String, Any>>(HttpStatus.CONFLICT).body(
+                mapOf("error" to "Conflict", "message" to (e.message ?: "Cannot delete this release"))
+            )
         }
     }
 

--- a/src/backendng/src/main/kotlin/com/secman/service/ReleaseService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ReleaseService.kt
@@ -140,6 +140,20 @@ open class ReleaseService(
             throw IllegalStateException("Cannot delete an ACTIVE release. Set another release as active first.")
         }
 
+        if (force) {
+            // Detach any risk assessments locked to this release so the FK
+            // release_id -> release.id does not block deletion (mirrors the
+            // detachment deleteAllReleases() does before its own force-delete loop).
+            val lockedAssessments = riskAssessmentRepository.findAll().filter { it.lockedRelease?.id == releaseId }
+            for (ra in lockedAssessments) {
+                ra.lockedRelease = null
+                riskAssessmentRepository.update(ra)
+            }
+            if (lockedAssessments.isNotEmpty()) {
+                logger.info("Detached ${lockedAssessments.size} risk assessment(s) from release ID=$releaseId before force delete")
+            }
+        }
+
         // Delete alignment session data (respecting FK order: reviews → snapshots/reviewers → sessions)
         val sessions = alignmentSessionRepository.findAllByRelease_Id(releaseId)
         for (session in sessions) {

--- a/src/backendng/src/test/kotlin/com/secman/service/ReleaseServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/ReleaseServiceTest.kt
@@ -1,0 +1,124 @@
+package com.secman.service
+
+import com.secman.domain.AssessmentBasisType
+import com.secman.domain.Release
+import com.secman.domain.RiskAssessment
+import com.secman.domain.User
+import com.secman.repository.AlignmentReviewerRepository
+import com.secman.repository.AlignmentSessionRepository
+import com.secman.repository.AlignmentSnapshotRepository
+import com.secman.repository.ReleaseRepository
+import com.secman.repository.RequirementRepository
+import com.secman.repository.RequirementReviewRepository
+import com.secman.repository.RequirementSnapshotRepository
+import com.secman.repository.RiskAssessmentRepository
+import com.secman.repository.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.util.Optional
+
+class ReleaseServiceTest {
+
+    private val releaseRepository = mockk<ReleaseRepository>(relaxed = true)
+    private val requirementRepository = mockk<RequirementRepository>(relaxed = true)
+    private val snapshotRepository = mockk<RequirementSnapshotRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val alignmentSessionRepository = mockk<AlignmentSessionRepository>(relaxed = true)
+    private val alignmentSnapshotRepository = mockk<AlignmentSnapshotRepository>(relaxed = true)
+    private val alignmentReviewerRepository = mockk<AlignmentReviewerRepository>(relaxed = true)
+    private val requirementReviewRepository = mockk<RequirementReviewRepository>(relaxed = true)
+    private val riskAssessmentRepository = mockk<RiskAssessmentRepository>(relaxed = true)
+
+    private val service = ReleaseService(
+        releaseRepository,
+        requirementRepository,
+        snapshotRepository,
+        userRepository,
+        alignmentSessionRepository,
+        alignmentSnapshotRepository,
+        alignmentReviewerRepository,
+        requirementReviewRepository,
+        riskAssessmentRepository
+    )
+
+    private val activeRelease = Release(id = 42L, version = "1.0.0", name = "e2e-awsmail-release", status = Release.ReleaseStatus.ACTIVE)
+    private val someUser = User(id = 1L, username = "assessor", email = "assessor@test.com", passwordHash = "x")
+
+    private fun riskAssessment(id: Long, lockedRelease: Release?) = RiskAssessment(
+        id = id,
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now().plusDays(7),
+        assessmentBasisType = AssessmentBasisType.ASSET,
+        assessmentBasisId = 1L,
+        assessor = someUser,
+        requestor = someUser,
+        lockedRelease = lockedRelease
+    )
+
+    // --- guard against deleting an ACTIVE release ------------------------------
+
+    @Test
+    fun `deleteRelease without force refuses an ACTIVE release`() {
+        every { releaseRepository.findById(42L) } returns Optional.of(activeRelease)
+
+        val ex = assertThrows<IllegalStateException> { service.deleteRelease(42L, force = false) }
+        assertThat(ex.message).contains("ACTIVE")
+        verify(exactly = 0) { releaseRepository.delete(any()) }
+    }
+
+    @Test
+    fun `deleteRelease force=true deletes an ACTIVE release`() {
+        every { releaseRepository.findById(42L) } returns Optional.of(activeRelease)
+        every { riskAssessmentRepository.findAll() } returns emptyList()
+
+        service.deleteRelease(42L, force = true)
+
+        verify { releaseRepository.delete(activeRelease) }
+    }
+
+    // --- FK detachment: the bug this test guards against -----------------------
+
+    @Test
+    fun `deleteRelease force=true detaches risk assessments locked to that release`() {
+        // Without this detach, the FK release_id -> release.id on risk_assessment
+        // makes releaseRepository.delete() throw at the DB layer even though the
+        // ACTIVE guard was bypassed — exactly the failure E2E cleanup was silently
+        // swallowing, leaving debris releases behind forever.
+        val lockedHere = riskAssessment(100L, lockedRelease = activeRelease)
+        val lockedElsewhere = riskAssessment(101L, lockedRelease = Release(id = 99L, version = "9.9.9", name = "other"))
+        val unlocked = riskAssessment(102L, lockedRelease = null)
+
+        every { releaseRepository.findById(42L) } returns Optional.of(activeRelease)
+        every { riskAssessmentRepository.findAll() } returns listOf(lockedHere, lockedElsewhere, unlocked)
+
+        service.deleteRelease(42L, force = true)
+
+        assertThat(lockedHere.lockedRelease).isNull()
+        verify { riskAssessmentRepository.update(lockedHere) }
+        verify(exactly = 0) { riskAssessmentRepository.update(lockedElsewhere) }
+        verify(exactly = 0) { riskAssessmentRepository.update(unlocked) }
+    }
+
+    @Test
+    fun `deleteRelease without force never touches lockedRelease on non-ACTIVE releases`() {
+        val archived = activeRelease.copy(status = Release.ReleaseStatus.ARCHIVED)
+        every { releaseRepository.findById(42L) } returns Optional.of(archived)
+
+        service.deleteRelease(42L, force = false)
+
+        verify(exactly = 0) { riskAssessmentRepository.findAll() }
+        verify { releaseRepository.delete(archived) }
+    }
+
+    @Test
+    fun `deleteRelease throws when release does not exist`() {
+        every { releaseRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows<NoSuchElementException> { service.deleteRelease(999L) }
+    }
+}


### PR DESCRIPTION
## Summary

- `DELETE /api/releases/{id}?force=true` never actually bypassed the ACTIVE-release guard — the controller silently ignored the `force` query param, so the two AWS-account E2E drivers' own seeded releases could never be deleted once set ACTIVE, and their `|| true` cleanup swallowed the failure.
- Fixed the underlying backend gap and two test-script cleanup bugs so `e2e-awsmail-release` / `e2e-awsra-release` rows (like the pile visible under Releases in the report) actually get removed.

## Changes

- `src/backendng/.../controller/ReleaseController.kt`: `DELETE /api/releases/{id}` now reads `force` (`@QueryValue`, default `false`), requires `ADMIN` when `force=true` (403 otherwise), and maps `IllegalStateException` to a clean 409 instead of an unhandled 500.
- `src/backendng/.../service/ReleaseService.kt`: `deleteRelease(force = true)` now detaches any `RiskAssessment.lockedRelease` pointing at the release before deleting it, mirroring the detachment `deleteAllReleases()` already does for its bulk force-delete — otherwise the FK still blocks the delete even with the ACTIVE guard bypassed.
- `scripts/test/test-e2e-aws-account-risk-assessment.sh`: `cleanup()` matched releases by *this run's own* generated version instead of by the constant release name, so it could never catch a release orphaned by an earlier/interrupted run. Now matches by name (like the owner-email driver already did) and logs a warning instead of failing silently.
- `scripts/test/test-e2e-aws-account-owner-email.sh`: same cleanup block now logs a warning on delete failure instead of going fully silent.
- Added `ReleaseServiceTest` covering: the ACTIVE guard without force, successful force-delete of an ACTIVE release, that only risk assessments actually locked to *that* release get detached, and the not-found path.

## Testing

- [ ] `./gradlew build` is clean — **could not run**: this sandboxed session's network policy blocks `services.gradle.org` (Gradle distribution download) and the Gradle plugin portal, so the wrapper can't bootstrap here. Changes were reviewed by hand against existing patterns (`deleteAllReleases()`'s force-delete/detach logic, other controllers' `authentication.roles.contains("ADMIN")` checks). Please run `./gradlew build` / `./gradlew :backendng:test --tests "*ReleaseServiceTest*"` in CI or a networked environment before merging.
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes) — not run, same network constraint
- [x] New/updated unit or integration tests cover the change — `ReleaseServiceTest`
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — not run (no frontend change; also blocked by the same constraint)
- [ ] `/e2evulnexception` passes with 0 failures — not run, same network constraint

## Backend contract changes

- [x] N/A — no backend contract changes (the `extensions/` clients call auth/vulnerability/asset endpoints and MCP tools only; `DELETE /api/releases/{id}` is untouched by them, and the new `force` param is additive/backward-compatible — omitting it preserves the exact prior behavior)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — `force=true` is further gated to `ADMIN` only (the plain delete already required `ADMIN`/`REQADMIN`)
- [x] Input validation / file handling reviewed for new attack surface — n/a, no new input surface beyond a boolean query flag
- [x] No secrets hardcoded (uses `pass-cli`)


---
_Generated by [Claude Code](https://claude.ai/code/session_013rvNfgZhFe4tpD2rXYpK3t)_