### PR TITLE
Fix Word export chapter heading number/title size mismatch

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/service/WordExportStyle.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/WordExportStyle.kt
@@ -7,6 +7,7 @@ import org.apache.poi.xwpf.usermodel.XWPFParagraph
 import org.apache.poi.xwpf.usermodel.XWPFRun
 import org.apache.poi.xwpf.usermodel.XWPFTable
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STBorder
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.STOnOff
 import java.math.BigInteger
 
 /**
@@ -110,8 +111,33 @@ object WordExportStyle {
         paragraph.style = "Heading1"
         paragraph.spacingAfter = 120
         run(paragraph, text, size = SIZE_SECTION_HEADING, bold = true)
+        styleParagraphMark(paragraph, size = SIZE_SECTION_HEADING, bold = true, color = COLOR_TEXT)
         addBottomRule(paragraph)
         return paragraph
+    }
+
+    /**
+     * Formats the paragraph mark's own run properties (`w:pPr/w:rPr`) to match a heading's visible
+     * run. This is what an auto-generated outline/list number renders with when a "Heading1"-styled
+     * paragraph sits inside a template that links its own multilevel-list numbering to that style
+     * (common in company-uploaded Word templates) — without it, the auto-number falls back to the
+     * template's base style size while the heading text renders at [SIZE_SECTION_HEADING], producing
+     * a visibly mismatched "small number, big title" heading.
+     */
+    private fun styleParagraphMark(paragraph: XWPFParagraph, size: Int, bold: Boolean, color: String) {
+        val ctp = paragraph.ctp
+        val ppr = if (ctp.isSetPPr) ctp.pPr else ctp.addNewPPr()
+        val rpr = if (ppr.isSetRPr) ppr.rPr else ppr.addNewRPr()
+        val rFonts = if (rpr.isSetRFonts) rpr.rFonts else rpr.addNewRFonts()
+        rFonts.ascii = FONT_FAMILY
+        rFonts.hAnsi = FONT_FAMILY
+        if (bold) {
+            (if (rpr.isSetB) rpr.b else rpr.addNewB()).`val` = STOnOff.TRUE
+        }
+        val sz = if (rpr.isSetSz) rpr.sz else rpr.addNewSz()
+        sz.`val` = BigInteger.valueOf((size * 2).toLong())
+        val col = if (rpr.isSetColor) rpr.color else rpr.addNewColor()
+        col.`val` = color
     }
 
     /** 1-inch margins on every side, set explicitly rather than left to whatever default applies. */


### PR DESCRIPTION
## Summary

- Fixes generated Word exports where a chapter heading's leading number (e.g. "6.") rendered visibly smaller than the chapter title text next to it.

## Changes

- `WordExportStyle.sectionHeading()` (`src/backendng/.../service/WordExportStyle.kt`) previously formatted only the visible run holding the chapter text, never the paragraph mark's own run properties (`w:pPr/w:rPr`). When a company-uploaded template links its `Heading1` style to automatic multilevel-list numbering, Word renders the auto-generated chapter number using that paragraph-mark formatting — which stayed at the template's base size while the heading text rendered at `SIZE_SECTION_HEADING` (18pt bold), producing the reported "small number, big title" mismatch.
- Added a private `styleParagraphMark()` helper that stamps the same font/size/bold/color used on the visible run onto the paragraph mark, so any auto-generated heading number renders consistently. This is a single shared helper (`RequirementWordContentRenderer`, the translated export, and `ExampleRequirementExportTemplateBuilder` all funnel through it), so the fix applies to every export path: built-in export, public download endpoint, MCP `export_requirements`, and company-template insertion.

## Testing

- [ ] `./gradlew build` is clean — **could not run in this session**: outbound access to `services.gradle.org` (wrapper distribution) and the Gradle/Maven plugin repositories is blocked by this sandbox's egress policy (403 on CONNECT), and no local Gradle 9.7.0 / dependency cache exists here. Verified instead by careful manual review: every POI XmlBeans call added (`CTParaRPr.rFonts/b/sz/color`) mirrors POI's own internal implementation of the equivalent `XWPFRun` setters, and follows the same raw-CTP idiom already used successfully elsewhere in this exact file (`addBottomRule`, `shadeParagraph`). Please run the real build before merging.
- [ ] `./scripts/startbackenddev.sh` starts cleanly — not run, same environment limitation.
- [ ] New/updated unit or integration tests cover the change — not added; this is a pure OOXML formatting tweak with no automated gate that opens a generated `.docx` to check layout (same category as the Excel sanitizer noted in CLAUDE.md).
- [ ] `/e2ejs` — not run (needs a running stack).
- [ ] `/e2evulnexception` — not run (needs a running stack).

**Manual verification note:** the shipped example template (`ExampleRequirementExportTemplateBuilder`) defines no heading numbering, so this bug is only visually reproducible with a real customer-uploaded template whose `Heading1` style links automatic numbering (the kind the original bug report screenshot came from). Please re-export with your actual template after this change and confirm the chapter number now matches the title's size.

## Backend contract changes

- [x] N/A — no backend contract changes

## Security

- [x] N/A — pure document-formatting change, no new input handling or auth surface
- [x] No secrets hardcoded

`./scripts/owasp-check.sh`: 0 block, 27 review — all pre-existing findings on this long-lived branch unrelated to this file; none reference `WordExportStyle.kt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvJEAfFWv4uFDBgw1TZANt)_