### PR TITLE
Fix CRLF log injection in InputValidationService

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/InputValidationService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/InputValidationService.kt
@@ -86,7 +86,7 @@ class InputValidationService {
         }
         
         if (containsSqlInjection(email) || containsXss(email)) {
-            logger.warn("Potential injection attempt in email: {}", email)
+            logger.warn("Potential injection attempt in email: {}", sanitizeLogInput(email))
             return ValidationResult(false, "Invalid email format")
         }
         
@@ -106,7 +106,7 @@ class InputValidationService {
         }
         
         if (containsSqlInjection(name) || containsXss(name)) {
-            logger.warn("Potential injection attempt in {}: {}", fieldName, name)
+            logger.warn("Potential injection attempt in {}: {}", fieldName, sanitizeLogInput(name))
             return ValidationResult(false, "$fieldName contains invalid characters")
         }
         
@@ -126,7 +126,7 @@ class InputValidationService {
         }
         
         if (containsSqlInjection(text) || containsXss(text)) {
-            logger.warn("Potential injection attempt in {}: {}", fieldName, text.take(100))
+            logger.warn("Potential injection attempt in {}: {}", fieldName, sanitizeLogInput(text.take(100)))
             return ValidationResult(false, "$fieldName contains invalid content")
         }
         
@@ -170,7 +170,7 @@ class InputValidationService {
         }
         
         if (containsSqlInjection(url) || containsXss(url)) {
-            logger.warn("Potential injection attempt in URL: {}", url)
+            logger.warn("Potential injection attempt in URL: {}", sanitizeLogInput(url))
             return ValidationResult(false, "Invalid URL")
         }
         
@@ -211,6 +211,14 @@ class InputValidationService {
         return ValidationResult(true, input)
     }
     
+    /**
+     * Strip CR/LF/tab before an untrusted value reaches a log line, to prevent
+     * log forging (CWE-117). Mirrors AuditLogService.sanitizeLogInput.
+     */
+    private fun sanitizeLogInput(input: String): String {
+        return input.replace(Regex("[\r\n\t]"), "_")
+    }
+
     /**
      * Check for SQL injection patterns
      */

--- a/src/backendng/src/test/kotlin/com/secman/service/InputValidationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/InputValidationServiceTest.kt
@@ -1,0 +1,90 @@
+package com.secman.service
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+/**
+ * Regression test for CWE-117 log forging: injection-attempt warnings must never
+ * write the raw (attacker-controlled) input into the log line, since that lets an
+ * unauthenticated caller (e.g. via /api/auth/login -> validateName) forge fake
+ * log/audit entries by embedding CR/LF in the submitted value.
+ */
+class InputValidationServiceTest {
+
+    private val service = InputValidationService()
+    private lateinit var listAppender: ListAppender<ILoggingEvent>
+    private lateinit var logbackLogger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        logbackLogger = LoggerFactory.getLogger(InputValidationService::class.java) as Logger
+        listAppender = ListAppender()
+        listAppender.start()
+        logbackLogger.addAppender(listAppender)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        logbackLogger.detachAppender(listAppender)
+    }
+
+    private fun loggedMessages(): List<String> = listAppender.list.map { it.formattedMessage }
+
+    @Test
+    fun `validateName strips CRLF from the logged value on a detected injection attempt`() {
+        val forged = "admin'--\r\n14:32:01.000 [main] INFO  AuditLogService - AUDIT: action=LOGIN_SUCCESS"
+
+        val result = service.validateName(forged, "Username")
+
+        assertFalse(result.isValid)
+        val messages = loggedMessages()
+        assertTrue(messages.isNotEmpty())
+        messages.forEach { message ->
+            assertFalse(message.contains("\r"), "Logged message must not contain a raw CR: $message")
+            assertFalse(message.contains("\n"), "Logged message must not contain a raw LF: $message")
+        }
+    }
+
+    @Test
+    fun `validateEmail strips CRLF from the logged value on a detected injection attempt`() {
+        val forged = "a@b.com' OR '1'='1\r\ninjected=true"
+
+        service.validateEmail(forged)
+
+        loggedMessages().forEach { message ->
+            assertFalse(message.contains("\r"))
+            assertFalse(message.contains("\n"))
+        }
+    }
+
+    @Test
+    fun `validateDescription strips CRLF from the logged value on a detected injection attempt`() {
+        val forged = "desc -- \r\ninjected=true"
+
+        service.validateDescription(forged, "Description")
+
+        loggedMessages().forEach { message ->
+            assertFalse(message.contains("\r"))
+            assertFalse(message.contains("\n"))
+        }
+    }
+
+    @Test
+    fun `validateUrl strips CRLF from the logged value on a detected injection attempt`() {
+        val forged = "https://example.com/--\r\ninjected=true"
+
+        service.validateUrl(forged)
+
+        loggedMessages().forEach { message ->
+            assertFalse(message.contains("\r"))
+            assertFalse(message.contains("\n"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Security review (HIGH, CWE-117 log/audit forging): `InputValidationService` logged the raw, unsanitized value whenever a potential SQL-injection/XSS pattern was detected in `validateEmail`/`validateName`/`validateDescription`/`validateUrl`.
- `POST /api/auth/login` is `@Secured(IS_ANONYMOUS)` and calls `validateName(loginRequest.username, "Username")` before rate limiting, so an unauthenticated caller could submit a username containing CR/LF plus a fabricated line (e.g. a forged `AUDIT: ... action=LOGIN_SUCCESS` entry) and have it written verbatim into the plain-text `STDOUT` log appender — undermining the integrity of the log/audit trail on a compliance-focused platform.
- Same sink is reachable from any other endpoint that calls `validateName`/`validateDescription`/`validateEmail`/`validateUrl` on user-controlled text.

## Changes

- `src/backendng/.../service/InputValidationService.kt`: added a private `sanitizeLogInput()` helper (identical CR/LF/tab-stripping regex to the existing, already-shipped `AuditLogService.sanitizeLogInput`) and applied it at all four raw-input `logger.warn` call sites.
- `src/backendng/.../test/.../InputValidationServiceTest.kt` (new): regression tests asserting the logged message never contains a raw CR or LF for each of the four validators, using a Logback `ListAppender` to capture the emitted log event.

## Testing

- [ ] `./gradlew build` is clean — **could not verify**: this sandbox's egress policy blocks `services.gradle.org` (403 at the proxy), so the pinned Gradle 9.7.0 wrapper distribution cannot download; the system-installed Gradle 8.14.3 fallback cannot resolve the `org.jetbrains.kotlin.jvm:2.4.10` plugin either. The change is a minimal, mechanical reuse of an existing, already-shipped sanitization pattern (same regex, same shape as `AuditLogService`), reviewed by hand for Kotlin syntax correctness.
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes) — not run for the same reason (script requires `pass-cli` secrets + a working build)
- [ ] `cd src/frontend && npm ci && npm run build` exits 0 (frontend changes) — N/A, no frontend files touched
- [x] New/updated unit or integration tests cover the change — `InputValidationServiceTest.kt` added
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — not run, no frontend/runtime change and stack could not be started in this session
- [ ] `/e2evulnexception` passes with 0 failures — not run, unrelated to this change and stack could not be started in this session
- [ ] Doc-only change outside `src/`, `tests/`, `scripts/` — E2E gates skipped — N/A, `src/` files changed

## Backend contract changes

- [x] N/A — no backend contract changes (internal logging fix only, no path/method/field/`@Secured` changes)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — unchanged by this fix
- [x] Input validation / file handling reviewed for new attack surface — this *is* the fix; validated logic against `InputValidationService.kt`, `AuthController.kt`, and `logback.xml`'s plain-text `STDOUT` appender
- [x] No secrets hardcoded (uses `pass-cli`) — no secrets involved

## Related issues

Found via a scheduled automated security-review routine covering the `secman`, `secman_ai_github`, and `secman_visual_check` repositories. No linked issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_0186v38zxEdnSLieNGJULzKS)_