### PR TITLE
Fix crash on /chat-notifications when a user has no subscriptions

### DIFF
--- a/src/frontend/src/components/NotificationEventSelector.tsx
+++ b/src/frontend/src/components/NotificationEventSelector.tsx
@@ -24,13 +24,19 @@ export default function NotificationEventSelector({
   disabled = false,
   onToggle,
 }: Props) {
-  if (availableEventTypes.length === 0) {
+  // Both lists arrive from an API response, and Micronaut Serde drops empty collections
+  // from the body rather than sending `[]`. A missing key used to throw here and take the
+  // whole settings card down, so treat "absent" as "empty" instead of trusting the type.
+  const eventTypes = Array.isArray(availableEventTypes) ? availableEventTypes : [];
+  const selectedNames = Array.isArray(selected) ? selected : [];
+
+  if (eventTypes.length === 0) {
     return <p className="text-muted">No notification events are available.</p>;
   }
 
   return (
     <>
-      {availableEventTypes.map((eventType) => {
+      {eventTypes.map((eventType) => {
         const id = `${idPrefix}-event-${eventType.name}`;
         return (
           <div className="form-check mb-3" key={eventType.name}>
@@ -38,7 +44,7 @@ export default function NotificationEventSelector({
               className="form-check-input"
               type="checkbox"
               id={id}
-              checked={selected.includes(eventType.name)}
+              checked={selectedNames.includes(eventType.name)}
               onChange={() => onToggle(eventType.name)}
               disabled={disabled}
             />

--- a/src/frontend/src/services/chatNotificationService.ts
+++ b/src/frontend/src/services/chatNotificationService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { normalizeChatSettings } from './chatSettingsNormalizer';
 
 // API base URL - always use relative URLs to go through Astro's proxy and avoid CORS issues
 const API_BASE_URL = import.meta.env.PUBLIC_API_URL || '';
@@ -100,14 +101,14 @@ const JSON_HEADERS = { headers: { 'Content-Type': 'application/json' } };
 /** Current user's Slack settings, plus the catalogue of subscribable events. */
 export async function getSlackSettings(): Promise<SlackSettings> {
   const response = await axios.get(`${API_BASE_URL}/api/slack/settings`);
-  return response.data;
+  return normalizeChatSettings<SlackSettings>(response.data);
 }
 
 export async function updateSlackSettings(
   request: UpdateSlackSettingsRequest
 ): Promise<SlackSettings> {
   const response = await axios.put(`${API_BASE_URL}/api/slack/settings`, request, JSON_HEADERS);
-  return response.data;
+  return normalizeChatSettings<SlackSettings>(response.data);
 }
 
 export async function sendSlackTestMessage(): Promise<ChatTestResult> {
@@ -118,14 +119,14 @@ export async function sendSlackTestMessage(): Promise<ChatTestResult> {
 /** Current user's Telegram settings, plus the catalogue of subscribable events. */
 export async function getTelegramSettings(): Promise<TelegramSettings> {
   const response = await axios.get(`${API_BASE_URL}/api/telegram/settings`);
-  return response.data;
+  return normalizeChatSettings<TelegramSettings>(response.data);
 }
 
 export async function updateTelegramSettings(
   request: UpdateTelegramSettingsRequest
 ): Promise<TelegramSettings> {
   const response = await axios.put(`${API_BASE_URL}/api/telegram/settings`, request, JSON_HEADERS);
-  return response.data;
+  return normalizeChatSettings<TelegramSettings>(response.data);
 }
 
 export async function sendTelegramTestMessage(): Promise<ChatTestResult> {

--- a/src/frontend/src/services/chatSettingsNormalizer.test.ts
+++ b/src/frontend/src/services/chatSettingsNormalizer.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeChatSettings } from './chatSettingsNormalizer.ts';
+
+/**
+ * Regression: uncaught TypeError "Cannot read properties of undefined (reading 'includes')"
+ * on /chat-notifications, which blanked both the Slack and the Telegram settings card.
+ *
+ * Micronaut Serde omits empty collections from a response body, so a user with no
+ * subscriptions yet receives a payload with no `eventTypes` key at all. The component then
+ * called `.includes()` on `undefined`.
+ */
+test('a response with no eventTypes key yields an empty selection, not undefined', () => {
+  const raw = {
+    enabled: false,
+    webhookUrlConfigured: false,
+    channel: null,
+    availableEventTypes: [
+      { name: 'CROWDSTRIKE_IMPORT_COMPLETED', displayName: 'CrowdStrike', description: 'x' },
+    ],
+  } as any;
+
+  const normalized = normalizeChatSettings(raw);
+
+  assert.deepEqual(normalized.eventTypes, []);
+  assert.equal(normalized.availableEventTypes.length, 1);
+});
+
+test('a response with no availableEventTypes key yields an empty catalogue', () => {
+  const normalized = normalizeChatSettings({ enabled: true, eventTypes: ['A'] } as any);
+
+  assert.deepEqual(normalized.availableEventTypes, []);
+  assert.deepEqual(normalized.eventTypes, ['A']);
+});
+
+test('populated arrays are passed through untouched', () => {
+  const catalogue = [{ name: 'A', displayName: 'A', description: 'a' }];
+  const normalized = normalizeChatSettings({
+    enabled: true,
+    eventTypes: ['A'],
+    availableEventTypes: catalogue,
+  } as any);
+
+  assert.deepEqual(normalized.eventTypes, ['A']);
+  assert.deepEqual(normalized.availableEventTypes, catalogue);
+});
+
+test('every other field survives normalization', () => {
+  const normalized = normalizeChatSettings({
+    enabled: true,
+    chatId: '12345',
+    botTokenConfigured: true,
+    lastNotifiedAt: '2026-08-06T10:00:00',
+    lastDeliveryStatus: 'SUCCESS',
+    lastDeliveryError: null,
+    workspaceBotAvailable: true,
+  } as any);
+
+  assert.equal(normalized.enabled, true);
+  assert.equal((normalized as any).chatId, '12345');
+  assert.equal((normalized as any).botTokenConfigured, true);
+  assert.equal((normalized as any).lastDeliveryStatus, 'SUCCESS');
+  assert.equal((normalized as any).lastDeliveryError, null);
+});
+
+// A body that is not an object at all (empty 200, proxy hiccup) must not throw either —
+// the card should render its "no events available" state rather than crash the page.
+test('a null body normalizes to empty arrays instead of throwing', () => {
+  const normalized = normalizeChatSettings(null as any);
+
+  assert.deepEqual(normalized.eventTypes, []);
+  assert.deepEqual(normalized.availableEventTypes, []);
+});

--- a/src/frontend/src/services/chatSettingsNormalizer.ts
+++ b/src/frontend/src/services/chatSettingsNormalizer.ts
@@ -1,0 +1,32 @@
+import type { NotificationEventType } from './chatNotificationService';
+
+/**
+ * Shape shared by the Slack and Telegram settings responses: the events the user is
+ * subscribed to, plus the catalogue of events that can be subscribed to.
+ */
+export interface ChatSettingsArrays {
+  eventTypes: string[];
+  availableEventTypes: NotificationEventType[];
+}
+
+/**
+ * Fill in the array fields a chat-settings response can legitimately arrive without.
+ *
+ * Micronaut Serde omits empty collections from the serialized body, so a user who has not
+ * subscribed to anything yet receives a payload with **no `eventTypes` key at all** rather
+ * than `eventTypes: []`. Handing that straight to React state made
+ * `NotificationEventSelector` call `.includes()` on `undefined` and take both settings
+ * cards down with an uncaught TypeError — the page rendered its heading and nothing else.
+ *
+ * Normalising here rather than in the components keeps every consumer of the service safe,
+ * and matches how the other services in this app absorb the same serializer behaviour
+ * (`data.products ?? []`, `data.adDomains ?? []`).
+ */
+export function normalizeChatSettings<T extends ChatSettingsArrays>(raw: T): T {
+  const data = (raw ?? {}) as T;
+  return {
+    ...data,
+    eventTypes: Array.isArray(data.eventTypes) ? data.eventTypes : [],
+    availableEventTypes: Array.isArray(data.availableEventTypes) ? data.availableEventTypes : [],
+  };
+}


### PR DESCRIPTION
## Summary

- `/chat-notifications` rendered only its heading: both the Slack and the Telegram settings card died with an uncaught `TypeError: Cannot read properties of undefined (reading 'includes')` in `NotificationEventSelector`.
- Root cause: Micronaut Serde omits empty collections from a serialized body, so a user who has not subscribed to any event yet gets a settings response with **no `eventTypes` key at all** rather than `eventTypes: []`. That `undefined` went into React state and reached `selected.includes(...)`. `availableEventTypes` is never empty, which is why the `.map` ran and only the membership test threw.
- Fixed at the service layer so every consumer is safe, plus a guard in the component so no caller can blank the page again.

## Changes

- `src/frontend/src/services/chatSettingsNormalizer.ts` (new) — `normalizeChatSettings()` fills in `eventTypes` / `availableEventTypes` when the serializer omitted them; tolerates a non-object body.
- `src/frontend/src/services/chatNotificationService.ts` — applied on all four settings reads/writes (Slack + Telegram, GET + PUT). Matches how the other services here absorb the same serializer behaviour (`data.products ?? []`, `data.adDomains ?? []`).
- `src/frontend/src/components/NotificationEventSelector.tsx` — treats both list props as possibly-absent; a genuinely empty catalogue now renders the existing empty state instead of throwing.
- `src/frontend/src/services/chatSettingsNormalizer.test.ts` (new) — covers the missing-key regression, a missing catalogue, pass-through of populated arrays and other fields, and a null body.

Frontend-only. No schema, endpoint, role or backend change.

## Testing

- [x] `cd src/frontend && npm ci && npm run build` exits 0 (frontend changes)
- [x] New/updated unit tests cover the change — `npm test`: 81 passing, 0 failing
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — **not run**: this container has no `pass-cli`, so the credentials and `SECMAN_HOST` the gate needs are unavailable here. Needs a run on a host that has them before merge.
- [ ] `/e2evulnexception` passes with 0 failures — **not run**, same reason.

`./gradlew build` and the backend startup check are not applicable — no Kotlin or backend resource was touched.

## Backend contract changes

- [x] N/A — no backend contract changes

## Security

- [x] RBAC unchanged — no `@Secured` or UI role gate touched
- [x] Input validation / file handling — no new attack surface; the change only widens tolerance of a missing response field, and the values still flow through the same validated save path
- [x] No secrets hardcoded (uses `pass-cli`)

OWASP: none of A01–A10 touched — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bNvp6GUDcmS4BKY1yPfbL)_