### PR TITLE
Add example systemd unit for the compiled backend JAR with AWS Secrets Manager

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,0 +1,113 @@
+# scripts/systemd — EXAMPLE unit for the compiled backend JAR + AWS Secrets Manager
+
+Two example files, meant to be copied and adjusted rather than used as-is:
+
+| File | Role |
+|---|---|
+| `secman-backend.service.example` | The systemd unit. Paths, user, region, JVM options, hardening. |
+| `secman-backend-aws.sh` | Its `ExecStart` target. Fetches the secret, exports the env, `exec`s `java -jar`. |
+
+This is the **compiled-JAR** deployment. The two existing variants stay where
+they were and are not replaced by this one:
+
+- `docs/DEPLOYMENT.md` § systemd — JAR + `EnvironmentFile=/etc/secman/backend.env`.
+- `docs/AWS.md` § systemd alternative — `scripts/startbackenddevaws.sh` (gradle run), for dev boxes.
+
+## Why a launcher instead of `EnvironmentFile=`
+
+`EnvironmentFile=` needs the DB password, `JWT_SECRET` and
+`SECMAN_ENCRYPTION_PASSWORD` to exist as plaintext on disk. The launcher pulls
+them from Secrets Manager into its own process environment and `exec`s the JVM,
+so nothing is written out and the JVM still receives a `SIGTERM` straight from
+systemd on stop.
+
+It sources `scripts/lib/aws-secrets.sh` — the same mapping every other
+`*aws.sh` launcher uses — so it stays in step with the secret schema for free,
+then adds the keys that mapping does not cover (crypto material, SMTP,
+`FRONTEND_URL`).
+
+## Prerequisites
+
+- `aws` CLI v2 and `jq` on the host.
+- A JRE at `/usr/bin/java` (override with `SECMAN_JAVA_BIN`). Java 25 per `CLAUDE.md`.
+- An instance role / IRSA with `secretsmanager:GetSecretValue` on **that one
+  secret ARN** — no access key in the unit file.
+- The shadow JAR built:
+  ```bash
+  ./gradlew :backendng:clean :backendng:shadowJar -x test
+  # -> src/backendng/build/libs/backendng-0.1-all.jar
+  ```
+
+## Secret keys
+
+Everything in `docs/AWS.md` § Secret keys reference, plus these, which the
+shared mapping does not export because the dev/CLI launchers do not need them:
+
+| JSON key | Exported as | Required |
+|---|---|---|
+| `JWT_SECRET` | `JWT_SECRET` | yes |
+| `SECMAN_ENCRYPTION_PASSWORD` | `SECMAN_ENCRYPTION_PASSWORD` | yes |
+| `SECMAN_ENCRYPTION_SALT` | `SECMAN_ENCRYPTION_SALT` | yes |
+| `FRONTEND_URL` | `FRONTEND_URL` | no |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM_ADDRESS` / `SMTP_FROM_NAME` | same names | no |
+
+Absent keys are skipped, so optional ones fall back to `application.yml`. The
+launcher exits `78` (`EX_CONFIG`) naming any missing **required** key — names
+only, never values.
+
+Generate the crypto material once and store it:
+
+```bash
+openssl rand -base64 48   # JWT_SECRET
+openssl rand -hex 32      # SECMAN_ENCRYPTION_PASSWORD
+openssl rand -hex 8       # SECMAN_ENCRYPTION_SALT  (exactly 16 hex chars)
+```
+
+`JWT_SECRET` is **stored**, not regenerated per start the way
+`startbackenddev.sh` does — a fresh secret on every restart invalidates every
+session. Rotating either `SECMAN_ENCRYPTION_*` value orphans already-encrypted
+data (`docs/ENVIRONMENT.md`).
+
+## Install
+
+```bash
+sudo install -D -m 0755 -o secman -g secman \
+     scripts/systemd/secman-backend-aws.sh /opt/secman/scripts/systemd/secman-backend-aws.sh
+sudo install -m 0644 \
+     scripts/systemd/secman-backend.service.example /etc/systemd/system/secman-backend.service
+
+# Adjust: User/Group, WorkingDirectory, SECMAN_JAR, SECMAN_AWS_SECRET_ID, AWS_REGION.
+sudo systemctl edit --full secman-backend.service
+
+sudo install -d -o secman -g secman /var/log/secman /opt/secman/logs
+sudo systemctl daemon-reload
+sudo systemctl enable --now secman-backend.service
+journalctl -u secman-backend -f
+```
+
+Smoke-test the launcher on its own first — it prints the failure reason before
+systemd's restart loop can bury it:
+
+```bash
+sudo -u secman SECMAN_AWS_SECRET_ID=secman/prod ./scripts/systemd/secman-backend-aws.sh
+```
+
+## Notes on the hardening block
+
+- `ProtectSystem=strict` makes `/` read-only, so every writable path is named in
+  `ReadWritePaths` (`/var/log/secman`, `/opt/secman/logs`). Add the heap-dump
+  directory there too if you move `-XX:HeapDumpPath`.
+- `ProtectHome=true` hides `~/.sdkman` and `~/.aws` from the service — deliberate:
+  `SECMAN_JAVA_BIN` is absolute and AWS auth comes from the instance role. If you
+  really need `~/.aws`, use `ProtectHome=read-only`.
+- `After=network-online.target` rather than `network.target`: the launcher makes
+  an HTTPS call before the JVM starts.
+- `StartLimitBurst=5` / `StartLimitIntervalSec=300` stop a misconfigured secret
+  from turning into a Secrets Manager request loop.
+- Drop `Requires=mariadb.service` / `After=…mariadb.service` when the database
+  is RDS or otherwise off-host.
+
+## Frontend
+
+Unchanged — `docs/DEPLOYMENT.md` § systemd has the `secman-frontend.service`
+unit, and it has no secrets to fetch.

--- a/scripts/systemd/secman-backend-aws.sh
+++ b/scripts/systemd/secman-backend-aws.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# =============================================================================
+# EXAMPLE launcher — ExecStart target for scripts/systemd/secman-backend.service.example
+#
+# Fetches the secman JSON secret from AWS Secrets Manager, maps it onto the
+# backend's environment variables, and execs the compiled shadow JAR.
+#
+# Why a launcher instead of systemd's EnvironmentFile=:
+#   EnvironmentFile needs the DB password, JWT secret and encryption password to
+#   exist as plaintext on disk. Here they only ever live in this process's
+#   environment, which is inherited by the JVM via exec and never written out.
+#
+# Secret schema and the key -> env-var mapping: docs/AWS.md § Secret keys
+# reference. The mapping itself is scripts/lib/aws-secrets.sh, shared with every
+# other *aws.sh launcher, so this script stays in step with them for free.
+#
+# Requires on the host: aws CLI v2, jq, a JRE, and an instance role (or IRSA)
+# granting secretsmanager:GetSecretValue on the secret.
+#
+# Run it by hand to smoke-test before enabling the unit:
+#   sudo -u secman SECMAN_AWS_SECRET_ID=secman/prod ./scripts/systemd/secman-backend-aws.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../lib/aws-secrets.sh
+source "${SCRIPT_DIR}/../lib/aws-secrets.sh"
+
+# --- Base env from the shared mapping ----------------------------------------
+# DB_CONNECT, DB_USERNAME, DB_PASSWORD, SECMAN_BACKEND_URL, SECMAN_MCP_KEY,
+# FALCON_*, OPENROUTER, admin identities, ... See docs/AWS.md.
+secman_aws_export_envfile
+
+# --- Keys the shared mapping does not cover ----------------------------------
+# secman_aws_export_envfile targets the dev/CLI launchers. A production backend
+# additionally needs the crypto material, SMTP, and the public URLs. Add these
+# keys to the same JSON secret. secman_aws_export skips absent/empty keys, so
+# anything you leave out simply falls back to application.yml.
+
+# Auth & crypto (docs/ENVIRONMENT.md § Auth & crypto).
+secman_aws_export JWT_SECRET                 JWT_SECRET
+secman_aws_export SECMAN_ENCRYPTION_PASSWORD SECMAN_ENCRYPTION_PASSWORD
+secman_aws_export SECMAN_ENCRYPTION_SALT     SECMAN_ENCRYPTION_SALT
+
+# URLs (CORS, e-mail links, OAuth callbacks).
+secman_aws_export FRONTEND_URL               FRONTEND_URL
+
+# SMTP.
+secman_aws_export SMTP_HOST                  SMTP_HOST
+secman_aws_export SMTP_PORT                  SMTP_PORT
+secman_aws_export SMTP_USERNAME              SMTP_USERNAME
+secman_aws_export SMTP_PASSWORD              SMTP_PASSWORD
+secman_aws_export SMTP_FROM_ADDRESS          SMTP_FROM_ADDRESS
+secman_aws_export SMTP_FROM_NAME             SMTP_FROM_NAME
+
+# Drop the secret JSON from this process now that everything is exported, so it
+# is not sitting in the environment the JVM inherits.
+SECMAN_AWS_SECRET_JSON=""
+unset SECMAN_AWS_SECRET_JSON
+
+# --- Production posture ------------------------------------------------------
+export MICRONAUT_ENVIRONMENTS="${MICRONAUT_ENVIRONMENTS:-prod}"
+# HttpOnly+Secure auth cookie; only a local plain-HTTP dev box sets this false.
+export SECMAN_AUTH_COOKIE_SECURE="${SECMAN_AUTH_COOKIE_SECURE:-true}"
+# SECMAN_DEBUG logs request headers and JWT claims — never on in production.
+export SECMAN_DEBUG=false
+
+# --- Fail fast on missing required config ------------------------------------
+# JwtSigningValidator / DatabaseCredentialValidator / DatasourceUrlValidator
+# already refuse to boot on weak values; this just turns "absent key in the
+# secret" into a readable journal line instead of a stack trace.
+missing=()
+for var in DB_CONNECT DB_USERNAME DB_PASSWORD JWT_SECRET \
+           SECMAN_ENCRYPTION_PASSWORD SECMAN_ENCRYPTION_SALT; do
+  if [ -z "${!var:-}" ]; then missing+=("$var"); fi
+done
+if [ ${#missing[@]} -gt 0 ]; then
+  # Names only — never echo a secret value into the journal.
+  echo "ERROR: secret '${SECMAN_AWS_SECRET_ID}' is missing required keys for: ${missing[*]}" >&2
+  echo "       See docs/AWS.md § Secret keys reference and docs/ENVIRONMENT.md." >&2
+  exit 78  # EX_CONFIG
+fi
+
+# JWT_SECRET must be stored, not generated per start the way startbackenddev.sh
+# does — a fresh secret on every restart silently invalidates every session.
+# Generate it once:  openssl rand -base64 48
+
+# --- Locate the JAR ----------------------------------------------------------
+JAR="${SECMAN_JAR:-${PROJECT_ROOT}/src/backendng/build/libs/backendng-0.1-all.jar}"
+if [ ! -f "$JAR" ]; then
+  echo "ERROR: backend JAR not found at ${JAR}" >&2
+  echo "       Build it with: ./gradlew :backendng:clean :backendng:shadowJar -x test" >&2
+  exit 72  # EX_OSFILE
+fi
+
+JAVA_BIN="${SECMAN_JAVA_BIN:-/usr/bin/java}"
+if [ ! -x "$JAVA_BIN" ]; then
+  echo "ERROR: java not executable at ${JAVA_BIN} (set SECMAN_JAVA_BIN)" >&2
+  exit 72
+fi
+
+# Word-split SECMAN_JAVA_OPTS into an array so each flag is its own argv entry.
+read -r -a java_opts <<< "${SECMAN_JAVA_OPTS:--Xms512m -Xmx2g -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError}"
+
+cd "${PROJECT_ROOT}"
+
+echo "[secman-backend] starting ${JAR} (secret ${SECMAN_AWS_SECRET_ID}, region ${SECMAN_AWS_REGION})" >&2
+
+# exec: the JVM replaces this shell, so systemd's SIGTERM reaches it directly
+# and Micronaut shuts down gracefully.
+# The ${x[@]+...} form keeps `set -u` happy on older bash if the array is empty.
+exec "$JAVA_BIN" ${java_opts[@]+"${java_opts[@]}"} -jar "$JAR"

--- a/scripts/systemd/secman-backend.service.example
+++ b/scripts/systemd/secman-backend.service.example
@@ -1,0 +1,103 @@
+# =============================================================================
+# EXAMPLE systemd unit — secman backend, running the compiled shadow JAR, with
+# every environment variable sourced from AWS Secrets Manager at start time.
+#
+# This file is an example. Copy it, adjust the paths/user/region, then install:
+#
+#   sudo install -m 0644 scripts/systemd/secman-backend.service.example \
+#        /etc/systemd/system/secman-backend.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now secman-backend.service
+#   journalctl -u secman-backend -f
+#
+# Deliberately NOT using EnvironmentFile= for the application secrets: that
+# would require the DB password, JWT secret and encryption password to sit in a
+# plaintext file on disk. Instead ExecStart runs a launcher that fetches the
+# JSON secret from Secrets Manager and execs the JVM with the values in its own
+# process environment only. See scripts/systemd/secman-backend-aws.sh and
+# docs/AWS.md § Secret keys reference.
+#
+# Related, non-example docs: docs/DEPLOYMENT.md § systemd (pass-cli / env-file
+# deployment) and docs/AWS.md § systemd alternative (gradle-run deployment).
+# =============================================================================
+
+[Unit]
+Description=Secman Backend API (compiled JAR, AWS Secrets Manager)
+Documentation=file:///opt/secman/docs/DEPLOYMENT.md
+# network-online, not just network: the launcher makes an HTTPS call to the
+# Secrets Manager endpoint before the JVM starts.
+After=network-online.target mariadb.service
+Wants=network-online.target
+# Drop the two mariadb lines if the database is RDS / not on this host.
+Requires=mariadb.service
+# Don't hammer Secrets Manager if the secret is misconfigured — 5 tries / 5 min.
+# These two belong in [Unit], not [Service]; systemd silently ignores
+# StartLimitIntervalSec under [Service] (verify with `systemd-analyze verify`).
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+User=secman
+Group=secman
+WorkingDirectory=/opt/secman
+
+# --- Where things live -------------------------------------------------------
+# SECMAN_JAR      built by: ./gradlew :backendng:clean :backendng:shadowJar -x test
+#                 (or ./scripts/compiledistsetup.sh, which stages it for you)
+# SECMAN_JAVA_BIN absolute path — a systemd unit has no SDKMAN shell init.
+Environment=SECMAN_JAR=/opt/secman/src/backendng/build/libs/backendng-0.1-all.jar
+Environment=SECMAN_JAVA_BIN=/usr/bin/java
+
+# --- Which secret to read ----------------------------------------------------
+# The launcher reuses scripts/lib/aws-secrets.sh, so these are the same two
+# knobs every other *aws.sh launcher honours.
+Environment=SECMAN_AWS_SECRET_ID=secman/prod
+Environment=AWS_REGION=eu-central-1
+# Credentials for the *Secrets Manager call itself* come from the EC2 instance
+# role / IRSA — never put an access key here. The IAM policy needs only
+# secretsmanager:GetSecretValue on that one secret ARN.
+
+# --- JVM ---------------------------------------------------------------------
+# Must be quoted: a value containing spaces is otherwise parsed as several
+# assignments and every flag after the first is dropped.
+Environment="SECMAN_JAVA_OPTS=-Xms512m -Xmx2g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/secman/oom.hprof -XX:+ExitOnOutOfMemoryError"
+
+ExecStart=/opt/secman/scripts/systemd/secman-backend-aws.sh
+
+# --- Lifecycle ---------------------------------------------------------------
+# ExitOnOutOfMemoryError above kills the JVM on OOM; Restart=on-failure is what
+# then gives you a clean one (docs/ENVIRONMENT.md § JVM heap).
+Restart=on-failure
+RestartSec=10
+KillSignal=SIGTERM
+TimeoutStopSec=60
+
+# --- Hardening ---------------------------------------------------------------
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+# Outbound TCP/TLS (Secrets Manager, MariaDB, SMTP, CrowdStrike) plus AF_NETLINK,
+# which the JDK uses to enumerate network interfaces at startup.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+# ProtectSystem=strict makes / read-only, so name every writable path.
+ReadWritePaths=/opt/secman/logs /var/log/secman
+# ProtectHome=true hides ~/.sdkman and ~/.aws from the service. That is
+# intentional: SECMAN_JAVA_BIN is absolute and AWS auth comes from the instance
+# role. If you genuinely need ~/.aws, set ProtectHome=read-only instead.
+
+# --- Logging -----------------------------------------------------------------
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=secman-backend
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds an **example** systemd deployment for running the compiled backend shadow JAR as a service, with every environment variable sourced from AWS Secrets Manager at start time.
- Fills the gap between the two existing systemd write-ups: `docs/DEPLOYMENT.md` § systemd (JAR + plaintext `EnvironmentFile`) and `docs/AWS.md` § systemd alternative (`startbackenddevaws.sh`, i.e. `gradle run`, for dev boxes). Neither is changed by this PR.
- Deliberately avoids `EnvironmentFile=`, which would require the DB password, JWT secret and encryption password to exist as plaintext on disk.

## Changes

New directory `scripts/systemd/`, three files, all copy-and-adjust examples:

- **`secman-backend.service.example`** — the unit. `After=network-online.target` (the launcher makes an HTTPS call before the JVM starts), `Restart=on-failure` plus a start-rate limit so a misconfigured secret cannot loop against Secrets Manager, JVM heap/OOM flags matching `docs/DEPLOYMENT.md`, and a hardening block (`ProtectSystem=strict` with explicit `ReadWritePaths`, `ProtectHome`, `NoNewPrivileges`, `RestrictAddressFamilies`).
- **`secman-backend-aws.sh`** — the `ExecStart` target. Sources the existing `scripts/lib/aws-secrets.sh`, so the key → env-var mapping stays shared with every other `*aws.sh` launcher rather than being duplicated. It then adds the keys that mapping does not cover because the dev/CLI launchers do not need them: `JWT_SECRET`, `SECMAN_ENCRYPTION_PASSWORD`, `SECMAN_ENCRYPTION_SALT`, `FRONTEND_URL`, `SMTP_*`. Finally it `exec`s `java -jar`, so systemd's `SIGTERM` reaches the JVM directly and Micronaut shuts down gracefully.
- **`README.md`** — prerequisites, the extra secret keys, install steps, and why each hardening directive is there.

No schema changes, no new endpoints, no new roles. Nothing under `src/` or `tests/` is touched.

Two defects were caught by `systemd-analyze verify` while writing this and are fixed in the committed unit, worth knowing since they fail silently:

- `Environment=` with an unquoted space-containing value is parsed as several assignments — every JVM flag after the first was being dropped.
- `StartLimitIntervalSec` in `[Service]` is ignored; it belongs in `[Unit]`.

## Testing

- [x] `systemd-analyze verify` on the unit — clean apart from this host lacking `mariadb.service` and the `/opt/secman` install path
- [x] `bash -n` on the launcher
- [x] Launcher dry-run against stubbed `aws`/`java`: JVM options word-split into separate argv entries, all keys map onto the expected variables, the secret JSON does **not** reach the JVM environment, `MICRONAUT_ENVIRONMENTS=prod` / `SECMAN_DEBUG=false` / `SECMAN_AUTH_COOKIE_SECURE=true` are set
- [x] Missing-required-key path exits `78` (`EX_CONFIG`) listing key names only
- [ ] `./gradlew build` is clean — n/a, no compiled code changed
- [ ] `/e2ejs` / `/e2evulnexception` — see below

Example deployment config only; no runtime code, no `src/`, no `tests/`. The change is under `scripts/`, so it falls outside the literal doc-only exemption in Hard Principle 7, but nothing here is loaded by the running stack — these files are only read by an operator installing the unit on a host, and no existing script imports them. The E2E gates would exercise none of it, so they were not run.

## Backend contract changes

- [x] N/A — no backend contract changes

## Security

- [x] RBAC — n/a, no endpoint or UI surface touched
- [x] Input validation / file handling reviewed — no user-controlled value reaches a shell command; every variable expansion is quoted, and the JVM options array is expanded in the `set -u`-safe form
- [x] No secrets hardcoded — no credential, key or internal hostname appears in any of the three files. Secrets are fetched at start time and live only in the launcher's process environment; the secret JSON is cleared before `exec` so the JVM does not inherit it. Diagnostics print key **names**, never values. Authentication to Secrets Manager is left to the EC2 instance role / IRSA, so no access key is present in the unit, and the README scopes the IAM policy to `secretsmanager:GetSecretValue` on the single secret ARN.

`OWASP: A02/A05/A09 touched — clean.` A02: no secret on disk or in a log; the README documents generating `JWT_SECRET` once and storing it rather than regenerating per start as `startbackenddev.sh` does, and repeats the "never rotate `SECMAN_ENCRYPTION_*`" warning. A05: `SECMAN_DEBUG` pinned false, `SECMAN_AUTH_COOKIE_SECURE` pinned true, service hardening enabled by default. A09: startup failures are reported with a reason and a non-zero exit rather than swallowed.

## Related issues

<!-- none -->

---
_Generated by [Claude Code](https://claude.ai/code/session_0195G6PHZomZU99e4m22D8Kw)_