### PR TITLE
Stop logging the generated default-admin password (A09)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/config/DefaultAdminBootstrapper.kt
+++ b/src/backendng/src/main/kotlin/com/secman/config/DefaultAdminBootstrapper.kt
@@ -70,11 +70,20 @@ open class DefaultAdminBootstrapper(
             )
 
             userRepository.save(admin)
-            log.warn("==========================================================")
-            log.warn("  DEFAULT ADMIN USER CREATED")
-            log.warn("  Username: {}", DEFAULT_ADMIN_USERNAME)
-            log.warn("  Password: {} (CHANGE IMMEDIATELY!)", generatedPassword)
-            log.warn("==========================================================")
+            log.warn("Default admin user created (username={}); generated credential printed to console only, never logged", DEFAULT_ADMIN_USERNAME)
+            // The generated credential is written straight to stdout, bypassing SLF4J/Logback
+            // entirely, so it never reaches a log file, log appender or centralized log
+            // aggregator. See CLAUDE.md A09: never log a password, token, cookie value or API
+            // key. The banner text is assembled first and emitted with a single stdout write.
+            val divider = "=".repeat(58)
+            val firstBootBanner = buildString {
+                appendLine(divider)
+                appendLine("  DEFAULT ADMIN USER CREATED")
+                appendLine("  Username: $DEFAULT_ADMIN_USERNAME")
+                appendLine("  Password: $generatedPassword (CHANGE IMMEDIATELY!)")
+                append(divider)
+            }
+            println(firstBootBanner)
         } catch (e: Exception) {
             log.error("Failed to bootstrap default admin user: {}", e.message, e)
         }

--- a/src/backendng/src/test/kotlin/com/secman/config/DefaultAdminBootstrapperTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/config/DefaultAdminBootstrapperTest.kt
@@ -1,0 +1,94 @@
+package com.secman.config
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.secman.repository.UserRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * A09 regression test: the freshly generated default admin password must never be handed to
+ * the logging framework (any sink it's wired to - file, console appender, aggregator). It must
+ * still reach the operator, via a direct stdout write that bypasses SLF4J/Logback entirely.
+ */
+@DisplayName("DefaultAdminBootstrapper password exposure")
+class DefaultAdminBootstrapperTest {
+
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private lateinit var bootstrapper: DefaultAdminBootstrapper
+
+    private lateinit var logAppender: ListAppender<ILoggingEvent>
+    private lateinit var originalOut: PrintStream
+    private lateinit var capturedOut: ByteArrayOutputStream
+
+    @BeforeEach
+    fun setUp() {
+        bootstrapper = DefaultAdminBootstrapper(userRepository)
+        every { userRepository.count() } returns 0L
+
+        val logger = LoggerFactory.getLogger(DefaultAdminBootstrapper::class.java) as Logger
+        logAppender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(logAppender)
+
+        originalOut = System.out
+        capturedOut = ByteArrayOutputStream()
+        System.setOut(PrintStream(capturedOut))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.setOut(originalOut)
+        val logger = LoggerFactory.getLogger(DefaultAdminBootstrapper::class.java) as Logger
+        logger.detachAppender(logAppender)
+    }
+
+    @Test
+    fun `generated password is never passed to the logger`() {
+        val savedUser = slot<com.secman.domain.User>()
+        every { userRepository.save(capture(savedUser)) } answers { savedUser.captured }
+
+        bootstrapper.bootstrapDefaultAdmin()
+
+        verify(exactly = 1) { userRepository.save(any()) }
+
+        // The plaintext password only ever appears on stdout, never in a log record.
+        val console = capturedOut.toString()
+        val passwordLine = console.lines().first { it.contains("Password:") }
+        val generatedPassword = passwordLine
+            .substringAfter("Password:")
+            .substringBefore("(CHANGE IMMEDIATELY!)")
+            .trim()
+
+        assertThat(generatedPassword).isNotBlank()
+        assertThat(BCryptPasswordEncoder().matches(generatedPassword, savedUser.captured.passwordHash)).isTrue()
+
+        val loggedMessages = logAppender.list.map { it.formattedMessage }
+        assertThat(loggedMessages).noneMatch { it.contains(generatedPassword) }
+
+        // The console banner still carries the operator-facing content and warning.
+        assertThat(console).contains("DEFAULT ADMIN USER CREATED")
+        assertThat(console).contains("CHANGE IMMEDIATELY")
+    }
+
+    @Test
+    fun `skips bootstrap when users already exist`() {
+        every { userRepository.count() } returns 5L
+
+        bootstrapper.bootstrapDefaultAdmin()
+
+        verify(exactly = 0) { userRepository.save(any()) }
+        assertThat(capturedOut.toString()).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes an A09 (Security Logging and Monitoring Failures) finding from an automated scheduled security review: `DefaultAdminBootstrapper` wrote the freshly generated default ADMIN password to the application log (`log.warn("... {} ...", generatedPassword)`) on every first-boot bootstrap (fresh install, wiped test env, disaster-recovery restore). `log.warn` runs in every environment, so if logs ship to a centralized aggregator or are readable by lower-trust ops/support staff, the root admin password was recoverable from log history indefinitely — a direct violation of CLAUDE.md's A09 rule: "Never log a password, token, cookie value, API key, or the body of an auth request."

## Changes

- `src/backendng/src/main/kotlin/com/secman/config/DefaultAdminBootstrapper.kt`: the first-boot banner (username, generated password, "CHANGE IMMEDIATELY!" warning) is now assembled into a single string and written directly to `System.out` via `println`, bypassing SLF4J/Logback entirely, so it never reaches a log file, appender or aggregator. The remaining `log.warn` call only announces that a default admin was created (username only, no secret). No other behavior changed: still only runs on an empty `users` table, still generates and persists the same 20-char random password via the same `BCryptPasswordEncoder`.
- `src/backendng/src/test/kotlin/com/secman/config/DefaultAdminBootstrapperTest.kt` (new): regression test asserting the generated password never appears in any captured Logback log record, while still appearing on stdout and matching the persisted BCrypt hash; also covers the existing skip-when-users-exist path.

## Testing

- [x] `./scripts/owasp-check.sh --verbose` (diff-scoped) — `owasp-check: OK — no static findings`. **`OWASP: A09 touched — clean`**
- [ ] `./gradlew build` / `./gradlew :backendng:test --tests "*DefaultAdminBootstrapper*"` — **could not run**: this sandboxed environment has no cached Gradle 9.7.0 distribution and no dependency cache, and outbound network access to `services.gradle.org` / Maven/Gradle plugin repos is blocked by the environment's proxy policy (`CONNECT tunnel failed, response 403`). The change was reviewed by hand instead (syntax, imports, Mockk/Logback test API usage all checked against existing tests in the repo, e.g. `ExceptionExpirationSchedulerTest`).
- [ ] `./scripts/startbackenddev.sh` — not run, requires `pass-cli` secrets not available in this automated context.
- [ ] `/e2ejs`, `/e2evulnexception` — not run, require a running backend+frontend stack and `pass-cli` secrets not available in this automated context.

Per CLAUDE.md Hard Principle 5/7, this change is **not** verified as fully "complete" — someone with access to `pass-cli` and the running stack should run `./gradlew build`, `./scripts/startbackenddev.sh`, and the `/e2ejs` + `/e2evulnexception` gates before merge.

## Backend contract changes

- [x] N/A — no backend contract changes (internal startup bootstrapper only, no endpoint/DTO touched)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — N/A, no controller changed
- [x] Input validation / file handling reviewed for new attack surface — N/A, no new input surface
- [x] No secrets hardcoded (uses `pass-cli`) — the whole point of this change is to stop a *generated* secret from reaching logs; nothing hardcoded

## Related issues

Found by an automated scheduled security review (A09 finding on `DefaultAdminBootstrapper.kt`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BZjnSzGSyBAz4zXvoejkbV)_