### PR TITLE
Security review: HTML injection in exception emails + anonymous read of internal demand classifications

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/DemandClassificationController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/DemandClassificationController.kt
@@ -340,13 +340,33 @@ open class DemandClassificationController(
         }
     }
     
+    /**
+     * `classificationHash` is derived from `demandId-classification-timestamp` (see
+     * DemandClassificationResult.generateHash) purely to make results independently
+     * addressable — it is not a secret capability token. Anonymous access is safe only for
+     * results with `demand == null`, i.e. ones created via the genuinely public
+     * `/public/classify` endpoint above. A result with a non-null `demand` came from the
+     * ADMIN/SECCHAMPION-only `/classify-demand` endpoint and carries the real demand's
+     * title/description/businessJustification (`inputData`) — anonymous callers must not be
+     * able to read that just by holding (or brute-forcing/leaking) the hash.
+     */
     @Get("/results/{hash}")
     @Secured(SecurityRule.IS_ANONYMOUS)
     @Transactional(readOnly = true)
-    open fun getResultByHash(hash: String): HttpResponse<DemandClassificationResult> {
-        return resultRepository.findByClassificationHash(hash)
-            .map { HttpResponse.ok(it) }
-            .orElse(HttpResponse.notFound())
+    open fun getResultByHash(hash: String, @Nullable authentication: Authentication?): HttpResponse<DemandClassificationResult> {
+        val result = resultRepository.findByClassificationHash(hash).orElse(null)
+            ?: return HttpResponse.notFound()
+
+        if (result.demand != null) {
+            val roles = authentication?.roles ?: emptyList()
+            if (!roles.contains("ADMIN") && !roles.contains("SECCHAMPION")) {
+                // 404, not 403: do not confirm to an anonymous caller that a demand-linked
+                // hash exists.
+                return HttpResponse.notFound()
+            }
+        }
+
+        return HttpResponse.ok(result)
     }
     
     @Get("/statistics")

--- a/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExceptionRequestNotificationService.kt
@@ -50,6 +50,19 @@ open class ExceptionRequestNotificationService(
     private fun dashboardUrl(): String =
         "${appConfig.backend.baseUrl.trimEnd('/')}$DASHBOARD_PATH"
 
+    /**
+     * Escape HTML metacharacters before interpolating user/DB-controlled text (requester
+     * username, free-text reason, reviewer comment, subject/scope values) into an HTML email
+     * body. Mirrors the identical helper already used by AwsAccountRiskAssessmentService,
+     * NewAccountNotificationService, OAuthService and other email-generating services.
+     */
+    private fun escapeHtml(text: String): String =
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;")
+
     private fun loadLogoInlineImage(): Map<String, Pair<ByteArray, String>> {
         return try {
             val logoBytes = javaClass.getResourceAsStream("/email-templates/SecManLogo.png")
@@ -378,25 +391,27 @@ open class ExceptionRequestNotificationService(
      * @return HTML email content
      */
     private fun generateNewRequestEmail(request: VulnerabilityExceptionRequest, recipientName: String): String {
-        val cveId = describeSubject(request)
-        val scopeDescription = describeScope(request)
-        val assetName = resolveAssetName(request)
-        val assetIp = resolveAssetIp(request)
-        val originatingAssetRow = if (request.scope != VulnerabilityException.Scope.ASSET && assetName != "Unknown Asset") {
+        val cveId = escapeHtml(describeSubject(request))
+        val scopeDescription = escapeHtml(describeScope(request))
+        val assetName = escapeHtml(resolveAssetName(request))
+        val assetIp = escapeHtml(resolveAssetIp(request))
+        val originatingAssetRow = if (request.scope != VulnerabilityException.Scope.ASSET && resolveAssetName(request) != "Unknown Asset") {
             """
                                 <tr>
                                     <td style="padding:12px 14px;background-color:#f7f9fc;border:1px solid #e2e8f0;border-radius:6px 0 0 6px;font-weight:600;color:#475569;font-size:12px;text-transform:uppercase;letter-spacing:0.6px;">Originating Asset</td>
                                     <td style="padding:12px 14px;background-color:#ffffff;border:1px solid #e2e8f0;border-left:0;border-radius:0 6px 6px 0;color:#1f2933;font-size:14px;">$assetName <span style="color:#64748b;">($assetIp)</span></td>
                                 </tr>"""
         } else ""
-        val requesterName = request.requestedByUsername
-        val reasonSummary = if (request.reason.length > 200) {
+        val requesterName = escapeHtml(request.requestedByUsername)
+        val rawReasonSummary = if (request.reason.length > 200) {
             request.reason.substring(0, 200) + "..."
         } else {
             request.reason
         }
+        val reasonSummary = escapeHtml(rawReasonSummary)
         val submittedDate = request.createdAt?.format(DATE_FORMATTER) ?: "Unknown"
         val expirationDate = request.expirationDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val safeRecipientName = escapeHtml(recipientName)
 
         return """
 <!DOCTYPE html>
@@ -431,7 +446,7 @@ open class ExceptionRequestNotificationService(
                     </tr>
                     <tr>
                         <td style="padding:28px 32px 8px 32px;">
-                            <p style="margin:0 0 14px 0;font-size:15px;line-height:1.5;">Hello <strong>$recipientName</strong>,</p>
+                            <p style="margin:0 0 14px 0;font-size:15px;line-height:1.5;">Hello <strong>$safeRecipientName</strong>,</p>
                             <p style="margin:0 0 22px 0;font-size:15px;line-height:1.5;color:#475569;">A new vulnerability exception request has been submitted and is awaiting your review.</p>
                         </td>
                     </tr>
@@ -550,11 +565,11 @@ open class ExceptionRequestNotificationService(
      * @return HTML email content
      */
     private fun generateApprovalEmail(request: VulnerabilityExceptionRequest): String {
-        val cveId = describeSubject(request)
-        val assetName = describeScope(request)
-        val reviewerName = request.reviewedByUsername ?: "Unknown Reviewer"
+        val cveId = escapeHtml(describeSubject(request))
+        val assetName = escapeHtml(describeScope(request))
+        val reviewerName = escapeHtml(request.reviewedByUsername ?: "Unknown Reviewer")
         val reviewDate = request.reviewDate?.format(DATE_FORMATTER) ?: "Unknown"
-        val reviewComment = request.reviewComment ?: "(No comment provided)"
+        val reviewComment = escapeHtml(request.reviewComment ?: "(No comment provided)")
         val expirationDate = request.expirationDate.format(DateTimeFormatter.ofPattern("MMMM d, yyyy"))
 
         return """
@@ -640,11 +655,11 @@ open class ExceptionRequestNotificationService(
      * @return HTML email content
      */
     private fun generateRejectionEmail(request: VulnerabilityExceptionRequest): String {
-        val cveId = describeSubject(request)
-        val assetName = describeScope(request)
-        val reviewerName = request.reviewedByUsername ?: "Unknown Reviewer"
+        val cveId = escapeHtml(describeSubject(request))
+        val assetName = escapeHtml(describeScope(request))
+        val reviewerName = escapeHtml(request.reviewedByUsername ?: "Unknown Reviewer")
         val reviewDate = request.reviewDate?.format(DATE_FORMATTER) ?: "Unknown"
-        val reviewComment = request.reviewComment ?: "(No comment provided)"
+        val reviewComment = escapeHtml(request.reviewComment ?: "(No comment provided)")
 
         return """
 <!DOCTYPE html>
@@ -784,9 +799,14 @@ open class ExceptionRequestNotificationService(
     }
 
     private fun generateExpirationNoticeEmail(
-        cveId: String, assetName: String, requesterName: String,
-        expirationDate: String, recipientName: String
-    ): String = """
+        rawCveId: String, rawAssetName: String, rawRequesterName: String,
+        expirationDate: String, rawRecipientName: String
+    ): String {
+        val cveId = escapeHtml(rawCveId)
+        val assetName = escapeHtml(rawAssetName)
+        val requesterName = escapeHtml(rawRequesterName)
+        val recipientName = escapeHtml(rawRecipientName)
+        return """
 <!DOCTYPE html>
 <html>
 <head>
@@ -868,6 +888,7 @@ open class ExceptionRequestNotificationService(
 </body>
 </html>
     """.trimIndent()
+    }
 
     private fun generateExpirationNoticeTextEmail(
         cveId: String, assetName: String, requesterName: String,
@@ -904,8 +925,8 @@ open class ExceptionRequestNotificationService(
      * @return HTML email content
      */
     private fun generateExpirationReminderEmail(request: VulnerabilityExceptionRequest): String {
-        val cveId = describeSubject(request)
-        val assetName = describeScope(request)
+        val cveId = escapeHtml(describeSubject(request))
+        val assetName = escapeHtml(describeScope(request))
         val expirationDate = request.expirationDate.format(DateTimeFormatter.ofPattern("MMMM d, yyyy"))
 
         return """

--- a/src/backendng/src/test/kotlin/com/secman/controller/DemandClassificationControllerAuthorizationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/DemandClassificationControllerAuthorizationTest.kt
@@ -1,0 +1,132 @@
+package com.secman.controller
+
+import com.secman.domain.Classification
+import com.secman.domain.Demand
+import com.secman.domain.DemandClassificationResult
+import com.secman.domain.DemandType
+import com.secman.repository.DemandClassificationResultRepository
+import com.secman.repository.DemandClassificationRuleRepository
+import com.secman.repository.DemandRepository
+import com.secman.repository.UserRepository
+import com.secman.service.DemandClassificationService
+import io.micronaut.http.HttpStatus
+import io.micronaut.security.authentication.Authentication
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.Optional
+
+/**
+ * Authorization coverage for [DemandClassificationController.getResultByHash].
+ *
+ * `classificationHash` (SHA-256 of `demandId-classification-timestamp`) exists to make
+ * classification results independently addressable, not as a secret capability token — its
+ * inputs (a small sequential demand id, one of 3 classification values) are far too
+ * low-entropy to rely on for access control. A result with `demand == null` came from the
+ * genuinely public `/public/classify` endpoint and anonymous lookup is fine. A result with a
+ * non-null `demand` came from the ADMIN/SECCHAMPION-only `/classify-demand` endpoint and
+ * carries a real internal demand's title/description/businessJustification — anonymous callers
+ * must not be able to read that merely by holding (or brute-forcing/leaking) the hash.
+ */
+class DemandClassificationControllerAuthorizationTest {
+
+    private val classificationService: DemandClassificationService = mockk()
+    private val ruleRepository: DemandClassificationRuleRepository = mockk()
+    private val resultRepository: DemandClassificationResultRepository = mockk()
+    private val demandRepository: DemandRepository = mockk()
+    private val userRepository: UserRepository = mockk()
+
+    private val controller = DemandClassificationController(
+        classificationService, ruleRepository, resultRepository, demandRepository, userRepository
+    )
+
+    private fun auth(roles: Set<String>): Authentication = mockk {
+        every { name } returns "someuser"
+        every { this@mockk.roles } returns roles
+    }
+
+    private fun publicResult() = DemandClassificationResult(
+        demand = null,
+        classification = Classification.B,
+        confidenceScore = 0.9,
+        ruleEvaluationLog = "",
+        classificationHash = "publichash",
+        inputData = "{}",
+        classifiedAt = LocalDateTime.now()
+    )
+
+    private fun demandLinkedResult(): DemandClassificationResult {
+        val demand = Demand(
+            id = 7L,
+            title = "Confidential internal demand",
+            description = "sensitive business justification",
+            demandType = DemandType.CREATE_NEW,
+            requestor = mockk(relaxed = true)
+        )
+        return DemandClassificationResult(
+            demand = demand,
+            classification = Classification.A,
+            confidenceScore = 0.95,
+            ruleEvaluationLog = "",
+            classificationHash = "demandhash",
+            inputData = "{\"title\":\"Confidential internal demand\"}",
+            classifiedAt = LocalDateTime.now()
+        )
+    }
+
+    @Test
+    fun `anonymous caller can fetch a public classification result by hash`() {
+        every { resultRepository.findByClassificationHash("publichash") } returns Optional.of(publicResult())
+
+        val response = controller.getResultByHash("publichash", authentication = null)
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    @Test
+    fun `anonymous caller cannot fetch a demand-linked classification result by hash`() {
+        every { resultRepository.findByClassificationHash("demandhash") } returns Optional.of(demandLinkedResult())
+
+        val response = controller.getResultByHash("demandhash", authentication = null)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.status)
+    }
+
+    @Test
+    fun `plain USER cannot fetch a demand-linked classification result by hash`() {
+        every { resultRepository.findByClassificationHash("demandhash") } returns Optional.of(demandLinkedResult())
+
+        val response = controller.getResultByHash("demandhash", auth(setOf("USER")))
+
+        assertEquals(HttpStatus.NOT_FOUND, response.status)
+    }
+
+    @Test
+    fun `ADMIN can fetch a demand-linked classification result by hash`() {
+        every { resultRepository.findByClassificationHash("demandhash") } returns Optional.of(demandLinkedResult())
+
+        val response = controller.getResultByHash("demandhash", auth(setOf("ADMIN")))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    @Test
+    fun `SECCHAMPION can fetch a demand-linked classification result by hash`() {
+        every { resultRepository.findByClassificationHash("demandhash") } returns Optional.of(demandLinkedResult())
+
+        val response = controller.getResultByHash("demandhash", auth(setOf("SECCHAMPION")))
+
+        assertEquals(HttpStatus.OK, response.status)
+    }
+
+    @Test
+    fun `unknown hash is 404 regardless of authentication`() {
+        every { resultRepository.findByClassificationHash("missing") } returns Optional.empty()
+
+        val response = controller.getResultByHash("missing", authentication = null)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.status)
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/service/ExceptionRequestNotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/ExceptionRequestNotificationServiceTest.kt
@@ -195,4 +195,61 @@ class ExceptionRequestNotificationServiceTest {
         assertThat(service.notifyRequesterOfApproval(request).get()).isFalse()
         verify(exactly = 0) { emailService.sendHtmlEmail(any(), any(), any()) }
     }
+
+    @Test
+    fun `new-request email HTML-escapes attacker-controlled username and reason`() {
+        val payload = "<script>alert(document.cookie)</script>"
+        val request = VulnerabilityExceptionRequest(
+            id = 1,
+            requestedByUsername = "demo$payload",
+            subject = VulnerabilityException.Subject.CVE,
+            scope = VulnerabilityException.Scope.ASSET,
+            reason = payload + "x".repeat(50),
+            expirationDate = LocalDateTime.now().plusDays(30),
+            status = ExceptionRequestStatus.PENDING,
+            cveId = "CVE-2026-12448",
+            assetId = 42
+        )
+
+        val combined = captureNewRequestHtml(request)
+
+        assertThat(combined).doesNotContain("<script>")
+        assertThat(combined).contains("&lt;script&gt;")
+    }
+
+    @Test
+    fun `approval email HTML-escapes an attacker-controlled reviewer comment`() {
+        val payload = "<img src=x onerror=alert(1)>"
+        val request = baseRequest(VulnerabilityException.Scope.ASSET).apply {
+            reviewComment = payload
+        }
+        every { assetRepository.findById(42L) } returns Optional.of(originatingAsset)
+        every { userRepository.findByUsername("demo") } returns Optional.of(requester)
+        val htmlSlot = slot<String>()
+        every { emailService.sendHtmlEmail(any(), any(), capture(htmlSlot)) } returns
+            CompletableFuture.completedFuture(true)
+
+        service.notifyRequesterOfApproval(request).get()
+
+        assertThat(htmlSlot.captured).doesNotContain("<img src=x onerror=alert(1)>")
+        assertThat(htmlSlot.captured).contains("&lt;img src=x onerror=alert(1)&gt;")
+    }
+
+    @Test
+    fun `rejection email HTML-escapes an attacker-controlled reviewer comment`() {
+        val payload = "<img src=x onerror=alert(1)>"
+        val request = baseRequest(VulnerabilityException.Scope.ASSET).apply {
+            reviewComment = payload
+        }
+        every { assetRepository.findById(42L) } returns Optional.of(originatingAsset)
+        every { userRepository.findByUsername("demo") } returns Optional.of(requester)
+        val htmlSlot = slot<String>()
+        every { emailService.sendHtmlEmail(any(), any(), capture(htmlSlot)) } returns
+            CompletableFuture.completedFuture(true)
+
+        service.notifyRequesterOfRejection(request).get()
+
+        assertThat(htmlSlot.captured).doesNotContain("<img src=x onerror=alert(1)>")
+        assertThat(htmlSlot.captured).contains("&lt;img src=x onerror=alert(1)&gt;")
+    }
 }


### PR DESCRIPTION
## Summary

Daily automated security review, continuing two items explicitly flagged but left unfixed ("Reported, not fixed") in PR #446, the last full review pass:

- `ExceptionRequestNotificationService` interpolated user-controlled text raw into HTML emails (no escaping) — HIGH.
- `DemandClassificationController`'s anonymous `GET /results/{hash}` let anyone holding a hash read internal business demand data with no authentication — HIGH.

Both are fixed independently in this PR (one commit each, individually revertable).

## Changes

**1. HTML injection in vulnerability-exception emails (`ExceptionRequestNotificationService.kt`)**

`generateNewRequestEmail` interpolated `request.requestedByUsername` and `request.reason` (any authenticated `USER`, free text, 50–2048 chars, no HTML validation on the DTO) directly into the HTML email sent to every ADMIN/SECCHAMPION on every new exception request. `generateApprovalEmail`/`generateRejectionEmail` did the same with the reviewer's `reviewComment`, and `generateExpirationNoticeEmail` with the requester's username. Ten sibling services (`AwsAccountRiskAssessmentService`, `NewAccountNotificationService`, `OAuthService`, `GdprWelcomeEmailListener`, etc.) already carry an identical `escapeHtml()` helper for exactly this purpose — this was the one email-generating service still interpolating raw.

Fix: added the same `escapeHtml()` helper and applied it at every user/DB-controlled interpolation site across all five HTML-generating methods. The plain-text email variants are deliberately left unescaped (HTML-entity-encoding plain text would corrupt it, and there's no HTML renderer to inject into).

**2. Anonymous read of internal demand classification results (`DemandClassificationController.kt`)**

`GET /api/classification/results/{hash}` was `@Secured(IS_ANONYMOUS)` with no further check. `classificationHash` (`DemandClassificationResult.generateHash`) is `SHA256("{demandId}-{classification}-{timestamp}")` — low-entropy inputs (sequential id, 1-of-3 classification), and more importantly it isn't meant to function as a secret: it's returned directly in the API response to whoever triggers the classification, so any leak of that response (browser history, access logs, a "share this result" UI) hands an anonymous, unrevocable, unaudited reader permanent access to whatever it points at.

For results from the genuinely public `POST /public/classify` (`demand == null` by construction), anonymous read is the intended design. But `POST /classify-demand` (ADMIN/SECCHAMPION-only) classifies a real internal `Demand` — title, description, businessJustification flow into the stored `inputData` — and sets `demand` to that real entity. The same anonymous endpoint served both, so a leaked demand-linked hash exposed real internal business data with zero authentication and zero audit trail.

Fix: `getResultByHash` now branches on the resolved result's `demand` field — `null` (public) stays anonymous-readable; non-null (private/admin-triggered) now requires `ADMIN` or `SECCHAMPION`, returning 404 (not 403) for everyone else so an unauthorized/anonymous caller can't distinguish "wrong permissions" from "hash doesn't exist."

## Testing

⚠️ **This sandbox has no outbound network access to `services.gradle.org` or Maven Central** (proxy returns 403 on CONNECT to both, confirmed by attempting a `./gradlew` invocation), and no pre-populated Gradle dependency cache, so `./gradlew build` could not be run here — the same environment limitation documented in PRs #424/#428/#446. Both diffs were hand-verified for brace/paren balance and reviewed line-by-line against the existing patterns they reuse (the `escapeHtml` helper signature matches all 10 existing copies verbatim; the `Authentication?`/role-check pattern matches `AwsAccountSharingController`/`DomainVulnsController`).

- [ ] `./gradlew build` is clean — **could not run, see above**
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes) — **could not run, see above**
- [ ] `cd src/frontend && npm ci && npm run build` exits 0 — N/A, no frontend files touched
- [x] New/updated unit tests cover the change
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — needs a live stack, not run here
- [ ] `/e2evulnexception` passes with 0 failures — needs a live stack, not run here

Tests added:
- `ExceptionRequestNotificationServiceTest`: two new cases assert an HTML/JS payload in `requestedByUsername`/`reason` and in `reviewComment` is neutralized (`&lt;script&gt;`, not `<script>`) in the rendered HTML for the new-request, approval and rejection emails.
- `DemandClassificationControllerAuthorizationTest` (new file): anonymous/`USER` denied (404) on a demand-linked hash; `ADMIN`/`SECCHAMPION` allowed; anonymous still allowed on a public (`demand == null`) hash; unknown hash 404 regardless of auth.

## Backend contract changes

- [x] N/A — no backend contract changes

`GET /api/classification/results/{hash}` gains a role check for demand-linked results only; the documented `extensions/` client surface (`/api/auth/login`, `/api/vulnerabilities/cli-add`, `/api/vulnerabilities/current`, `/api/assets/import`, `/mcp`) does not include this endpoint.

## Security

- [x] RBAC enforced at controller (`@Secured`) — `getResultByHash` stays reachable anonymously by design for public results, with an in-method role check gating demand-linked ones (Micronaut's declarative `@Secured` can't express "anonymous for some rows, ADMIN for others" on the same route)
- [x] Input validation / file handling reviewed for new attack surface — N/A, no new input surface
- [x] No secrets hardcoded (uses `pass-cli`)

OWASP: A01 (Broken Access Control, finding 2) and A03 (Injection — stored HTML injection via email, finding 1) touched — both fixed via the codebase's own established patterns, no new patterns introduced.

## Not investigated further this pass

Per PR #446's "Reported, not fixed" list, still open: MCP delegation-as-impersonation, MCP auth timing/CPU-exhaustion via BCrypt-compare-against-every-key, no CSRF filter (SameSite=Lax only), `?token=` authenticating any endpoint, deny-list-only SSRF validation for IdP/LLM URLs, OIDC missing `aud`/`nonce` validation, no account-disable/JWT-revocation, username-only login rate limiting, `ConfigBundleService`'s shared literal password for imported users. None of these were re-verified in this pass; deferring to a future review rather than making unverified claims.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Umz6g7VbE7FriaFfMmhmaX)_