### PR TITLE
Preserve requirement formatting (bullets, line breaks) in Word exports

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/PublicRequirementDownloadController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/PublicRequirementDownloadController.kt
@@ -3,6 +3,7 @@ package com.secman.controller
 import com.secman.domain.Requirement
 import com.secman.repository.RequirementRepository
 import com.secman.repository.UseCaseRepository
+import com.secman.service.RequirementRichTextRenderer
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
@@ -170,29 +171,19 @@ open class PublicRequirementDownloadController(
 
                 // Details
                 requirement.details?.let { details ->
-                    val detailsParagraph = document.createParagraph()
-                    val detailsRun = detailsParagraph.createRun()
-                    detailsRun.setText(details)
+                    RequirementRichTextRenderer.write(details) { document.createParagraph() }
                 }
 
                 // Motivation
                 requirement.motivation?.let { motivation ->
-                    val motivationParagraph = document.createParagraph()
-                    val motivationLabelRun = motivationParagraph.createRun()
-                    motivationLabelRun.setText("Motivation: ")
-                    motivationLabelRun.isBold = true
-                    val motivationValueRun = motivationParagraph.createRun()
-                    motivationValueRun.setText(motivation)
+                    document.createParagraph().createRun().apply { setText("Motivation:"); isBold = true }
+                    RequirementRichTextRenderer.write(motivation) { document.createParagraph() }
                 }
 
                 // Example
                 requirement.example?.let { example ->
-                    val exampleParagraph = document.createParagraph()
-                    val exampleLabelRun = exampleParagraph.createRun()
-                    exampleLabelRun.setText("Example: ")
-                    exampleLabelRun.isBold = true
-                    val exampleValueRun = exampleParagraph.createRun()
-                    exampleValueRun.setText(example)
+                    document.createParagraph().createRun().apply { setText("Example:"); isBold = true }
+                    RequirementRichTextRenderer.write(example) { document.createParagraph() }
                 }
 
                 // Norm reference

--- a/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RequirementController.kt
@@ -24,6 +24,7 @@ import com.secman.service.InputValidationService
 import com.secman.service.RequirementService
 import com.secman.service.RequirementIdService
 import com.secman.service.RequirementExportTemplateValidationService
+import com.secman.service.RequirementRichTextRenderer
 import com.secman.service.ReleaseRequirementScopeService
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
@@ -237,10 +238,17 @@ open class RequirementController(
         try {
             val requirement = Requirement(
                 shortreq = inputValidationService.sanitizeForDisplay(request.shortreq),
-                details = request.details?.let { inputValidationService.sanitizeForDisplay(it) },
+                // details/example/motivation are rich text authored via the HtmlEditor component
+                // and rendered via RichContent + DOMPurify on read, per the sanitize-at-render
+                // pattern (see CLAUDE.md §A03). sanitizeForDisplay() strips all HTML tags with no
+                // regard for block/list boundaries, which destroyed paragraph and bullet-list
+                // structure on every newly created requirement; validateDescription() above
+                // already rejects script/iframe/on*=/javascript: content, and update() (below)
+                // already stores these fields unstripped, so create() is aligned with that.
+                details = request.details,
                 language = request.language,
-                example = request.example?.let { inputValidationService.sanitizeForDisplay(it) },
-                motivation = request.motivation?.let { inputValidationService.sanitizeForDisplay(it) },
+                example = request.example,
+                motivation = request.motivation,
                 usecase = request.usecase?.let { inputValidationService.sanitizeForDisplay(it) },
                 norm = request.norm?.let { inputValidationService.sanitizeForDisplay(it) },
                 chapter = request.chapter?.let { inputValidationService.sanitizeForDisplay(it) }
@@ -1052,16 +1060,14 @@ open class RequirementController(
                 reqHeaderRun.setText("REQ-$requirementNumber: ${requirement.shortreq}")
                 reqHeaderRun.fontSize = 12
                 reqHeaderRun.isBold = true
-                requirement.details?.let { newParagraph().createRun().setText(it) }
+                requirement.details?.let { RequirementRichTextRenderer.write(it, newParagraph) }
                 requirement.motivation?.let {
-                    val paragraph = newParagraph()
-                    paragraph.createRun().apply { setText("Motivation: "); isBold = true }
-                    paragraph.createRun().setText(it)
+                    newParagraph().createRun().apply { setText("Motivation:"); isBold = true }
+                    RequirementRichTextRenderer.write(it, newParagraph)
                 }
                 requirement.example?.let {
-                    val paragraph = newParagraph()
-                    paragraph.createRun().apply { setText("Example: "); isBold = true }
-                    paragraph.createRun().setText(it)
+                    newParagraph().createRun().apply { setText("Example:"); isBold = true }
+                    RequirementRichTextRenderer.write(it, newParagraph)
                 }
                 requirement.norm?.let {
                     val paragraph = newParagraph()
@@ -1162,29 +1168,19 @@ open class RequirementController(
                 
                 // Details - no label, content follows directly after header
                 requirement.details?.let { details ->
-                    val detailsParagraph = document.createParagraph()
-                    val detailsRun = detailsParagraph.createRun()
-                    detailsRun.setText(details)
+                    RequirementRichTextRenderer.write(details) { document.createParagraph() }
                 }
 
                 // Motivation - label bold, content regular
                 requirement.motivation?.let { motivation ->
-                    val motivationParagraph = document.createParagraph()
-                    val motivationLabelRun = motivationParagraph.createRun()
-                    motivationLabelRun.setText("Motivation: ")
-                    motivationLabelRun.isBold = true
-                    val motivationValueRun = motivationParagraph.createRun()
-                    motivationValueRun.setText(motivation)
+                    document.createParagraph().createRun().apply { setText("Motivation:"); isBold = true }
+                    RequirementRichTextRenderer.write(motivation) { document.createParagraph() }
                 }
 
                 // Example - label bold, content regular
                 requirement.example?.let { example ->
-                    val exampleParagraph = document.createParagraph()
-                    val exampleLabelRun = exampleParagraph.createRun()
-                    exampleLabelRun.setText("Example: ")
-                    exampleLabelRun.isBold = true
-                    val exampleValueRun = exampleParagraph.createRun()
-                    exampleValueRun.setText(example)
+                    document.createParagraph().createRun().apply { setText("Example:"); isBold = true }
+                    RequirementRichTextRenderer.write(example) { document.createParagraph() }
                 }
 
                 // Norm reference - label bold, content regular
@@ -1541,41 +1537,23 @@ open class RequirementController(
 
                 // Details (use batch-translated value)
                 if (!requirement.details.isNullOrBlank()) {
-                    val detailsParagraph = document.createParagraph()
-                    val detailsRun = detailsParagraph.createRun()
-                    detailsRun.setText("Details: ")
-                    detailsRun.isBold = true
-
+                    document.createParagraph().createRun().apply { setText("Details:"); isBold = true }
                     val detailsTranslated = translationMap[requirement.details] ?: requirement.details!!
-
-                    val detailsValueRun = detailsParagraph.createRun()
-                    detailsValueRun.setText(detailsTranslated)
+                    RequirementRichTextRenderer.write(detailsTranslated) { document.createParagraph() }
                 }
 
                 // Motivation (use batch-translated value)
                 if (!requirement.motivation.isNullOrBlank()) {
-                    val motivationParagraph = document.createParagraph()
-                    val motivationRun = motivationParagraph.createRun()
-                    motivationRun.setText("Motivation: ")
-                    motivationRun.isBold = true
-
+                    document.createParagraph().createRun().apply { setText("Motivation:"); isBold = true }
                     val motivationTranslated = translationMap[requirement.motivation] ?: requirement.motivation!!
-
-                    val motivationValueRun = motivationParagraph.createRun()
-                    motivationValueRun.setText(motivationTranslated)
+                    RequirementRichTextRenderer.write(motivationTranslated) { document.createParagraph() }
                 }
 
                 // Example (use batch-translated value)
                 if (!requirement.example.isNullOrBlank()) {
-                    val exampleParagraph = document.createParagraph()
-                    val exampleRun = exampleParagraph.createRun()
-                    exampleRun.setText("Example: ")
-                    exampleRun.isBold = true
-
+                    document.createParagraph().createRun().apply { setText("Example:"); isBold = true }
                     val exampleTranslated = translationMap[requirement.example] ?: requirement.example!!
-
-                    val exampleValueRun = exampleParagraph.createRun()
-                    exampleValueRun.setText(exampleTranslated)
+                    RequirementRichTextRenderer.write(exampleTranslated) { document.createParagraph() }
                 }
 
                 // Use cases (use batch-translated label)

--- a/src/backendng/src/main/kotlin/com/secman/service/RequirementRichTextRenderer.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/RequirementRichTextRenderer.kt
@@ -1,0 +1,77 @@
+package com.secman.service
+
+import org.apache.poi.xwpf.usermodel.XWPFParagraph
+
+/**
+ * Renders a requirement's rich-text fields (details/motivation/example) into Word paragraphs.
+ *
+ * Those fields are authored either as HTML (via the frontend's HtmlEditor component, rendered
+ * with RichContent + DOMPurify) or, for older rows, as Markdown-ish plain text using "- " bullet
+ * lines. `RichContent.tsx`'s `isLikelyHtml` detects which; this mirrors that detection so the
+ * .docx export shows the same paragraph/bullet structure the web UI renders, instead of the
+ * historical behaviour of a single `XWPFRun.setText(...)` call, which silently drops every line
+ * break (Word does not treat an embedded "\n" as a line break inside one run) and collapses a
+ * bulleted list into one run-on sentence.
+ */
+object RequirementRichTextRenderer {
+
+    private val HTML_TAG_RE = Regex(
+        "</?(p|div|span|h[1-6]|ul|ol|li|strong|em|b|i|u|a|br|table|tr|td|th|blockquote|code|pre)(\\s|/?>)",
+        RegexOption.IGNORE_CASE
+    )
+    private val LIST_ITEM_OPEN_RE = Regex("<li[^>]*>", RegexOption.IGNORE_CASE)
+    private val LIST_ITEM_CLOSE_RE = Regex("</li>", RegexOption.IGNORE_CASE)
+    private val LINE_BREAK_RE = Regex("<br\\s*/?>", RegexOption.IGNORE_CASE)
+    private val BLOCK_CLOSE_RE = Regex("</(p|div|h[1-6]|tr|blockquote)>", RegexOption.IGNORE_CASE)
+    private val BLOCK_OPEN_RE = Regex("<(p|div|h[1-6])[^>]*>", RegexOption.IGNORE_CASE)
+    private val ANY_TAG_RE = Regex("<[^>]*>")
+    private val BULLET_LINE_RE = Regex("^[-*]\\s+(.*)$")
+
+    private val HTML_ENTITIES = linkedMapOf(
+        "&nbsp;" to " ",
+        "&quot;" to "\"",
+        "&#39;" to "'",
+        "&apos;" to "'",
+        "&lt;" to "<",
+        "&gt;" to ">",
+        "&amp;" to "&"
+    )
+
+    fun isLikelyHtml(text: String): Boolean = HTML_TAG_RE.containsMatchIn(text)
+
+    /** Splits [text] into logical lines; a "- "/"* " prefix marks a bullet-list item. */
+    private fun toLines(text: String): List<String> {
+        if (!isLikelyHtml(text)) {
+            return text.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
+        }
+        var normalized = text
+            .replace(LIST_ITEM_OPEN_RE, "\n- ")
+            .replace(LIST_ITEM_CLOSE_RE, "")
+            .replace(LINE_BREAK_RE, "\n")
+            .replace(BLOCK_CLOSE_RE, "\n")
+            .replace(BLOCK_OPEN_RE, "\n")
+            .replace(ANY_TAG_RE, "")
+        for ((entity, replacement) in HTML_ENTITIES) {
+            normalized = normalized.replace(entity, replacement)
+        }
+        return normalized.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
+    }
+
+    /**
+     * Writes [text] as one or more Word paragraphs via [newParagraph]. Each source line becomes
+     * its own paragraph so line breaks survive, and a bullet-list line renders as an indented
+     * bullet paragraph rather than plain text with a literal "-" prefix.
+     */
+    fun write(text: String, newParagraph: () -> XWPFParagraph) {
+        for (line in toLines(text)) {
+            val paragraph = newParagraph()
+            val bulletMatch = BULLET_LINE_RE.matchEntire(line)
+            if (bulletMatch != null) {
+                paragraph.indentationLeft = 360
+                paragraph.createRun().setText("• ${bulletMatch.groupValues[1]}")
+            } else {
+                paragraph.createRun().setText(line)
+            }
+        }
+    }
+}

--- a/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/RequirementControllerWordExportTest.kt
@@ -78,6 +78,28 @@ class RequirementControllerWordExportTest {
     }
 
     @Test
+    fun `word export renders bulleted details as separate paragraphs instead of one flattened line`() {
+        val bulletedRequirement = Requirement(
+            id = 51L,
+            internalId = "REQ-51",
+            shortreq = "All assets must be registered in the asset inventory",
+            details = "<ul><li>identification of the asset</li><li>criticality of the asset</li></ul>",
+            chapter = "Asset Management"
+        )
+
+        val document = createWordDocument(listOf(bulletedRequirement))
+        val texts = document.paragraphs.map { it.text }
+
+        assertThat(texts).contains("• identification of the asset", "• criticality of the asset")
+        // Regression guard for the historical bug: both bullets must NOT be joined into one
+        // paragraph by a single XWPFRun.setText() call on the raw (still-tagged) details string.
+        assertThat(texts).noneMatch { it.contains("<li>") || it.contains("<ul>") }
+        assertThat(texts).noneMatch {
+            it.contains("identification of the asset") && it.contains("criticality of the asset")
+        }
+    }
+
+    @Test
     fun `word export rebases visible requirement numbering to one`() {
         val requirements = listOf(
             requirement(id = 285L, internalId = "REQ-285", shortreq = "Use SSM for EC2 console access"),

--- a/src/backendng/src/test/kotlin/com/secman/service/RequirementRichTextRendererTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/RequirementRichTextRendererTest.kt
@@ -1,0 +1,77 @@
+package com.secman.service
+
+import org.apache.poi.xwpf.usermodel.XWPFDocument
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RequirementRichTextRendererTest {
+
+    @Test
+    fun `isLikelyHtml detects markup produced by the HtmlEditor component`() {
+        assertThat(RequirementRichTextRenderer.isLikelyHtml("<ul><li>item</li></ul>")).isTrue()
+        assertThat(RequirementRichTextRenderer.isLikelyHtml("<p>Hello</p>")).isTrue()
+        assertThat(RequirementRichTextRenderer.isLikelyHtml("- item one\n- item two")).isFalse()
+        assertThat(RequirementRichTextRenderer.isLikelyHtml("Plain text, no markup here.")).isFalse()
+    }
+
+    @Test
+    fun `html list items render as one bullet paragraph each`() {
+        val document = XWPFDocument()
+        val html = "<ul><li>identification of the asset</li><li>criticality of the asset</li></ul>"
+
+        RequirementRichTextRenderer.write(html) { document.createParagraph() }
+
+        val texts = document.paragraphs.map { it.text }
+        assertThat(texts).containsExactly(
+            "• identification of the asset",
+            "• criticality of the asset"
+        )
+    }
+
+    @Test
+    fun `html paragraphs and line breaks become separate paragraphs`() {
+        val document = XWPFDocument()
+        val html = "<p>First line.</p><p>Second line.<br/>Third line.</p>"
+
+        RequirementRichTextRenderer.write(html) { document.createParagraph() }
+
+        assertThat(document.paragraphs.map { it.text }).containsExactly(
+            "First line.",
+            "Second line.",
+            "Third line."
+        )
+    }
+
+    @Test
+    fun `html entities are decoded after tags are stripped`() {
+        val document = XWPFDocument()
+        val html = "<p>Tom &amp; Jerry &mdash;&nbsp;a &quot;classic&quot;</p>"
+
+        RequirementRichTextRenderer.write(html) { document.createParagraph() }
+
+        assertThat(document.paragraphs.map { it.text }).containsExactly("Tom & Jerry &mdash; a \"classic\"")
+    }
+
+    @Test
+    fun `legacy markdown bullet lines render as one bullet paragraph each`() {
+        val document = XWPFDocument()
+        val markdown = "The inventory must provide:\n- identification of the asset\n- criticality of the asset"
+
+        RequirementRichTextRenderer.write(markdown) { document.createParagraph() }
+
+        assertThat(document.paragraphs.map { it.text }).containsExactly(
+            "The inventory must provide:",
+            "• identification of the asset",
+            "• criticality of the asset"
+        )
+    }
+
+    @Test
+    fun `plain single-line text renders as a single paragraph`() {
+        val document = XWPFDocument()
+
+        RequirementRichTextRenderer.write("A suitable asset inventory is the basis.") { document.createParagraph() }
+
+        assertThat(document.paragraphs.map { it.text }).containsExactly("A suitable asset inventory is the basis.")
+    }
+}


### PR DESCRIPTION
## Summary

- Exported requirement `.docx` files flattened bulleted `Details`/`Motivation`/`Example` content into a single run-on paragraph (the bullet markers and every line break were lost), even though the same content renders correctly as a bullet list in the web UI.
- Root causes: (1) every Word export path dumped a multi-line/bulleted field into one `XWPFRun.setText()` call — Word does not treat an embedded `\n` as a line break inside a single run — and (2) `POST /api/requirements` stripped all HTML tags from `details`/`example`/`motivation` on create via `sanitizeForDisplay()`, destroying paragraph/list structure at save time, while `PUT` (update) never did this.

## Changes

- New `RequirementRichTextRenderer` (`com.secman.service`): a small HTML/Markdown-aware renderer that mirrors the frontend's `RichContent.tsx` `isLikelyHtml` detection and turns each source line/list item into its own Word paragraph, rendering list items as indented bullet paragraphs instead of one flattened line.
- Wired into all four `.docx` generators: `RequirementController`'s templated/plain/translated exports and `PublicRequirementDownloadController`'s export.
- `RequirementController.create()` no longer strips HTML from `details`/`example`/`motivation` (these are rich-text fields authored via the `HtmlEditor` component and sanitized at render time via `RichContent` + DOMPurify, per the existing sanitize-at-render pattern). This aligns `create()` with `update()`, which already stored these fields unstripped. `validateDescription()` still rejects `<script>`/`<iframe>`/`on*=`/`javascript:` content upstream on both endpoints.

## Testing

- [ ] `./gradlew build` is clean — **could not run**: this session's egress policy blocks `services.gradle.org`, `plugins.gradle.org`, and `repo.maven.apache.org` (confirmed via the proxy status endpoint), so neither the Gradle wrapper nor a system Gradle could resolve the build. Please run this in CI/locally before merging.
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes) — not run, same network restriction
- [x] New/updated unit or integration tests cover the change (`RequirementRichTextRendererTest`, plus a new `RequirementControllerWordExportTest` regression case for bulleted `details`)
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — not run, no running stack available in this session
- [ ] `/e2evulnexception` passes with 0 failures — not run, same reason
- [ ] Doc-only change outside `src/`, `tests/`, `scripts/` — E2E gates skipped — N/A, backend change

## Backend contract changes

- [x] N/A — no backend contract changes (no path/method/field/auth changes; `extensions/` clients unaffected)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — unchanged
- [x] Input validation / file handling reviewed for new attack surface — `validateDescription()`'s XSS/SQLi checks still gate `details`/`example`/`motivation` before storage on both create and update; `RequirementRichTextRenderer` only reformats already-validated text into Word paragraphs, it doesn't introduce a new sink
- [x] No secrets hardcoded (uses `pass-cli`) — N/A, no secrets touched

`./scripts/owasp-check.sh` (diff-scoped): 0 block, 3 review — all three review findings are in `ResponseController.kt`, which is unrelated to this change and predates it on this branch.

## Related issues

N/A

---

Note: this branch already contained unrelated prior commits (EOL sync, account onboarding, `TrustedProxyResolver`, etc.) before this task started, with no existing PR. This description covers only the requirement-export-formatting change; I did not author or verify the earlier commits in this session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KKQ8tEzAbRjyQV6mr7V7GR)_