### PR TITLE
Fix onboarding rate-limiter XFF spoofing + oversized ad-hoc template upload (2 HIGH)

### DIFF
--- a/scripts/install/nginx/nginx.conf
+++ b/scripts/install/nginx/nginx.conf
@@ -68,6 +68,7 @@ server {
         	proxy_cache_bypass $http_upgrade;
                 proxy_set_header X-Forwarded-Host $server_name;        # ← ADD THIS
                 proxy_set_header X-Forwarded-Port $server_port; # ← ADD THIS
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # ← ADD THIS
     	}
 
         location /api {
@@ -79,6 +80,7 @@ server {
                 proxy_cache_bypass $http_upgrade;
                 proxy_set_header X-Forwarded-Host YOUR_CNAME_HERE;        # ← ADD THIS
                 proxy_set_header X-Forwarded-Port $server_port; # ← ADD THIS
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # ← ADD THIS
 
                 proxy_buffering off;
                 proxy_cache off;
@@ -99,6 +101,7 @@ server {
                 proxy_cache_bypass $http_upgrade;
                 proxy_set_header X-Forwarded-Host YOUR_CNAME_HERE;        # ← ADD THIS
                 proxy_set_header X-Forwarded-Port $server_port; # ← ADD THIS
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # ← ADD THIS
 
                 proxy_buffering off;
                 proxy_cache off;
@@ -121,6 +124,7 @@ server {
                 proxy_cache_bypass $http_upgrade;
                 proxy_set_header X-Forwarded-Host YOUR_CNAME_HERE;        # ← ADD THIS
                 proxy_set_header X-Forwarded-Port $server_port; # ← ADD THIS
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # ← ADD THIS
                 proxy_intercept_errors off;
 
         }

--- a/src/backendng/src/main/kotlin/com/secman/controller/AccountOnboardingPublicController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/AccountOnboardingPublicController.kt
@@ -10,6 +10,7 @@ import com.secman.dto.SubmitAnswersResponse
 import com.secman.repository.AccountOnboardingQuestionRepository
 import com.secman.service.AccountOnboardingRateLimiter
 import com.secman.service.AccountOnboardingService
+import com.secman.service.TrustedProxyResolver
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -57,7 +58,8 @@ import java.time.format.DateTimeFormatter
 open class AccountOnboardingPublicController(
     private val onboardingService: AccountOnboardingService,
     private val questionRepository: AccountOnboardingQuestionRepository,
-    private val rateLimiter: AccountOnboardingRateLimiter
+    private val rateLimiter: AccountOnboardingRateLimiter,
+    private val trustedProxyResolver: TrustedProxyResolver
 ) {
     private val log = LoggerFactory.getLogger(AccountOnboardingPublicController::class.java)
 
@@ -211,16 +213,16 @@ open class AccountOnboardingPublicController(
     /**
      * What the limiter counts against.
      *
-     * `X-Forwarded-For` is trusted only for its first hop and only because SecMan is deployed
-     * behind nginx, which overwrites it. It is spoofable if the app is ever exposed directly —
-     * hence the fallback to the socket address, and hence keying on it *only* for rate
-     * limiting, never for authorization.
+     * `X-Forwarded-For` is trusted only when the immediate TCP peer is a configured trusted
+     * proxy (`secman.account-onboarding.trusted-proxy-cidrs`, loopback by default — see
+     * [TrustedProxyResolver]), and even then only its right-most, non-proxy hop is used —
+     * never the first, since that is exactly the entry an unauthenticated caller controls.
+     * Without a trusted peer, the header is ignored entirely and the socket address is used,
+     * so this is spoofable only if a caller can reach the app directly, bypassing the proxy.
+     * Used *only* for rate limiting, never for authorization.
      */
     private fun clientKey(request: HttpRequest<*>): String {
-        val forwarded = request.headers.get("X-Forwarded-For")
-            ?.substringBefore(',')
-            ?.trim()
-            ?.takeIf { it.isNotEmpty() && it.length <= 64 }
-        return forwarded ?: request.remoteAddress?.address?.hostAddress ?: "unknown"
+        val forwarded = request.headers.get("X-Forwarded-For")?.takeIf { it.length <= 256 }
+        return trustedProxyResolver.resolveClientAddress(request.remoteAddress?.address, forwarded)
     }
 }

--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
@@ -25,6 +25,7 @@ import com.secman.service.RequirementService
 import com.secman.service.RequirementIdService
 import com.secman.service.RequirementExportTemplateValidationService
 import com.secman.service.ReleaseRequirementScopeService
+import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.data.model.Pageable
 import io.micronaut.http.HttpResponse
@@ -74,7 +75,9 @@ open class RequirementController(
     private val exportTemplateRepository: RequirementExportTemplateRepository,
     private val exportTemplateUsageRepository: RequirementExportTemplateUsageRepository,
     private val exportTemplateValidationService: RequirementExportTemplateValidationService,
-    private val releaseRequirementScopeService: ReleaseRequirementScopeService
+    private val releaseRequirementScopeService: ReleaseRequirementScopeService,
+    @Value("\${secman.requirement-export-templates.max-file-size-bytes:5242880}")
+    private val maxAdHocTemplateSizeBytes: Long
 ) {
     private val log = org.slf4j.LoggerFactory.getLogger(RequirementController::class.java)
 
@@ -780,6 +783,18 @@ open class RequirementController(
             }
             RequirementExportTemplateMode.ADHOC -> {
                 if (adHocTemplate == null) return null
+                // Reject on the declared part size before .bytes materialises it — the same
+                // rejectOversized() guard RequirementExportTemplateController applies to its
+                // own upload/validate endpoints, reused here rather than re-implemented. Without
+                // it the effective bound is micronaut.server.multipart.max-file-size (100 MB,
+                // kept large for the XLSX importers), not the 5 MB this feature configures.
+                if (adHocTemplate.size > maxAdHocTemplateSizeBytes) {
+                    log.warn(
+                        "Rejected ad-hoc requirement export template upload of {} bytes, above the {} byte limit",
+                        adHocTemplate.size, maxAdHocTemplateSizeBytes
+                    )
+                    throw IllegalArgumentException("Template exceeds the maximum allowed file size.")
+                }
                 val bytes = adHocTemplate.bytes
                 val report = exportTemplateValidationService.validate(
                     bytes = bytes,

--- a/src/backendng/src/main/kotlin/com/secman/service/TrustedProxyResolver.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/TrustedProxyResolver.kt
@@ -1,0 +1,109 @@
+package com.secman.service
+
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Singleton
+import java.net.InetAddress
+
+/**
+ * Trust boundary for `X-Forwarded-For`: the header is honoured only when the immediate TCP
+ * peer is inside one of [cidrs] (the reverse proxy). Mirrors
+ * `src/relay/internal/httpx/httpx.go`'s `ResolveClientIP`/`clientIP` — same algorithm, same
+ * reasoning: trusting the header unconditionally lets any caller pick its own rate-limit
+ * bucket or audit-log identity by sending one header, and taking the *left-most* hop (the
+ * naive approach) still trusts the caller, since that is exactly the entry the caller wrote
+ * itself. Only the right-most hop that is not itself inside a trusted network is safe to use.
+ *
+ * Defaults to loopback only, matching every documented nginx deployment (nginx and the
+ * backend on the same host — see `docs/DEPLOYMENT.md` and `scripts/install/nginx/nginx.conf`,
+ * both of which `proxy_pass` to `127.0.0.1`).
+ */
+@Singleton
+open class TrustedProxyResolver(
+    @Value("\${secman.account-onboarding.trusted-proxy-cidrs:127.0.0.1/32,::1/128}")
+    cidrs: String
+) {
+    private val networks: List<Pair<InetAddress, Int>> = cidrs.split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .mapNotNull { parseCidr(it) }
+
+    /** Is [address] itself a trusted reverse proxy? */
+    fun isTrusted(address: InetAddress?): Boolean {
+        if (address == null) return false
+        return networks.any { (network, prefixLength) -> matches(address, network, prefixLength) }
+    }
+
+    /**
+     * The address to key rate limiting / audit logging on: [peer] unless it is a trusted
+     * proxy, in which case the right-most `X-Forwarded-For` hop that is not itself trusted
+     * (skipping our own infrastructure's hops). Falls back to [peer] if the header is absent,
+     * unparsable, or every hop is trusted.
+     */
+    fun resolveClientAddress(peer: InetAddress?, forwardedFor: String?): String {
+        val peerAddress = peer?.hostAddress ?: "unknown"
+        if (!isTrusted(peer) || forwardedFor.isNullOrBlank()) {
+            return peerAddress
+        }
+        val hops = forwardedFor.split(',').map { it.trim() }
+        for (hop in hops.asReversed()) {
+            val candidate = parseLiteral(hop) ?: continue
+            if (isTrusted(candidate)) continue // another hop of our own infrastructure
+            return candidate.hostAddress
+        }
+        return peerAddress
+    }
+
+    private fun parseCidr(cidr: String): Pair<InetAddress, Int>? {
+        val parts = cidr.split('/')
+        val address = parseLiteral(parts[0]) ?: return null
+        val prefixLength = if (parts.size > 1) {
+            parts[1].toIntOrNull() ?: return null
+        } else {
+            address.address.size * 8
+        }
+        if (prefixLength < 0 || prefixLength > address.address.size * 8) return null
+        return address to prefixLength
+    }
+
+    /**
+     * Parses a strict IP literal — never a hostname. `InetAddress.getByName` performs a real
+     * DNS lookup for anything that is not already a numeric literal, and `forwardedFor` is
+     * attacker-influenced (the caller controls every hop except the one the trusted proxy
+     * itself appended), so resolving it as a hostname would let a header value trigger an
+     * outbound DNS query. [IPV4_LITERAL] and [looksLikeIpv6Literal] gate that.
+     */
+    private fun parseLiteral(value: String): InetAddress? {
+        if (!IPV4_LITERAL.matches(value) && !looksLikeIpv6Literal(value)) return null
+        return try {
+            InetAddress.getByName(value)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun looksLikeIpv6Literal(value: String): Boolean =
+        value.contains(':') && IPV6_LITERAL_CHARS.matches(value)
+
+    private fun matches(address: InetAddress, network: InetAddress, prefixLength: Int): Boolean {
+        val addrBytes = address.address
+        val netBytes = network.address
+        if (addrBytes.size != netBytes.size) return false
+        val fullBytes = prefixLength / 8
+        val remainingBits = prefixLength % 8
+        for (i in 0 until fullBytes) {
+            if (addrBytes[i] != netBytes[i]) return false
+        }
+        if (remainingBits > 0) {
+            val mask = (0xFF shl (8 - remainingBits)) and 0xFF
+            if ((addrBytes[fullBytes].toInt() and mask) != (netBytes[fullBytes].toInt() and mask)) return false
+        }
+        return true
+    }
+
+    companion object {
+        private val IPV4_LITERAL = Regex(
+            """^(25[0-5]|2[0-4]\d|1?\d{1,2})(\.(25[0-5]|2[0-4]\d|1?\d{1,2})){3}$"""
+        )
+        private val IPV6_LITERAL_CHARS = Regex("""^[0-9a-fA-F:]+(%[a-zA-Z0-9._-]+)?$""")
+    }
+}

--- a/src/backendng/src/main/resources/application.yml
+++ b/src/backendng/src/main/resources/application.yml
@@ -268,6 +268,14 @@ secman:
     # per pair, so an import introducing hundreds of accounts would otherwise fire a mail storm.
     # Exceeding it is refused up front, before anything is imported — never throttled silently.
     max-accounts-per-run: ${SECMAN_ONBOARDING_MAX_ACCOUNTS_PER_RUN:200}
+    # Peers whose X-Forwarded-For header the public questionnaire's rate limiter trusts when
+    # computing its bucket key (see TrustedProxyResolver / AccountOnboardingPublicController's
+    # clientKey). Anyone else's header is ignored — an unauthenticated caller could otherwise
+    # pick its own bucket and defeat the limit entirely. Comma-separated CIDRs; defaults to
+    # loopback only, matching every documented nginx deployment (nginx and the backend run on
+    # the same host — see docs/DEPLOYMENT.md and scripts/install/nginx/nginx.conf, both of
+    # which proxy_pass to 127.0.0.1).
+    trusted-proxy-cidrs: ${SECMAN_ONBOARDING_TRUSTED_PROXY_CIDRS:127.0.0.1/32,::1/128}
     # How long a guided questionnaire link stays valid. Shorter than the 30 days
     # assessment_token grants, because this token *creates* a risk assessment rather than
     # opening one that already exists. Range 1..90, enforced in code.

--- a/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
@@ -13,13 +13,18 @@ import com.secman.repository.UseCaseRepository
 import com.secman.service.InputValidationService
 import com.secman.service.ReleaseRequirementScopeService
 import com.secman.service.RequirementExportTemplateValidationService
+import com.secman.domain.MissingPlaceholderBehavior
+import com.secman.domain.RequirementExportTemplateMode
 import com.secman.service.RequirementIdService
 import com.secman.service.RequirementService
 import com.secman.service.TranslationService
+import io.micronaut.http.multipart.CompletedFileUpload
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.apache.poi.xwpf.usermodel.XWPFDocument
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.time.LocalDate
@@ -48,7 +53,8 @@ class RequirementControllerWordExportTest {
         exportTemplateRepository = mockk<RequirementExportTemplateRepository>(relaxed = true),
         exportTemplateUsageRepository = mockk<RequirementExportTemplateUsageRepository>(relaxed = true),
         exportTemplateValidationService = mockk<RequirementExportTemplateValidationService>(relaxed = true),
-        releaseRequirementScopeService = mockk<ReleaseRequirementScopeService>(relaxed = true)
+        releaseRequirementScopeService = mockk<ReleaseRequirementScopeService>(relaxed = true),
+        maxAdHocTemplateSizeBytes = 5_242_880L
     )
     private val publicController = PublicRequirementDownloadController(
         requirementRepository = mockk<RequirementRepository>(relaxed = true),
@@ -343,6 +349,44 @@ class RequirementControllerWordExportTest {
         assertThat(document.tables).describedAs("the template's release table must survive").isNotEmpty()
         assertThat(document.paragraphs.map { it.text }).anyMatch { it.contains("Appendix") }
         assertThat(document.paragraphs.map { it.text }).noneMatch { it.contains("\${requirements}") }
+    }
+
+    @Test
+    fun `an oversized ad-hoc template is rejected before its bytes are materialised`() {
+        // Regression guard for the HIGH finding: RequirementExportTemplateController's own
+        // upload/validate endpoints reject on the declared part size via rejectOversized()
+        // before touching .bytes; this path (ad-hoc templates on the export endpoints) must do
+        // the same rather than reading a 100 MB multipart body into heap first.
+        val oversized = mockk<CompletedFileUpload> {
+            every { size } returns 5_242_880L + 1
+        }
+        // Sanity: the fixture really is oversized, mirroring resolveTemplate's own
+        // `adHocTemplate.size > maxAdHocTemplateSizeBytes` guard.
+        check(oversized.size > 5_242_880L)
+
+        assertThatThrownBy { resolveAdHocTemplate(oversized) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("exceeds the maximum allowed file size")
+
+        verify(exactly = 0) { oversized.bytes }
+    }
+
+    private fun resolveAdHocTemplate(file: CompletedFileUpload): Any? {
+        val method = RequirementController::class.java.getDeclaredMethod(
+            "resolveTemplate",
+            String::class.java,
+            java.lang.Long::class.java,
+            CompletedFileUpload::class.java,
+            MissingPlaceholderBehavior::class.java
+        )
+        method.isAccessible = true
+        return try {
+            method.invoke(
+                controller, RequirementExportTemplateMode.ADHOC.name, null, file, MissingPlaceholderBehavior.APPEND
+            )
+        } catch (e: java.lang.reflect.InvocationTargetException) {
+            throw e.targetException
+        }
     }
 
     private fun requirement(id: Long, internalId: String, shortreq: String): Requirement =

--- a/src/backendng/src/test/kotlin/com/secman/service/TrustedProxyResolverTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/TrustedProxyResolverTest.kt
@@ -1,0 +1,85 @@
+package com.secman.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+
+/**
+ * Covers the trust boundary behind [AccountOnboardingPublicController]'s rate-limit key:
+ * X-Forwarded-For must never let an unauthenticated caller pick its own bucket, and the
+ * fallback to the raw TCP peer must not silently bucket every legitimate request together.
+ */
+class TrustedProxyResolverTest {
+
+    private fun resolver(cidrs: String = "127.0.0.1/32,::1/128") = TrustedProxyResolver(cidrs)
+
+    private fun ip(value: String): InetAddress = InetAddress.getByName(value)
+
+    @Test
+    fun `untrusted peer's X-Forwarded-For is ignored entirely`() {
+        val r = resolver()
+        // Peer is a public address, not the configured proxy — the header it sent must not be honoured.
+        val result = r.resolveClientAddress(ip("203.0.113.5"), "9.9.9.9")
+        assertThat(result).isEqualTo("203.0.113.5")
+    }
+
+    @Test
+    fun `trusted peer's X-Forwarded-For right-most hop is used`() {
+        val r = resolver()
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "198.51.100.7, 127.0.0.1")
+        assertThat(result).isEqualTo("198.51.100.7")
+    }
+
+    @Test
+    fun `spoofed left-most hop is not trusted over the real client appended by the proxy`() {
+        val r = resolver()
+        // Attacker sends "X-Forwarded-For: 9.9.9.9", nginx appends the real peer as the last hop.
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "9.9.9.9, 203.0.113.9")
+        assertThat(result).isEqualTo("203.0.113.9")
+    }
+
+    @Test
+    fun `every hop trusted falls back to the peer address`() {
+        val r = resolver()
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "127.0.0.1, ::1")
+        assertThat(result).isEqualTo("127.0.0.1")
+    }
+
+    @Test
+    fun `missing header falls back to the peer address`() {
+        val r = resolver()
+        assertThat(r.resolveClientAddress(ip("127.0.0.1"), null)).isEqualTo("127.0.0.1")
+        assertThat(r.resolveClientAddress(ip("127.0.0.1"), "")).isEqualTo("127.0.0.1")
+    }
+
+    @Test
+    fun `unparsable hops are skipped rather than trusted`() {
+        val r = resolver()
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "not-an-ip, 203.0.113.10")
+        assertThat(result).isEqualTo("203.0.113.10")
+    }
+
+    @Test
+    fun `a hostname in the header is never resolved via DNS`() {
+        // Regression guard for the DNS-lookup-on-attacker-data trap: a hostname-looking hop
+        // must be skipped, not passed to InetAddress.getByName (which would trigger a lookup).
+        val r = resolver()
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "attacker.example, 203.0.113.11")
+        assertThat(result).isEqualTo("203.0.113.11")
+    }
+
+    @Test
+    fun `no trusted proxies configured means the header is never honoured`() {
+        val r = resolver(cidrs = "")
+        val result = r.resolveClientAddress(ip("127.0.0.1"), "203.0.113.12")
+        assertThat(result).isEqualTo("127.0.0.1")
+    }
+
+    @Test
+    fun `isTrusted reflects the configured CIDR`() {
+        val r = resolver(cidrs = "10.0.0.0/8")
+        assertThat(r.isTrusted(ip("10.1.2.3"))).isTrue()
+        assertThat(r.isTrusted(ip("11.1.2.3"))).isFalse()
+        assertThat(r.isTrusted(null)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Automated security code review surfaced two HIGH findings on this branch (which was otherwise at parity with `main`):

- `AccountOnboardingPublicController`'s rate-limit key trusted a client-supplied `X-Forwarded-For` header unconditionally, defeating the anti-enumeration rate limiter on the one unauthenticated write path in the app (and, for legitimate traffic with no header, bucketing every real caller together behind nginx's own peer address).
- The ad-hoc requirement-export-template upload path (`resolveTemplate()`'s `ADHOC` branch in `RequirementController`) read the entire multipart body into a byte array before checking its size, unlike its sibling `RequirementExportTemplateController`, which already rejects on the declared part size first.

## Changes

- **New `TrustedProxyResolver`** (`src/backendng/.../service/TrustedProxyResolver.kt`): `X-Forwarded-For` is honoured only when the immediate TCP peer is inside a configured trusted-proxy CIDR set (`secman.account-onboarding.trusted-proxy-cidrs`, defaults to loopback only), and only the right-most hop that isn't itself a trusted proxy is used — mirrors `src/relay/internal/httpx/httpx.go`'s `ResolveClientIP`/`clientIP` algorithm and rationale. Guards against triggering DNS lookups on attacker-influenced header content by requiring a strict IP-literal match before calling `InetAddress.getByName`.
- `AccountOnboardingPublicController.clientKey()` now delegates to `TrustedProxyResolver` instead of trusting the header's first hop directly.
- `scripts/install/nginx/nginx.conf` (the shipped local/dev reference config) now actually sets `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` on every proxied location — it previously never set the header at all, so `TrustedProxyResolver`'s default (loopback-only trust) would otherwise fall back to the raw peer address for every request. (`docs/DEPLOYMENT.md`'s production nginx config already did this correctly.)
- `RequirementController.resolveTemplate()`'s `ADHOC` branch now rejects an oversized upload on `adHocTemplate.size` **before** calling `.bytes`, reusing the same guard `RequirementExportTemplateController.rejectOversized()` already applies, via the existing `secman.requirement-export-templates.max-file-size-bytes` config (5 MB default) — previously the effective bound was `micronaut.server.multipart.max-file-size` (100 MB).
- New tests: `TrustedProxyResolverTest` (spoofed/legit XFF hops, DNS-lookup-avoidance regression guard, no-trusted-proxies case) and a new case in `RequirementControllerWordExportTest` asserting the oversized upload is rejected before `.bytes` is ever read.

## Testing

- [x] `./scripts/owasp-check.sh` — no static findings (diff-scoped)
- [ ] `./gradlew build` is clean — **could not run in this sandboxed session**: the egress proxy blocks `services.gradle.org`, `repo.maven.apache.org` and `plugins.gradle.org` by policy, so the pinned Gradle 9.7.0 distribution can't be fetched here. Changes were reviewed manually for compile-correctness (types, imports, constructor DI wiring, reflection-based test signatures). **Please confirm `./gradlew build` in CI before merging.**
- [ ] `./scripts/startbackenddev.sh` starts cleanly — not run, same reason
- [x] New/updated unit tests cover the change (see above)
- [ ] `/e2ejs` — not run in this session
- [ ] `/e2evulnexception` — not run in this session

## Backend contract changes

- [x] N/A — no backend contract changes (no path/method/field/`@Secured` change; new constructor-injected bean, additive config)

## Security

- [x] RBAC unaffected — `AccountOnboardingPublicController` stays `IS_ANONYMOUS` by design; `RequirementController`'s `@Secured` roles unchanged
- [x] Input validation / file handling reviewed — this PR *is* the file-handling fix (A08 pre-parse size check)
- [x] No secrets hardcoded

## Related issues

Findings from an automated security code review pass (no tracked issue).


---
_Generated by [Claude Code](https://claude.ai/code/session_019cEW43MiScnw7JhVUjj3nS)_