### PR TITLE
EOL notifications: cover and document --dry-run / --only-email

### DIFF
--- a/docs/EOL.md
+++ b/docs/EOL.md
@@ -227,6 +227,20 @@ distinguishable from a missing one.
 findings whose EOL date falls in the next `--months` months (default 12) by
 recipient and sends one consolidated mail each.
 
+Two safety valves, both ADMIN-only like the rest of this endpoint:
+
+- **`--dry-run`** resolves every recipient and their findings exactly as a real
+  run would, but sends no mail — `EolNotificationResponse.dryRun` is echoed
+  back and every `EolNotificationRecipientResult.sent` is `false`. Use it to
+  preview who is about to be mailed before committing to a real run.
+- **`--only-email <address>`** restricts *delivery* to one address
+  (case-insensitive); every other resolved recipient is dropped before send
+  and does not appear in the response at all. This is how one account owner
+  can be notified — or re-notified after a delivery failure — without mailing
+  the rest of the estate. It composes with `--dry-run`: `--only-email` alone
+  narrows who is *mailed*, `--dry-run` alone narrows to *nobody*, and both
+  together preview exactly what that one recipient would receive.
+
 Recipients reuse `AwsAccountRecipientResolver` — the single source of truth for
 "who owns this AWS account", already shared by the vulnerability and
 outdated-asset mails: the account's `UserMapping` owners, members of workgroups
@@ -269,7 +283,13 @@ secman eol-sync --scan-only
 # Who would be notified, without sending anything
 secman send-eol-notifications --dry-run --verbose
 
-# Send
+# Preview exactly what one owner would receive, without sending
+secman send-eol-notifications --dry-run --only-email owner@example.com --verbose
+
+# Notify (or re-notify) just that one owner, e.g. after a delivery failure
+secman send-eol-notifications --only-email owner@example.com --verbose
+
+# Send to everyone
 secman send-eol-notifications --months 12
 ```
 

--- a/src/backendng/src/main/kotlin/com/secman/dto/EolDtos.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/EolDtos.kt
@@ -128,8 +128,15 @@ data class EolSyncResponse(
 data class EolNotificationRequest(
     /** Notify about components going EOL within this many months (default 12). */
     val months: Long = 12,
+    /** Resolve recipients and findings as usual but send no mail; see [EolNotificationRecipientResult.sent]. */
     val dryRun: Boolean = false,
-    /** Restrict the run to one recipient address (case-insensitive). */
+    /**
+     * Restrict delivery to one recipient address (case-insensitive), e.g. to test
+     * a specific account owner's notification without mailing the whole run.
+     * Findings are still resolved for every recipient; every other recipient is
+     * simply dropped before send, so [EolNotificationResponse.recipientsResolved]
+     * reflects only the restricted set.
+     */
     val onlyEmail: String? = null,
     /** Include components already past EOL alongside the upcoming ones. */
     val includeAlreadyEol: Boolean = false

--- a/src/backendng/src/test/kotlin/com/secman/service/EolNotificationServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/EolNotificationServiceTest.kt
@@ -1,0 +1,117 @@
+package com.secman.service
+
+import com.secman.domain.EolFinding
+import com.secman.domain.EolStatus
+import com.secman.domain.EolSubjectType
+import com.secman.repository.EolFindingRepository
+import com.secman.repository.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.concurrent.CompletableFuture
+
+/**
+ * `--dry-run` and `--only-email` are the two safety valves an operator reaches
+ * for before a real notification run: preview who would be mailed, or narrow a
+ * run to one address while validating recipient resolution. Both are covered
+ * here because [EolNotificationBoundaryTest] only exercises address validation,
+ * not the run itself.
+ *
+ * ID prefix: ENS-*
+ */
+class EolNotificationServiceTest {
+
+    private val eolFindingRepository = mockk<EolFindingRepository>()
+    private val awsAccountRecipientResolver = mockk<AwsAccountRecipientResolver>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val emailService = mockk<EmailService>()
+
+    private val service = EolNotificationService(
+        eolFindingRepository = eolFindingRepository,
+        awsAccountRecipientResolver = awsAccountRecipientResolver,
+        userRepository = userRepository,
+        emailService = emailService
+    )
+
+    private fun finding(assetId: Long, assetName: String, owner: String, component: String) = EolFinding(
+        id = assetId,
+        subjectType = EolSubjectType.ASSET_PRODUCT,
+        assetId = assetId,
+        assetName = assetName,
+        assetOwner = owner,
+        componentName = component,
+        eolProductId = 1,
+        eolProductKey = component.lowercase(),
+        eolReleaseId = 1,
+        eolCycle = "1.0",
+        eolDate = LocalDate.now().plusMonths(3),
+        status = EolStatus.APPROACHING_EOL,
+        scanRunId = "run-1"
+    )
+
+    @Test
+    @DisplayName("ENS-001: dry-run resolves every recipient but sends no mail")
+    fun dryRunSendsNothing() {
+        every {
+            eolFindingRepository.findAssetFindingsWithEolBetween(any(), any(), any())
+        } returns listOf(
+            finding(1, "host-a", "alice@example.com", "OpenSSL"),
+            finding(2, "host-b", "bob@example.com", "Java")
+        )
+
+        val response = service.sendEolNotifications(months = 12, dryRun = true)
+
+        assertThat(response.dryRun).isTrue()
+        assertThat(response.status).isEqualTo("SUCCESS")
+        assertThat(response.recipientsResolved).isEqualTo(2)
+        assertThat(response.emailsSent).isZero()
+        assertThat(response.recipients).allSatisfy { assertThat(it.sent).isFalse() }
+        verify(exactly = 0) { emailService.sendEmail(any(), any(), any(), any()) }
+    }
+
+    @Test
+    @DisplayName("ENS-002: only-email restricts delivery to that address, case-insensitively")
+    fun onlyEmailRestrictsDelivery() {
+        every {
+            eolFindingRepository.findAssetFindingsWithEolBetween(any(), any(), any())
+        } returns listOf(
+            finding(1, "host-a", "alice@example.com", "OpenSSL"),
+            finding(2, "host-b", "bob@example.com", "Java")
+        )
+        every {
+            emailService.sendEmail(any(), any(), any(), any())
+        } returns CompletableFuture.completedFuture(true)
+
+        val response = service.sendEolNotifications(months = 12, onlyEmail = "ALICE@Example.com")
+
+        assertThat(response.recipientsResolved).isEqualTo(1)
+        assertThat(response.recipients).hasSize(1)
+        assertThat(response.recipients.single().email).isEqualTo("alice@example.com")
+        assertThat(response.emailsSent).isEqualTo(1)
+        verify(exactly = 1) { emailService.sendEmail("alice@example.com", any(), any(), any()) }
+        verify(exactly = 0) { emailService.sendEmail("bob@example.com", any(), any(), any()) }
+    }
+
+    @Test
+    @DisplayName("ENS-003: only-email combined with dry-run neither sends nor filters anything out silently")
+    fun onlyEmailDryRunCombination() {
+        every {
+            eolFindingRepository.findAssetFindingsWithEolBetween(any(), any(), any())
+        } returns listOf(
+            finding(1, "host-a", "alice@example.com", "OpenSSL"),
+            finding(2, "host-b", "bob@example.com", "Java")
+        )
+
+        val response = service.sendEolNotifications(months = 12, dryRun = true, onlyEmail = "bob@example.com")
+
+        assertThat(response.dryRun).isTrue()
+        assertThat(response.recipientsResolved).isEqualTo(1)
+        assertThat(response.recipients.single().email).isEqualTo("bob@example.com")
+        assertThat(response.emailsSent).isZero()
+        verify(exactly = 0) { emailService.sendEmail(any(), any(), any(), any()) }
+    }
+}

--- a/src/cli/src/main/kotlin/com/secman/cli/commands/SendEolNotificationsCommand.kt
+++ b/src/cli/src/main/kotlin/com/secman/cli/commands/SendEolNotificationsCommand.kt
@@ -16,6 +16,15 @@ import picocli.CommandLine.Spec
  * account's owners, workgroup members and sharing targets, falling back to the
  * asset's own owner. Run `eol-sync` first — this command reads stored findings
  * and performs no matching of its own.
+ *
+ * Two safety valves before a real run touches every owner's inbox:
+ *  - `--dry-run` resolves the full recipient list and prints it, sending no mail
+ *    (`EolNotificationService.sendEolNotifications` short-circuits the send).
+ *  - `--only-email` narrows delivery to one address — e.g. to verify a single
+ *    account owner receives their notification, or to re-notify just that
+ *    person after a delivery failure — without touching every other resolved
+ *    recipient. Findings are still resolved for everyone; every other
+ *    recipient is dropped before send.
  */
 @Singleton
 @Command(
@@ -28,13 +37,17 @@ class SendEolNotificationsCommand : Runnable {
     @Option(names = ["--months"], description = ["Look-ahead window in months, 1-60 (default: 12)"])
     var months: Int = 12
 
-    @Option(names = ["--dry-run"], description = ["Preview planned recipients without sending emails"])
+    @Option(names = ["--dry-run"], description = ["Resolve and print the recipient list without sending any email"])
     var dryRun: Boolean = false
 
     @Option(names = ["--include-already-eol"], description = ["Also report components that are already past EOL"])
     var includeAlreadyEol: Boolean = false
 
-    @Option(names = ["--only-email"], description = ["Only notify this address (case-insensitive)"])
+    @Option(
+        names = ["--only-email"],
+        description = ["Send only to this recipient address (case-insensitive); every other resolved recipient is skipped"],
+        paramLabel = "<address>"
+    )
     var onlyEmail: String? = null
 
     @Option(names = ["--verbose", "-v"], description = ["Per-recipient delivery status"])


### PR DESCRIPTION
## Summary

- `secman send-eol-notifications` already had `--dry-run` and `--only-email` flags end-to-end (CLI → `POST /api/eol/notifications/send` → `EolNotificationService`), but neither had run-level test coverage, and `--only-email` was undocumented.
- Add `EolNotificationServiceTest` covering: dry-run resolves recipients but sends no mail, `--only-email` restricts delivery case-insensitively (and drops every other resolved recipient from the response), and the two flags combined.
- Expand KDoc on the CLI command, the `EolNotificationRequest` DTO fields, and `docs/EOL.md` (§5 Notifications, §7 Operating it) with worked examples for both flags, including using `--only-email` to notify (or re-notify) a single account owner.

## Changes

- `src/backendng/src/main/kotlin/com/secman/dto/EolDtos.kt` — doc comments on `EolNotificationRequest.dryRun` / `.onlyEmail`
- `src/cli/src/main/kotlin/com/secman/cli/commands/SendEolNotificationsCommand.kt` — class-level KDoc + clearer `--dry-run`/`--only-email` help text
- `src/backendng/src/test/kotlin/com/secman/service/EolNotificationServiceTest.kt` — new (ENS-001..003)
- `docs/EOL.md` — §5/§7 document both flags and their composition, with CLI examples

## Testing

- [ ] `./gradlew build` is clean
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes)
- [ ] `cd src/frontend && npm ci && npm run build` exits 0 (frontend changes)
- [x] New/updated unit or integration tests cover the change
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user)
- [ ] `/e2evulnexception` passes with 0 failures
- [ ] Doc-only change outside `src/`, `tests/`, `scripts/` — E2E gates skipped

**Environment limitation**: this session cannot resolve the pinned Gradle 9.7.0 distribution (`services.gradle.org` is blocked by this session's egress policy) or find a compatible local Gradle/Kotlin toolchain, so `./gradlew build`, `startbackenddev.sh`, `/e2ejs` and `/e2evulnexception` could not be run here. `./scripts/owasp-check.sh` was run and is clean. `EolNotificationServiceTest` was hand-checked against every referenced signature (`EolFindingRepository`, `EolFinding`, `EmailService`, `AwsAccountRecipientResolver`, the DTOs) and follows the same mockk/AssertJ patterns as an existing, previously-passing test in the same package (`UserVulnerabilityNotificationServiceTest`). No frontend files touched. Please run the full gate before merging.

## Backend contract changes

- [x] N/A — no backend contract changes (no path/field/auth changes; `--dry-run`/`--only-email` already existed on the wire, this PR only adds tests/docs and doc comments)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — unchanged, endpoint was already `ADMIN`-only
- [x] Input validation / file handling reviewed for new attack surface — no new attack surface; `normalizeEmail` boundary is unchanged and already covered by `EolNotificationBoundaryTest`
- [x] No secrets hardcoded (uses `pass-cli`)

## Related issues

N/A — implements the requested `--dry-run` / single-recipient (`--only-email`) EOL notification behavior, which was already present in code; this PR adds the missing test coverage and documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG26AExCY9zSBi2aE5hhHJ)_