### PR TITLE
Security fix: MCP get_requirements missing role guard (RBAC bypass)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetRequirementsTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/GetRequirementsTool.kt
@@ -70,6 +70,15 @@ class GetRequirementsTool(
     )
 
     override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Mirrors RequirementController's own @Secured("ADMIN", "REQ", "SECCHAMPION") boundary —
+        // the requirement corpus is not asset/owner-scoped, so a role gate is the right control
+        // here rather than a row-scope check. Same pattern as ExportRequirementsTool.
+        requireAnyRole(
+            context, "ADMIN", "REQ", "SECCHAMPION",
+            code = "ROLE_REQUIRED",
+            message = "ADMIN, REQ or SECCHAMPION role required to read requirements"
+        )?.let { return it }
+
         val search = arguments["search"] as? String
         val usecase = arguments["usecase"] as? String
         val norm = arguments["norm"] as? String

--- a/src/backendng/src/test/kotlin/com/secman/mcp/tools/GetRequirementsToolTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/mcp/tools/GetRequirementsToolTest.kt
@@ -1,0 +1,68 @@
+package com.secman.mcp.tools
+
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.RequirementService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `get_requirements` has no asset/owner scoping — like RequirementController and
+ * ExportRequirementsTool, access is gated by role alone. Regression coverage for
+ * the missing-guard finding: this tool used to have no role check at all, so any
+ * MCP-delegated identity (including a plain USER) could read the full requirement
+ * corpus that RequirementController and export_requirements both restrict to
+ * ADMIN/REQ/SECCHAMPION.
+ */
+class GetRequirementsToolTest {
+
+    private val service = mockk<RequirementService>(relaxed = true)
+    private val tool = GetRequirementsTool(service)
+
+    private fun ctx(isAdmin: Boolean, roles: Set<String>) =
+        mockk<McpExecutionContext>().also {
+            every { it.isAdmin } returns isAdmin
+            every { it.delegatedUserRoles } returns roles
+        }
+
+    @Test
+    fun `plain USER role is rejected`() = runBlocking<Unit> {
+        val result = tool.execute(emptyMap(), ctx(isAdmin = false, roles = setOf("USER")))
+
+        assertThat(result.isError).isTrue()
+        val error = result as McpToolResult.Error
+        assertThat(error.code).isEqualTo("ROLE_REQUIRED")
+    }
+
+    @Test
+    fun `REQ role is accepted`() = runBlocking {
+        every { service.filterRequirements(any(), any(), any(), any(), any(), any()) } returns
+            (emptyList<com.secman.domain.Requirement>() to 0)
+
+        val result = tool.execute(emptyMap(), ctx(isAdmin = false, roles = setOf("REQ")))
+
+        assertThat(result.isError).isFalse()
+    }
+
+    @Test
+    fun `SECCHAMPION role is accepted`() = runBlocking {
+        every { service.filterRequirements(any(), any(), any(), any(), any(), any()) } returns
+            (emptyList<com.secman.domain.Requirement>() to 0)
+
+        val result = tool.execute(emptyMap(), ctx(isAdmin = false, roles = setOf("SECCHAMPION")))
+
+        assertThat(result.isError).isFalse()
+    }
+
+    @Test
+    fun `admin API key bypasses the role check regardless of delegated role`() = runBlocking {
+        every { service.filterRequirements(any(), any(), any(), any(), any(), any()) } returns
+            (emptyList<com.secman.domain.Requirement>() to 0)
+
+        val result = tool.execute(emptyMap(), ctx(isAdmin = true, roles = setOf("USER")))
+
+        assertThat(result.isError).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

- Scheduled security review found a HIGH-severity A01 Broken Access Control finding: the MCP `get_requirements` tool had no role guard at all, silently bypassing `RequirementController`'s `@Secured("ADMIN", "REQ", "SECCHAMPION")` boundary.
- Any MCP-delegated identity — including a plain `USER` role, via the `REQUIREMENTS_READ` permission granted through `McpToolPermissions.CALLING`'s `READ_ONLY_TOOLS` fallback — could call `get_requirements` and read the entire requirements corpus (shortreq, details, motivation, example, chapter, norms, usecases) that both the REST API and the sibling `export_requirements` MCP tool restrict.

## Changes

- `GetRequirementsTool.kt`: add `requireAnyRole(context, "ADMIN", "REQ", "SECCHAMPION", ...)` at the top of `execute()` — the exact same guard `ExportRequirementsTool` already uses for the identical corpus, reusing `McpToolGuards.requireAnyRole` rather than introducing a new control.
- `GetRequirementsToolTest.kt` (new): regression coverage — plain `USER` role rejected (`ROLE_REQUIRED`), `REQ`/`SECCHAMPION` accepted, admin API key bypasses the role check regardless of delegated role. Follows the same MockK pattern as `ListVulnerabilityExceptionsToolTest`.

## Testing

- [x] `./scripts/owasp-check.sh` — clean, no static findings (`77 added line(s)` scanned)
- [ ] `./gradlew build` is clean — **could not run in this sandboxed review environment**: no network egress to download the pinned Gradle 9.7.0 distribution (only Gradle 8.14.3 is present locally, and `services.gradle.org` is not reachable through the environment's proxy)
- [ ] `./scripts/startbackenddev.sh` starts cleanly — **could not run**: no `pass-cli` access in this environment
- [x] New/updated unit tests cover the change (`GetRequirementsToolTest`)
- [ ] `/e2ejs` / `/e2evulnexception` — not run (same environment limitation)

This is a minimal, same-package, same-function reuse of an already-merged and working pattern (`ExportRequirementsTool`'s identical guard for the identical requirements corpus), so risk of a compile/behavior surprise is low, but please run the standard build/startup/E2E gates before merging per this repo's own CLAUDE.md Hard Principle 5.

## Backend contract changes

- [x] N/A — no backend contract changes (this tightens an existing tool's authorization; it does not change the request/response shape, and no `extensions/` client calls `get_requirements`)

## Security

- [x] RBAC enforced at the MCP tool boundary (mirrors the controller's `@Secured`)
- [x] No new attack surface — this only narrows access to an existing read tool
- [x] No secrets involved

## Related issues

Found by scheduled automated security code review.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145TWfaSm8X9MDqpgsmDyzB)_