### PR TITLE
Security review: fix privilege escalation, auth bypass and config takeover

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/TranslationConfigController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/TranslationConfigController.kt
@@ -15,6 +15,19 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.*
 import java.time.LocalDateTime
 
+/**
+ * Translation (LLM) configuration.
+ *
+ * SECURITY: reads stay IS_AUTHENTICATED because non-admin pages depend on them — Export.tsx and
+ * ImportExport.tsx call GET /active to decide whether to offer translated export — and every read
+ * masks the credential via TranslationConfig.toSafeResponse().
+ *
+ * Every *mutating* method is ADMIN-only, matching the sibling EmailConfig/FalconConfig/GithubConfig
+ * controllers. Without that gate any authenticated user could rewrite `baseUrl` on the active
+ * config, and TranslationService sends the stored key as `Authorization: Bearer` to whatever host
+ * it names — leaking the API key and the requirement text being translated. `/test` is likewise an
+ * outbound-fetch primitive, and `activate` deactivates every other config in one call.
+ */
 @Controller("/api/translation-config")
 @Secured(SecurityRule.IS_AUTHENTICATED)
 @ExecuteOn(TaskExecutors.BLOCKING)
@@ -110,6 +123,7 @@ open class TranslationConfigController(
     }
 
     @Post
+    @Secured("ADMIN")
     @Transactional
     open fun createConfig(@Valid @Body request: CreateTranslationConfigRequest): HttpResponse<*> {
         return try {
@@ -135,6 +149,7 @@ open class TranslationConfigController(
     }
 
     @Put("/{id}")
+    @Secured("ADMIN")
     @Transactional
     open fun updateConfig(id: Long, @Valid @Body request: UpdateTranslationConfigRequest): HttpResponse<*> {
         return try {
@@ -175,6 +190,7 @@ open class TranslationConfigController(
     }
 
     @Delete("/{id}")
+    @Secured("ADMIN")
     @Transactional
     open fun deleteConfig(id: Long): HttpResponse<*> {
         return try {
@@ -191,6 +207,7 @@ open class TranslationConfigController(
     }
 
     @Post("/{id}/test")
+    @Secured("ADMIN")
     open fun testConfig(id: Long): HttpResponse<*> {
         return try {
             val config = translationConfigRepository.findById(id)
@@ -206,6 +223,7 @@ open class TranslationConfigController(
     }
 
     @Post("/{id}/activate")
+    @Secured("ADMIN")
     @Transactional
     open fun activateConfig(id: Long): HttpResponse<*> {
         return try {
@@ -232,6 +250,7 @@ open class TranslationConfigController(
     }
 
     @Post("/{id}/deactivate")
+    @Secured("ADMIN")
     @Transactional
     open fun deactivateConfig(id: Long): HttpResponse<*> {
         return try {

--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAdDomainController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAdDomainController.kt
@@ -1,6 +1,7 @@
 package com.secman.controller
 
 import com.secman.dto.WorkgroupAdDomainDto
+import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
 import com.secman.repository.WorkgroupRepository
 import com.secman.service.DuplicateAdDomainException
@@ -16,12 +17,22 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Pattern
 import org.slf4j.LoggerFactory
 
+/**
+ * REST controller for AD domain assignments on workgroups.
+ *
+ * Endpoints:
+ * - GET    /api/workgroups/{id}/ad-domains             — list (ADMIN or direct member)
+ * - POST   /api/workgroups/{id}/ad-domains             — add (ADMIN, or a direct member who
+ *                                                         already has access to the domain)
+ * - DELETE /api/workgroups/{id}/ad-domains/{adDomain}  — remove (ADMIN or direct member)
+ */
 @Controller("/api/workgroups/{workgroupId}/ad-domains")
 @Secured(SecurityRule.IS_AUTHENTICATED)
 open class WorkgroupAdDomainController(
     private val service: WorkgroupAdDomainService,
     private val userRepository: UserRepository,
-    private val workgroupRepository: WorkgroupRepository
+    private val workgroupRepository: WorkgroupRepository,
+    private val userMappingRepository: UserMappingRepository
 ) {
     private val logger = LoggerFactory.getLogger(WorkgroupAdDomainController::class.java)
 
@@ -30,6 +41,23 @@ open class WorkgroupAdDomainController(
         val workgroup = workgroupRepository.findById(workgroupId).orElse(null) ?: return false
         val user = userRepository.findByUsername(authentication.name).orElse(null) ?: return false
         return workgroup.users.any { it.id == user.id }
+    }
+
+    /**
+     * SECURITY: membership alone must not authorize *binding* an arbitrary AD domain.
+     *
+     * Any authenticated user can create a workgroup and is auto-enrolled as a member, so
+     * without this check they could bind any domain and AssetRepository.findAccessibleAssets
+     * would hand them every asset in it (unified asset access criterion 10) — a privilege
+     * escalation from USER to "reads an entire AD domain".
+     *
+     * A non-ADMIN actor may therefore only bind a domain they already reach through their own
+     * domain UserMapping (criterion 6). Matching is case-insensitive, mirroring
+     * AssetFilterService's domain comparison.
+     */
+    private fun canBindDomain(actorEmail: String, adDomain: String): Boolean {
+        val ownDomains = userMappingRepository.findDistinctDomainByEmail(actorEmail)
+        return ownDomains.any { it.equals(adDomain, ignoreCase = true) }
     }
 
     @Get(produces = [MediaType.APPLICATION_JSON])
@@ -57,6 +85,14 @@ open class WorkgroupAdDomainController(
         }
         if (!isMemberOrAdmin(workgroupId, authentication)) {
             return HttpResponse.status<Map<String, String>>(io.micronaut.http.HttpStatus.FORBIDDEN)
+        }
+        if (!authentication.roles.contains("ADMIN") && !canBindDomain(actor.email, request.adDomain)) {
+            logger.warn(
+                "Rejected AD domain bind: user {} has no access to domain {} (workgroup {})",
+                actor.username, request.adDomain, workgroupId
+            )
+            return HttpResponse.status<Map<String, String>>(io.micronaut.http.HttpStatus.FORBIDDEN)
+                .body(mapOf("error" to "You do not have access to AD domain ${request.adDomain}"))
         }
         return try {
             val saved = service.add(workgroupId, request.adDomain, actor.id!!)

--- a/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAwsAccountController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/WorkgroupAwsAccountController.kt
@@ -1,8 +1,10 @@
 package com.secman.controller
 
 import com.secman.dto.WorkgroupAwsAccountDto
+import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
 import com.secman.repository.WorkgroupRepository
+import com.secman.service.AwsAccountSharingService
 import com.secman.service.DuplicateAccountException
 import com.secman.service.WorkgroupAwsAccountService
 import io.micronaut.http.HttpResponse
@@ -21,16 +23,19 @@ import org.slf4j.LoggerFactory
  * Spec: docs/superpowers/specs/2026-04-28-workgroup-aws-account-assignment-design.md
  *
  * Endpoints:
- * - GET    /api/workgroups/{id}/aws-accounts                 — list (authenticated; access enforced by service+filter)
- * - POST   /api/workgroups/{id}/aws-accounts                 — add (ADMIN)
- * - DELETE /api/workgroups/{id}/aws-accounts/{awsAccountId}  — remove (ADMIN)
+ * - GET    /api/workgroups/{id}/aws-accounts                 — list (ADMIN or direct member)
+ * - POST   /api/workgroups/{id}/aws-accounts                 — add (ADMIN, or a direct member who
+ *                                                              already has access to the account)
+ * - DELETE /api/workgroups/{id}/aws-accounts/{awsAccountId}  — remove (ADMIN or direct member)
  */
 @Controller("/api/workgroups/{workgroupId}/aws-accounts")
 @Secured(SecurityRule.IS_AUTHENTICATED)
 open class WorkgroupAwsAccountController(
     private val service: WorkgroupAwsAccountService,
     private val userRepository: UserRepository,
-    private val workgroupRepository: WorkgroupRepository
+    private val workgroupRepository: WorkgroupRepository,
+    private val userMappingRepository: UserMappingRepository,
+    private val awsAccountSharingService: AwsAccountSharingService
 ) {
     private val logger = LoggerFactory.getLogger(WorkgroupAwsAccountController::class.java)
 
@@ -45,6 +50,29 @@ open class WorkgroupAwsAccountController(
         val workgroup = workgroupRepository.findById(workgroupId).orElse(null) ?: return false
         val user = userRepository.findByUsername(authentication.name).orElse(null) ?: return false
         return workgroup.users.any { it.id == user.id }
+    }
+
+    /**
+     * SECURITY: membership alone must not authorize *binding* an arbitrary AWS account.
+     *
+     * Any authenticated user can create a workgroup and is auto-enrolled as a member
+     * (WorkgroupController.createWorkgroup / WorkgroupService.createWorkgroupWithCreator).
+     * Without this check that member could bind any 12-digit account — which are trivially
+     * enumerable — and AssetRepository.findAccessibleAssets would then hand them every asset,
+     * scan result and vulnerability in it (unified asset access criterion 9). That is a
+     * privilege escalation from USER to "reads an entire AWS account".
+     *
+     * So a non-ADMIN actor may only bind an account they can *already* reach, via either:
+     *   - their own AWS UserMapping (criterion 5), or
+     *   - an AwsAccountSharing rule targeting them (criterion 7).
+     *
+     * Binding then only widens access for *other* workgroup members, never for the actor,
+     * so it cannot be used to escalate.
+     */
+    private fun canBindAccount(actorEmail: String, awsAccountId: String): Boolean {
+        val ownAccounts = userMappingRepository.findDistinctAwsAccountIdByEmail(actorEmail)
+        if (awsAccountId in ownAccounts) return true
+        return awsAccountId in awsAccountSharingService.getSharedAwsAccountIdsByEmail(actorEmail)
     }
 
     @Get(produces = [MediaType.APPLICATION_JSON])
@@ -74,6 +102,14 @@ open class WorkgroupAwsAccountController(
         }
         if (!isMemberOrAdmin(workgroupId, authentication)) {
             return HttpResponse.status<Map<String, String>>(io.micronaut.http.HttpStatus.FORBIDDEN)
+        }
+        if (!authentication.roles.contains("ADMIN") && !canBindAccount(actor.email, request.awsAccountId)) {
+            logger.warn(
+                "Rejected AWS account bind: user {} has no access to account {} (workgroup {})",
+                actor.username, request.awsAccountId, workgroupId
+            )
+            return HttpResponse.status<Map<String, String>>(io.micronaut.http.HttpStatus.FORBIDDEN)
+                .body(mapOf("error" to "You do not have access to AWS account ${request.awsAccountId}"))
         }
         return try {
             val saved = service.add(workgroupId, request.awsAccountId, actor.id!!)

--- a/src/backendng/src/main/kotlin/com/secman/filter/McpDebugHeaderFilter.kt
+++ b/src/backendng/src/main/kotlin/com/secman/filter/McpDebugHeaderFilter.kt
@@ -27,13 +27,29 @@ class McpDebugHeaderFilter : HttpServerFilter {
 
     private val logger = LoggerFactory.getLogger(McpDebugHeaderFilter::class.java)
 
+    companion object {
+        /**
+         * SECURITY: headers whose values are credentials and must never reach the log.
+         *
+         * `Cookie` carries `secman_auth=<JWT>` — a full 8-hour session — and `X-MCP-API-Key` is a
+         * standing MCP credential. Previously only `Authorization` was redacted, so enabling
+         * SECMAN_DEBUG wrote working credentials into the application log in cleartext.
+         */
+        private val REDACTED_HEADERS = setOf(
+            "authorization",
+            "cookie",
+            "set-cookie",
+            "x-mcp-api-key"
+        )
+    }
+
     override fun doFilter(request: HttpRequest<*>, chain: ServerFilterChain): Publisher<MutableHttpResponse<*>> {
         if (logger.isDebugEnabled) {
             val headers = request.headers.asMap()
                 .entries
                 .sortedBy { it.key }
                 .joinToString("\n  ") { (name, values) ->
-                    if (name.equals("Authorization", ignoreCase = true)) {
+                    if (name.lowercase() in REDACTED_HEADERS) {
                         "$name: [PRESENT - ${values.size} value(s)]"
                     } else {
                         "$name: ${values.joinToString(", ")}"

--- a/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/OAuthService.kt
@@ -455,11 +455,12 @@ open class OAuthService(
                     logger.info("[{}] ID token validated successfully. Claims: {}", correlationId,
                         idTokenClaims.keys.joinToString(", "))
 
-                    // Log all claims for debugging
-                    logger.info("[{}] === ID Token Claims ===", correlationId)
-                    idTokenClaims.forEach { (key, value) ->
-                        logger.info("[{}]   {}: {}", correlationId, key, value)
-                    }
+                    // SECURITY: log claim NAMES only, never values. The ID token carries directory
+                    // PII (oid, upn, tid, employee identifiers, group memberships) and the nonce;
+                    // dumping every value at INFO wrote all of it into the application log on every
+                    // OIDC login. The names alone are what troubleshooting actually needs.
+                    logger.debug("[{}] ID token claim names: {}", correlationId,
+                        idTokenClaims.keys.joinToString(", "))
 
                     // Validate tenant ID for Microsoft providers
                     if (!validateTenantId(provider, idTokenClaims)) {
@@ -480,15 +481,18 @@ open class OAuthService(
 
                     // For Microsoft providers, email is required
                     if (provider.name.contains("Microsoft", ignoreCase = true) && emailFromIdToken.isNullOrBlank()) {
-                        logger.error("[{}] Email extraction FAILED for Microsoft provider - checking available claims...", correlationId)
-                        idTokenClaims.forEach { (key, value) ->
-                            if (key.contains("mail", ignoreCase = true) ||
+                        // SECURITY: name the candidate claims, do not print their values (PII).
+                        val candidateClaims = idTokenClaims.keys.filter { key ->
+                            key.contains("mail", ignoreCase = true) ||
                                 key.contains("email", ignoreCase = true) ||
                                 key.contains("upn", ignoreCase = true) ||
-                                key.contains("unique_name", ignoreCase = true)) {
-                                logger.error("[{}]   Found potential email claim: {} = {}", correlationId, key, value)
-                            }
+                                key.contains("unique_name", ignoreCase = true)
                         }
+                        logger.error(
+                            "[{}] Email extraction FAILED for Microsoft provider. Candidate email claims present: {}",
+                            correlationId,
+                            if (candidateClaims.isEmpty()) "none" else candidateClaims.joinToString(", ")
+                        )
                         deleteOAuthStateQuietly(state)
                         return CallbackResult.Error(OAuthErrorCode.EMAIL_REQUIRED.userMessage)
                     }

--- a/src/backendng/src/main/kotlin/com/secman/service/WebAuthnService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/WebAuthnService.kt
@@ -15,6 +15,8 @@ import com.webauthn4j.data.client.Origin
 import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.data.client.challenge.DefaultChallenge
 import com.webauthn4j.server.ServerProperty
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.inject.Singleton
 import org.slf4j.LoggerFactory
@@ -22,6 +24,7 @@ import java.net.URI
 import java.security.SecureRandom
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 /**
  * Service for WebAuthn/FIDO2 operations
@@ -40,12 +43,30 @@ class WebAuthnService(
     private val attestedCredentialDataConverter = AttestedCredentialDataConverter(objectConverter)
     private val secureRandom = SecureRandom()
 
-    // Store challenges temporarily in-memory (TODO: consider persistent cache for multi-instance deployments)
-    private val challengeStore = mutableMapOf<String, Challenge>()
+    /**
+     * Pending WebAuthn challenges, keyed by user id (registration) or username (authentication).
+     *
+     * SECURITY: this must be bounded and self-expiring. `POST /api/passkey/login-options` is
+     * IS_ANONYMOUS and performs no user-existence check, so an unauthenticated caller controls both
+     * the key and the insertion rate — a plain mutableMapOf grew without limit (heap exhaustion),
+     * never enforced the CHALLENGE_TIMEOUT_MS it advertises to the client, and was mutated
+     * concurrently from Netty worker threads without synchronization.
+     *
+     * Caffeine fixes all three: expireAfterWrite matches the advertised timeout so a challenge is
+     * unusable exactly as long as the client believes, maximumSize caps the memory an anonymous
+     * caller can pin, and the map is thread-safe.
+     *
+     * TODO: consider a persistent/shared cache for multi-instance deployments.
+     */
+    private val challengeStore: Cache<String, Challenge> = Caffeine.newBuilder()
+        .expireAfterWrite(CHALLENGE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .maximumSize(MAX_PENDING_CHALLENGES)
+        .build()
 
     companion object {
         private const val RP_NAME = "SecMan"
         private const val CHALLENGE_TIMEOUT_MS = 120000L // 2 minutes
+        private const val MAX_PENDING_CHALLENGES = 10_000L
     }
 
     /**
@@ -92,7 +113,7 @@ class WebAuthnService(
         val challengeBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(challenge.value)
 
         // Store challenge with user ID
-        challengeStore[user.id.toString()] = challenge
+        challengeStore.put(user.id.toString(), challenge)
 
         val userIdBytes = user.id.toString().toByteArray()
         val userIdBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(userIdBytes)
@@ -134,7 +155,7 @@ class WebAuthnService(
     ): PasskeyCredential {
         try {
             // Retrieve stored challenge
-            val challenge = challengeStore.remove(user.id.toString())
+            val challenge = challengeStore.asMap().remove(user.id.toString())
                 ?: throw IllegalArgumentException("Challenge not found or expired")
 
             // Parse the registration response JSON
@@ -200,7 +221,7 @@ class WebAuthnService(
         val challengeBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(challenge.value)
 
         // Store challenge with username
-        challengeStore[username] = challenge
+        challengeStore.put(username, challenge)
 
         return AuthenticationOptionsResponse(
             challenge = challengeBase64,
@@ -220,7 +241,7 @@ class WebAuthnService(
     ): PasskeyCredential {
         try {
             // Retrieve stored challenge
-            val challenge = challengeStore.remove(username)
+            val challenge = challengeStore.asMap().remove(username)
                 ?: throw IllegalArgumentException("Challenge not found or expired")
 
             // Find credential by ID

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -99,6 +99,21 @@ micronaut:
           max-age: 3600
   security:
     authentication: bearer
+    # SECURITY: disable Micronaut's built-in POST /login and POST /logout controllers.
+    # They are registered by default whenever a LoginHandler bean exists (which
+    # `authentication: bearer` guarantees) and are @Secured(IS_ANONYMOUS) on paths outside the
+    # /api/** catch-all, so they bypassed every control implemented in AuthController.login:
+    #   - the MFA gate (AuthenticationProviderUserPassword never consults user.mfaEnabled)
+    #   - the 5-attempt / 15-minute lockout
+    #   - input validation
+    #   - HttpOnly-cookie-only token delivery (the built-in endpoint returns access_token
+    #     in the JSON response body)
+    # This application authenticates exclusively via /api/auth/login; nothing calls /login.
+    endpoints:
+      login:
+        enabled: false
+      logout:
+        enabled: false
     token:
       jwt:
         signatures:

--- a/src/backendng/src/test/kotlin/com/secman/controller/TranslationConfigControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/TranslationConfigControllerAuthorizationTest.kt
@@ -1,0 +1,88 @@
+package com.secman.controller
+
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Authorization contract for [TranslationConfigController].
+ *
+ * `@Secured` is enforced declaratively by Micronaut, so this pins the annotations themselves —
+ * the test fails if anyone removes or weakens one, which is exactly the regression that mattered:
+ * the controller previously carried only a class-level `IS_AUTHENTICATED` and no method-level role
+ * check, so any authenticated user could rewrite `baseUrl` on the active LLM config. Since
+ * TranslationService sends the stored key as `Authorization: Bearer` to whatever host that names,
+ * that leaked both the API key and the requirement text being translated, and `/test` doubled as an
+ * outbound-fetch primitive.
+ *
+ * Reads deliberately stay `IS_AUTHENTICATED`: non-admin pages (Export.tsx, ImportExport.tsx) call
+ * `GET /active` to decide whether to offer translated export, and every read masks the credential
+ * through `TranslationConfig.toSafeResponse()`.
+ */
+class TranslationConfigControllerAuthorizationTest {
+
+    private val controller = TranslationConfigController::class.java
+
+    private val mutatingMethods = listOf(
+        "createConfig",
+        "updateConfig",
+        "deleteConfig",
+        "testConfig",
+        "activateConfig",
+        "deactivateConfig"
+    )
+
+    private val readMethods = listOf(
+        "getAllConfigs",
+        "getActiveConfig",
+        "getConfig",
+        "getAvailableModels",
+        "getSupportedLanguages"
+    )
+
+    @Test
+    fun `class-level security is authenticated`() {
+        val secured = controller.getAnnotation(Secured::class.java)
+        assertNotNull(secured, "TranslationConfigController must carry a class-level @Secured")
+        assertEquals(
+            listOf(SecurityRule.IS_AUTHENTICATED),
+            secured.value.toList(),
+            "Class-level access must stay IS_AUTHENTICATED so non-admin reads keep working"
+        )
+    }
+
+    @Test
+    fun `every mutating endpoint is ADMIN-only`() {
+        mutatingMethods.forEach { name ->
+            val method = controller.methods.firstOrNull { it.name == name }
+            assertNotNull(method, "Expected method $name on TranslationConfigController")
+
+            val secured = method!!.getAnnotation(Secured::class.java)
+            assertNotNull(
+                secured,
+                "$name mutates LLM configuration and must carry a method-level @Secured(\"ADMIN\")"
+            )
+            assertEquals(
+                listOf("ADMIN"),
+                secured!!.value.toList(),
+                "$name must be restricted to ADMIN"
+            )
+        }
+    }
+
+    @Test
+    fun `read endpoints stay accessible to any authenticated user`() {
+        readMethods.forEach { name ->
+            val method = controller.methods.firstOrNull { it.name == name }
+            assertNotNull(method, "Expected method $name on TranslationConfigController")
+
+            assertNull(
+                method!!.getAnnotation(Secured::class.java),
+                "$name must inherit the class-level IS_AUTHENTICATED — the Export page depends on it"
+            )
+        }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAdDomainControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAdDomainControllerAuthorizationTest.kt
@@ -2,6 +2,8 @@ package com.secman.controller
 
 import com.secman.domain.User
 import com.secman.domain.Workgroup
+import com.secman.domain.WorkgroupAdDomain
+import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
 import com.secman.repository.WorkgroupRepository
 import com.secman.service.WorkgroupAdDomainService
@@ -12,34 +14,50 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.Optional
 
 /**
- * Regression coverage for the `list` endpoint's authorization: it must be
- * member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
- * documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ * Authorization coverage for [WorkgroupAdDomainController].
+ *
+ * Two contracts are pinned here:
+ *
+ * 1. `list` is member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
+ *    documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ *
+ * 2. `add` additionally requires that a non-ADMIN actor already reaches the domain through their
+ *    own domain UserMapping. Membership alone is not enough: any user can create a workgroup and
+ *    is auto-enrolled as a member, so a membership-only check let a plain USER bind an arbitrary
+ *    AD domain and thereby read every asset in it.
  */
 class WorkgroupAdDomainControllerAuthorizationTest {
 
     private lateinit var service: WorkgroupAdDomainService
     private lateinit var userRepository: UserRepository
     private lateinit var workgroupRepository: WorkgroupRepository
+    private lateinit var userMappingRepository: UserMappingRepository
     private lateinit var controller: WorkgroupAdDomainController
 
     private val member = User(id = 1L, username = "member", email = "member@example.com", passwordHash = "x")
     private val outsider = User(id = 2L, username = "outsider", email = "outsider@example.com", passwordHash = "x")
     private val admin = User(id = 3L, username = "admin", email = "admin@example.com", passwordHash = "x")
 
+    private val ownedDomain = "corp.example.com"
+    private val foreignDomain = "secret.example.com"
+
     @BeforeEach
     fun setUp() {
         service = mockk()
         userRepository = mockk()
         workgroupRepository = mockk()
-        controller = WorkgroupAdDomainController(service, userRepository, workgroupRepository)
+        userMappingRepository = mockk()
+        controller = WorkgroupAdDomainController(service, userRepository, workgroupRepository, userMappingRepository)
 
         every { userRepository.findByUsername(member.username) } returns Optional.of(member)
         every { userRepository.findByUsername(outsider.username) } returns Optional.of(outsider)
         every { userRepository.findByUsername(admin.username) } returns Optional.of(admin)
+
+        every { userMappingRepository.findDistinctDomainByEmail(member.email) } returns listOf(ownedDomain)
     }
 
     @Test
@@ -71,6 +89,76 @@ class WorkgroupAdDomainControllerAuthorizationTest {
 
         assertEquals(HttpStatus.OK, response.status)
     }
+
+    // --- `add`: ownership gate (privilege-escalation regression) ---
+
+    @Test
+    fun `member cannot bind an ad domain they have no access to`() {
+        val workgroup = workgroupOwnedByMember(40L)
+        every { workgroupRepository.findById(40L) } returns Optional.of(workgroup)
+
+        val response = controller.add(40L, AddAdDomainRequest(foreignDomain), auth(member))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+        io.mockk.verify(exactly = 0) { service.add(any(), any(), any()) }
+    }
+
+    @Test
+    fun `member can bind an ad domain from their own user mapping`() {
+        val workgroup = workgroupOwnedByMember(41L)
+        every { workgroupRepository.findById(41L) } returns Optional.of(workgroup)
+        every { service.add(41L, ownedDomain, member.id!!) } returns persisted(workgroup, ownedDomain)
+
+        val response = controller.add(41L, AddAdDomainRequest(ownedDomain), auth(member))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `ad domain ownership match is case-insensitive`() {
+        val workgroup = workgroupOwnedByMember(42L)
+        val upperCased = ownedDomain.uppercase()
+        every { workgroupRepository.findById(42L) } returns Optional.of(workgroup)
+        every { service.add(42L, upperCased, member.id!!) } returns persisted(workgroup, upperCased)
+
+        val response = controller.add(42L, AddAdDomainRequest(upperCased), auth(member))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `admin can bind any ad domain without a mapping`() {
+        val workgroup = workgroupOwnedByMember(43L)
+        every { service.add(43L, foreignDomain, admin.id!!) } returns persisted(workgroup, foreignDomain)
+
+        val response = controller.add(43L, AddAdDomainRequest(foreignDomain), auth(admin, roles = setOf("ADMIN")))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `non-member cannot bind even a domain they own`() {
+        val workgroup = workgroupOwnedByMember(44L)
+        every { workgroupRepository.findById(44L) } returns Optional.of(workgroup)
+        every { userMappingRepository.findDistinctDomainByEmail(outsider.email) } returns listOf(ownedDomain)
+
+        val response = controller.add(44L, AddAdDomainRequest(ownedDomain), auth(outsider))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+        io.mockk.verify(exactly = 0) { service.add(any(), any(), any()) }
+    }
+
+    private fun workgroupOwnedByMember(id: Long) =
+        Workgroup(id = id, name = "wg-$id", createdBy = member, users = mutableSetOf(member))
+
+    private fun persisted(workgroup: Workgroup, domain: String) = WorkgroupAdDomain(
+        id = 100L,
+        workgroup = workgroup,
+        adDomain = domain,
+        createdBy = member,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH
+    )
 
     private fun auth(user: User, roles: Set<String> = setOf("USER")): Authentication = mockk {
         every { name } returns user.username

--- a/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAwsAccountControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/WorkgroupAwsAccountControllerAuthorizationTest.kt
@@ -2,8 +2,11 @@ package com.secman.controller
 
 import com.secman.domain.User
 import com.secman.domain.Workgroup
+import com.secman.domain.WorkgroupAwsAccount
+import com.secman.repository.UserMappingRepository
 import com.secman.repository.UserRepository
 import com.secman.repository.WorkgroupRepository
+import com.secman.service.AwsAccountSharingService
 import com.secman.service.WorkgroupAwsAccountService
 import io.micronaut.http.HttpStatus
 import io.micronaut.security.authentication.Authentication
@@ -12,34 +15,57 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.Optional
 
 /**
- * Regression coverage for the `list` endpoint's authorization: it must be
- * member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
- * documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ * Authorization coverage for [WorkgroupAwsAccountController].
+ *
+ * Two contracts are pinned here:
+ *
+ * 1. `list` is member-or-ADMIN scoped like the sibling `add`/`remove` handlers, per the
+ *    documented "ADMIN/member-scoped" contract in CLAUDE.md.
+ *
+ * 2. `add` additionally requires that a non-ADMIN actor already has access to the account being
+ *    bound. Membership alone is not enough: any user can create a workgroup and is auto-enrolled
+ *    as a member, so a membership-only check let a plain USER bind an arbitrary (enumerable)
+ *    12-digit account and thereby read every asset and vulnerability in it.
  */
 class WorkgroupAwsAccountControllerAuthorizationTest {
 
     private lateinit var service: WorkgroupAwsAccountService
     private lateinit var userRepository: UserRepository
     private lateinit var workgroupRepository: WorkgroupRepository
+    private lateinit var userMappingRepository: UserMappingRepository
+    private lateinit var awsAccountSharingService: AwsAccountSharingService
     private lateinit var controller: WorkgroupAwsAccountController
 
     private val member = User(id = 1L, username = "member", email = "member@example.com", passwordHash = "x")
     private val outsider = User(id = 2L, username = "outsider", email = "outsider@example.com", passwordHash = "x")
     private val admin = User(id = 3L, username = "admin", email = "admin@example.com", passwordHash = "x")
 
+    private val ownedAccount = "111111111111"
+    private val sharedAccount = "222222222222"
+    private val foreignAccount = "999999999999"
+
     @BeforeEach
     fun setUp() {
         service = mockk()
         userRepository = mockk()
         workgroupRepository = mockk()
-        controller = WorkgroupAwsAccountController(service, userRepository, workgroupRepository)
+        userMappingRepository = mockk()
+        awsAccountSharingService = mockk()
+        controller = WorkgroupAwsAccountController(
+            service, userRepository, workgroupRepository, userMappingRepository, awsAccountSharingService
+        )
 
         every { userRepository.findByUsername(member.username) } returns Optional.of(member)
         every { userRepository.findByUsername(outsider.username) } returns Optional.of(outsider)
         every { userRepository.findByUsername(admin.username) } returns Optional.of(admin)
+
+        // The member owns one account outright and reaches a second via a sharing rule.
+        every { userMappingRepository.findDistinctAwsAccountIdByEmail(member.email) } returns listOf(ownedAccount)
+        every { awsAccountSharingService.getSharedAwsAccountIdsByEmail(member.email) } returns listOf(sharedAccount)
     }
 
     @Test
@@ -71,6 +97,76 @@ class WorkgroupAwsAccountControllerAuthorizationTest {
 
         assertEquals(HttpStatus.OK, response.status)
     }
+
+    // --- `add`: ownership gate (privilege-escalation regression) ---
+
+    @Test
+    fun `member cannot bind an aws account they have no access to`() {
+        val workgroup = workgroupOwnedByMember(30L)
+        every { workgroupRepository.findById(30L) } returns Optional.of(workgroup)
+
+        val response = controller.add(30L, AddAwsAccountRequest(foreignAccount), auth(member))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+        // The service must never be reached — the account must not be bound at all.
+        io.mockk.verify(exactly = 0) { service.add(any(), any(), any()) }
+    }
+
+    @Test
+    fun `member can bind an aws account from their own user mapping`() {
+        val workgroup = workgroupOwnedByMember(31L)
+        every { workgroupRepository.findById(31L) } returns Optional.of(workgroup)
+        every { service.add(31L, ownedAccount, member.id!!) } returns persisted(workgroup, ownedAccount)
+
+        val response = controller.add(31L, AddAwsAccountRequest(ownedAccount), auth(member))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `member can bind an aws account shared with them`() {
+        val workgroup = workgroupOwnedByMember(32L)
+        every { workgroupRepository.findById(32L) } returns Optional.of(workgroup)
+        every { service.add(32L, sharedAccount, member.id!!) } returns persisted(workgroup, sharedAccount)
+
+        val response = controller.add(32L, AddAwsAccountRequest(sharedAccount), auth(member))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `admin can bind any aws account without a mapping`() {
+        val workgroup = workgroupOwnedByMember(33L)
+        every { service.add(33L, foreignAccount, admin.id!!) } returns persisted(workgroup, foreignAccount)
+
+        val response = controller.add(33L, AddAwsAccountRequest(foreignAccount), auth(admin, roles = setOf("ADMIN")))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+    }
+
+    @Test
+    fun `non-member cannot bind even an account they own`() {
+        val workgroup = workgroupOwnedByMember(34L)
+        every { workgroupRepository.findById(34L) } returns Optional.of(workgroup)
+        every { userMappingRepository.findDistinctAwsAccountIdByEmail(outsider.email) } returns listOf(ownedAccount)
+
+        val response = controller.add(34L, AddAwsAccountRequest(ownedAccount), auth(outsider))
+
+        assertEquals(HttpStatus.FORBIDDEN, response.status)
+        io.mockk.verify(exactly = 0) { service.add(any(), any(), any()) }
+    }
+
+    private fun workgroupOwnedByMember(id: Long) =
+        Workgroup(id = id, name = "wg-$id", createdBy = member, users = mutableSetOf(member))
+
+    private fun persisted(workgroup: Workgroup, accountId: String) = WorkgroupAwsAccount(
+        id = 100L,
+        workgroup = workgroup,
+        awsAccountId = accountId,
+        createdBy = member,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH
+    )
 
     private fun auth(user: User, roles: Set<String> = setOf("USER")): Authentication = mockk {
         every { name } returns user.username


### PR DESCRIPTION
## Summary

- Full security review across authn/authz/RBAC, injection & unsafe data handling, and secrets/frontend/crypto. Four issues were verified in code that allow authentication bypass or privilege escalation; three cheap hardening items are fixed alongside them.
- **One critical finding is not fixable in code and needs your action — see "Action required" below.**
- The classic injection surface came back clean: SQL injection (whitelisted sort maps, bound parameters throughout), XXE (both XML importers fully hardened), deserialization, command execution (argv form + an explicit argument-injection guard), path traversal (canonical-containment re-checks on read *and* write), and zip-slip/zip-bomb caps.

## Action required — leaked secrets (not fixed here, by request)

The repository is **public**, and `git log -S` traces these to the **initial commit**. Removing them from HEAD would not help; they are in history and must be assumed scraped. **Rotation is the only remediation.**

| File | Secret |
|---|---|
| `secman.env`, `secmanpp.env` | `JWT_SECRET` — a real 48-byte value. Every other line in these files is a `pass://` indirection; this one is a pasted literal. |
| `src/misc/mcp.py` | A live `X-MCP-API-Key` (an unused `"your-api-key-here"` placeholder sits directly above it) |
| `src/frontend/cookies.txt` | A curl cookie jar holding an HS256 session JWT for an ADMIN user |

Signing is HS256 and tokens are minted from a plain claim map, so anyone holding that secret can forge an ADMIN token for any user. `JwtSigningValidator` only rejects the *documented default* literal by exact string match, so a committed non-default secret passes it. `.gitignore` covers `.env`/`.env.*` but not `secman.env`/`secmanpp.env`.

Suggested: rotate `JWT_SECRET` and the MCP key in Proton Pass, revoke the MCP key row, redeploy, then decide separately about history rewriting.

## Changes

Four commits, one per finding, each independently revertable.

**`WorkgroupAwsAccountController` / `WorkgroupAdDomainController` — privilege escalation.** Any authenticated user could read every asset, scan result and vulnerability in an arbitrary AWS account or AD domain in three calls: create a workgroup (non-admin creators are auto-enrolled as members), bind any 12-digit account to it (gated only on membership), and `findAccessibleAssets` honours the binding. A non-ADMIN actor may now only bind something they already reach — their own `UserMapping`, or an `AwsAccountSharing` rule targeting them — reusing the exact lookups `AssetFilterService` already uses, so the boundary stays defined in one place. `list`/`remove` unchanged; removal only reduces access. Both controllers' KDoc claimed ADMIN-only and had drifted from the code; now corrected.

**`application.yml` — built-in `POST /login` disabled.** `authentication: bearer` registers a `LoginHandler`, and `endpoints.login.enabled` was never set, so Micronaut's own `LoginController` was live, `IS_ANONYMOUS`, outside the `/api/**` catch-all. It bypassed the MFA gate (the backing provider never consults `mfaEnabled`), the 5-attempt lockout, input validation, and cookie-only token delivery — it returns `access_token` in the JSON body. Nothing calls it; the app uses `/api/auth/login`.

**`TranslationConfigController` — LLM config takeover.** Class-level `IS_AUTHENTICATED` only, with no method-level role check anywhere. Any user could rewrite `baseUrl` on the active config; `TranslationService` sends the stored key as `Authorization: Bearer` to whatever host it names, exfiltrating both the API key and the requirement text. `/test` was a blind outbound-fetch primitive. All six mutators are now `@Secured("ADMIN")`. Reads stay `IS_AUTHENTICATED` — `Export.tsx` and `ImportExport.tsx` depend on `GET /active`, and reads already mask via `toSafeResponse()`.

**Hardening.** `OAuthService` dumped the full ID-token claim set (oid, upn, tid, nonce, group memberships) at INFO on every OIDC login — now names only, at debug. `McpDebugHeaderFilter` redacted `Authorization` but printed `Cookie` (carrying `secman_auth`) and `X-MCP-API-Key` verbatim — redaction set extended. `WebAuthnService.challengeStore` was an unbounded, non-thread-safe map written from an `IS_ANONYMOUS` endpoint with no expiry — now a Caffeine cache, fixing all three.

## Testing

⚠️ **The build and E2E gates could NOT be run in this environment** — the agent proxy returns 403 for both `repo1.maven.org` and `services.gradle.org`, and there is no Gradle dependency cache, so `./gradlew build` cannot resolve anything. **These gates must be run before merge.**

What was done instead: every edited file was parsed with the Kotlin 2.0 compiler to confirm no syntax errors were introduced (all remaining diagnostics are `unresolved reference` cascades from the absent classpath, and the few structural ones were verified as pre-existing lines untouched by this change). `application.yml` was parsed to confirm `micronaut.security.endpoints` is nested correctly and the unrelated top-level management `endpoints:` block is intact.

- [ ] `./gradlew build` is clean
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes)
- [x] New/updated unit tests cover the change — see below
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user)
- [ ] `/e2evulnexception` passes with 0 failures

Tests added/updated (all DB-free Mockk/reflection tests):

- `WorkgroupAwsAccountControllerAuthorizationTest` — member without mapping denied (and the service never reached); member with own mapping allowed; member with a shared account allowed; ADMIN allowed without a mapping; non-member denied even for an account they own. Constructor updated for the new dependencies.
- `WorkgroupAdDomainControllerAuthorizationTest` — same matrix, plus case-insensitive domain matching.
- `TranslationConfigControllerAuthorizationTest` (new) — asserts the `@Secured` annotations themselves, since Micronaut enforces them declaratively: all six mutators ADMIN-only, reads left inheriting `IS_AUTHENTICATED`.

Targeted manual checks worth running once the stack is up (against `SECMAN_HOST`, not localhost): `POST /login` → 404 while `/api/auth/login` still sets `secman_auth`; a normal user binding an unmapped account → 403 and a mapped one → 201; a normal user `POST /api/translation-config` → 403 while `GET /active` → 200.

## Backend contract changes

- [x] Contract changed — but no `extensions/` client is affected

`@Secured` was tightened on `/api/workgroups/{id}/{aws-accounts,ad-domains}` and `/api/translation-config/*`, and `POST /login` was removed. The documented client surface is `/api/auth/login`, `/api/vulnerabilities/{cli-add,current}`, `/api/assets/import` and `/mcp` — none is touched in path, method, request/response fields, auth scheme or roles.

Note: the rediscovery grep from CLAUDE.md could not be run here — the client repos are gitignored and only `extensions/README.MD` exists in this clone. Worth re-running where they are checked out.

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable
- [x] Input validation / file handling reviewed for new attack surface
- [x] No secrets hardcoded (uses `pass-cli`) — no secret values are reproduced in this PR

## Reported, not fixed

Out of the agreed scope for this PR, roughly by severity: MCP delegation acts as an impersonation credential (a key with `delegationEnabled` can act as any user in an allowed domain, including ADMIN); MCP auth BCrypt-compares a bad key against every active key (unauthenticated CPU exhaustion) and its IP lockout is dead code because no caller passes an IP; requester-controlled `reason`/`requesterName` are interpolated raw into approver HTML emails (the `escapeHtml` pattern already exists in five sibling services); there is no CSRF filter at all and the frontend token is always empty, leaving `SameSite=Lax` as the only control; `DemandClassificationController` allows anonymous writes behind a predictable SHA-256 capability token; `?token=<jwt>` authenticates *any* endpoint, not just SSE; deny-list-only SSRF validation for IdP URLs and none at all for LLM base URLs; OIDC validates neither `aud` nor `nonce` and links accounts by email with no `email_verified` check; there is no account-disable flag and no JWT revocation; login rate limiting is username-keyed only (sprayable, and a lockout DoS); `GET /api/requirements/export/xlsx` dumps every requirement anonymously; `ConfigBundleService` assigns one shared literal password to every imported user including ADMINs. Separately, `McpAccessControlService` omits workgroup AWS accounts while implementing workgroup AD domains, so MCP and the web API grant different asset sets — a correctness gap, not a hole, since MCP grants less.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8yNf4ZLZMTENnCigGfBNi)_