### PR TITLE
Add EOL product drilldown page with owner contact/email feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Authoritative filter: `AssetFilterService.getAccessibleAssets()`. SQL pre-filter
 | User Mappings | `GET /api/user-mappings/{current,applied-history}`, `POST/PUT/DELETE /api/user-mappings[/{id}]` | ADMIN |
 | AWS Sharing | `GET/POST /api/aws-account-sharing`, `DELETE .../{id}` | ADMIN |
 | Heatmap | `GET /api/vulnerability-heatmap`; `POST .../refresh` (ADMIN); `GET /api/external/vulnerability-heatmap` (API-key, CORS) | mixed |
-| EOL | `GET /api/eol/{findings,summary,assets/{id},catalog/status}` (auth, asset-scoped); `GET /api/eol/repositories/top` (ADMIN/SECCHAMPION); `POST /api/eol/{catalog/sync,notifications/send}` (ADMIN). Source is operator config (`secman.eol.base-url` + `allowed-hosts`, a pair) | mixed |
+| EOL | `GET /api/eol/{findings,summary,assets/{id},catalog/status,products/{product}/assets}` (auth, asset-scoped); `GET /api/eol/repositories/top` (ADMIN/SECCHAMPION); `POST /api/eol/{catalog/sync,notifications/send}` (ADMIN); `GET/POST /api/admin/email-broadcast/eol/{product-recipients,product,jobs/{id}}` (ADMIN/SECCHAMPION, "contact affected owners"). Source is operator config (`secman.eol.base-url` + `allowed-hosts`, a pair) | mixed |
 | Identity Providers | `GET/POST/PUT/DELETE /api/identity-providers[/{id}[/test]]` | ADMIN |
 | Maintenance Banners | `GET /api/maintenance-banners/active` (PUBLIC); `GET/POST/PUT/DELETE /api/maintenance-banners[/{id}]` (ADMIN) | mixed |
 | User Profile | `GET /api/users/profile`, `PUT .../change-password` (LOCAL only), `GET/PUT .../mfa-{status,toggle}`; avatar `GET/POST/DELETE /api/users/profile/picture` (own only, no user id in the route) | auth |

--- a/docs/EOL.md
+++ b/docs/EOL.md
@@ -204,10 +204,12 @@ here. Consequently:
 | Surface | Who | Boundary |
 |---|---|---|
 | `GET /api/eol/findings`, `/summary`, `/assets/{id}` | any authenticated user | **asset-scoped** via `AssetFilterService` / `AccessibleAssetIdsCache` |
+| `GET /api/eol/products/{product}/assets` | any authenticated user | **asset-scoped**, same cache; backs the systems-affected-by-product drilldown page |
 | `GET /api/eol/catalog/status` | any authenticated user | reference data only, no per-tenant rows |
 | `GET /api/eol/repositories/top` | ADMIN, SECCHAMPION | mirrors `GithubRepositoryController` |
 | `POST /api/eol/catalog/sync` | ADMIN | logs actor + outcome |
 | `POST /api/eol/notifications/send` | ADMIN | logs actor + outcome |
+| `GET/POST /api/admin/email-broadcast/eol/*` | ADMIN, SECCHAMPION | "Contact affected owners" compose-and-send from the product drilldown page; see §6 |
 
 Every asset-scoped read resolves the caller's accessible asset ids **first** and
 passes them as a bound `IN` list. `EolFindingRepository` has no unscoped
@@ -263,6 +265,8 @@ reach the body or a log line.
 | **Vulnerability Management → End of life** (`/vulnerabilities/eol`) | the main view: counters, per-account rollup, filterable findings table |
 | Same page, ADMIN/SECCHAMPION only | **Top 10 repositories with the most EOL components** |
 | Same page, ADMIN only | "Sync catalogue & rescan" button |
+| **Vulnerability Statistics** (`/vulnerability-statistics`) | "Top 10 Most Often EOL Products" table; each row links to the drilldown below |
+| **EOL product systems** (`/vulnerabilities/eol/products/{product}`) | every accessible system a product is EOL/approaching-EOL on, plus (ADMIN/SECCHAMPION) a **Contact affected owners** button — compose a message in-browser and mail every owner/creator/uploader/mapped-user of those systems, reusing `HtmlEditor` and the async broadcast-job machinery from the admin product-notify feature. Distinct from `secman send-eol-notifications` (§5): this is ad-hoc, one product, admin-authored copy; that is scheduled, horizon-based, and templated |
 | **Installed products** (`/installed-products`) | a **Lifecycle** badge per row, linking through to the EOL view |
 | Sidebar → Vulnerability Management | "End of life" entry |
 

--- a/src/backendng/src/main/kotlin/com/secman/controller/EolController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/EolController.kt
@@ -83,6 +83,22 @@ open class EolController(
         return HttpResponse.ok(mapOf("findings" to findings))
     }
 
+    /**
+     * Systems affected by one EOL product, within the caller's accessible scope.
+     * Backs the drilldown from the "Top 10 Most Often EOL Products" table on the
+     * vulnerability statistics page — `product` is matched against the same
+     * `componentName` field that table groups by.
+     */
+    @Get("/products/{product}/assets")
+    @Produces(MediaType.APPLICATION_JSON)
+    open fun findingsForProduct(
+        authentication: Authentication,
+        @PathVariable product: String,
+        @Nullable @QueryValue page: Int?,
+        @Nullable @QueryValue pageSize: Int?
+    ): HttpResponse<*> =
+        HttpResponse.ok(eolQueryService.findingsForProduct(authentication, product, page, pageSize))
+
     /** Catalogue size and last sync outcome. Contains no per-tenant data. */
     @Get("/catalog/status")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/backendng/src/main/kotlin/com/secman/controller/EolProductEmailBroadcastController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/EolProductEmailBroadcastController.kt
@@ -1,0 +1,113 @@
+package com.secman.controller
+
+import com.secman.domain.EmailBroadcastJob
+import com.secman.domain.EmailBroadcastTargetGroup
+import com.secman.service.EmailBroadcastService
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.slf4j.LoggerFactory
+
+/**
+ * "Contact affected owners" feature for the EOL product drilldown page:
+ * compose a message and mail every owner/creator/uploader/mapped-user of the
+ * accessible systems a given EOL product is EOL or approaching EOL on.
+ *
+ * A distinct base path (rather than folding into [ProductEmailBroadcastController])
+ * keeps the two "product" concepts apart: that controller's `productName` means
+ * a vulnerable installed product, this one's means an EOL `EolFinding.componentName`
+ * — different recipient resolution, different data source.
+ *
+ * Endpoints:
+ *  - GET  /api/admin/email-broadcast/eol/product-recipients -> { count }
+ *  - POST /api/admin/email-broadcast/eol/product             -> creates job, kicks off async send
+ *  - GET  /api/admin/email-broadcast/eol/jobs/{id}           -> job status
+ */
+@Controller("/api/admin/email-broadcast/eol")
+@Secured("ADMIN", "SECCHAMPION")
+@ExecuteOn(TaskExecutors.IO)
+open class EolProductEmailBroadcastController(
+    private val emailBroadcastService: EmailBroadcastService
+) {
+    private val log = LoggerFactory.getLogger(EolProductEmailBroadcastController::class.java)
+
+    @Get("/product-recipients")
+    open fun productRecipientCount(
+        @QueryValue @NotBlank @Size(max = 512) productName: String,
+        authentication: Authentication
+    ): HttpResponse<Map<String, Any>> =
+        HttpResponse.ok(
+            mapOf(
+                "count" to emailBroadcastService.eolProductRecipientCount(productName, authentication),
+                "productName" to productName
+            )
+        )
+
+    @Post("/product")
+    open fun createEolProductBroadcast(
+        @Body @Valid request: EolProductBroadcastRequest,
+        authentication: Authentication
+    ): HttpResponse<EmailBroadcastJob> {
+        val htmlText = request.htmlContent.trim()
+        if (htmlText.isEmpty()) {
+            return HttpResponse.badRequest()
+        }
+
+        val job = emailBroadcastService.createEolProductJob(
+            subject = request.subject,
+            htmlContent = htmlText,
+            createdBy = authentication.name,
+            productName = request.productName,
+            authentication = authentication
+        )
+
+        if (job.totalRecipients == 0) {
+            log.warn("EOL product broadcast {} created with 0 recipients for {}", job.id, request.productName)
+        }
+
+        emailBroadcastService.runEolProductJobAsync(job.id!!, authentication)
+        log.info(
+            "EOL product broadcast job {} kicked off by {} for {} recipients and product {}",
+            job.id,
+            authentication.name,
+            job.totalRecipients,
+            request.productName
+        )
+        return HttpResponse.created(job)
+    }
+
+    /**
+     * Scoped deliberately to jobs created by *this* controller: [EmailBroadcastService.getJob]
+     * has no notion of caller — without the target-group check here, a SECCHAMPION
+     * (who cannot reach the ADMIN-only [EmailBroadcastController]) could still read
+     * an unrelated ALL_USERS/ADMINS_ONLY broadcast's subject and HTML body by id.
+     * An id for a job of a different target group answers 404, identical to an
+     * unknown id.
+     */
+    @Get("/jobs/{id}")
+    open fun getJob(@PathVariable id: Long): HttpResponse<EmailBroadcastJob> {
+        val job = emailBroadcastService.getJob(id)
+            ?.takeIf { it.targetGroup == EmailBroadcastTargetGroup.EOL_PRODUCT_USERS }
+            ?: return HttpResponse.notFound()
+        return HttpResponse.ok(job)
+    }
+
+    @Serdeable
+    data class EolProductBroadcastRequest(
+        @field:NotBlank @field:Size(max = 512) val productName: String,
+        @field:NotBlank @field:Size(max = 255) val subject: String,
+        @field:NotBlank @field:Size(max = 1_000_000) val htmlContent: String
+    )
+}

--- a/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
@@ -84,5 +84,6 @@ enum class EmailBroadcastTargetGroup {
     ADMINS_ONLY,
     ADMINS_AND_SECCHAMPIONS,
     SELF,
-    PRODUCT_USERS
+    PRODUCT_USERS,
+    EOL_PRODUCT_USERS
 }

--- a/src/backendng/src/main/kotlin/com/secman/repository/EolFindingRepository.kt
+++ b/src/backendng/src/main/kotlin/com/secman/repository/EolFindingRepository.kt
@@ -177,6 +177,48 @@ interface EolFindingRepository : JpaRepository<EolFinding, Long> {
     )
     fun findByAssetId(assetId: Long, pageable: Pageable): List<EolFinding>
 
+    /**
+     * Findings for one exact product name across the caller's accessible assets —
+     * the drilldown behind the "Top 10 Most Often EOL Products" table, which groups
+     * by this same `componentName` field (see [topEolProductsForAssets]).
+     */
+    @Query(
+        """
+        SELECT f FROM EolFinding f
+        WHERE f.assetId IN (:assetIds)
+          AND f.assetId IS NOT NULL
+          AND f.componentName = :product
+        ORDER BY f.status ASC, f.eolDate ASC, f.assetName ASC
+        """
+    )
+    fun findByComponentNameForAssets(product: String, assetIds: Collection<Long>, pageable: Pageable): List<EolFinding>
+
+    @Query(
+        """
+        SELECT COUNT(f) FROM EolFinding f
+        WHERE f.assetId IN (:assetIds)
+          AND f.assetId IS NOT NULL
+          AND f.componentName = :product
+        """
+    )
+    fun countByComponentNameForAssets(product: String, assetIds: Collection<Long>): Long
+
+    /**
+     * Distinct asset ids affected by one product, for the "contact affected
+     * owners" recipient resolution. Deliberately unbounded within `assetIds` —
+     * that collection is already the caller's accessible-asset universe, so this
+     * is not a second unbounded read.
+     */
+    @Query(
+        """
+        SELECT DISTINCT f.assetId FROM EolFinding f
+        WHERE f.assetId IN (:assetIds)
+          AND f.assetId IS NOT NULL
+          AND f.componentName = :product
+        """
+    )
+    fun findAssetIdsByComponentNameForAssets(product: String, assetIds: Collection<Long>): List<Long>
+
     // ---------------------------------------------------------- repository scope
 
     /**

--- a/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
@@ -27,7 +27,8 @@ open class EmailBroadcastService(
     private val emailBroadcastJobRepository: EmailBroadcastJobRepository,
     private val userRepository: UserRepository,
     private val emailService: EmailService,
-    private val productBroadcastRecipientResolver: ProductBroadcastRecipientResolver
+    private val productBroadcastRecipientResolver: ProductBroadcastRecipientResolver,
+    private val eolBroadcastRecipientResolver: EolBroadcastRecipientResolver
 ) {
     private val log = LoggerFactory.getLogger(EmailBroadcastService::class.java)
     private val broadcastHtmlSafelist = Safelist()
@@ -85,6 +86,30 @@ open class EmailBroadcastService(
         return emailBroadcastJobRepository.save(job)
     }
 
+    @Transactional
+    open fun createEolProductJob(
+        subject: String,
+        htmlContent: String,
+        createdBy: String,
+        productName: String,
+        authentication: Authentication
+    ): EmailBroadcastJob {
+        val normalizedProduct = productName.trim()
+        val total = eolBroadcastRecipientResolver.resolve(normalizedProduct, authentication).size
+        val sanitizedHtml = sanitizeBroadcastHtml(htmlContent)
+        val job = EmailBroadcastJob(
+            status = EmailBroadcastStatus.PENDING,
+            subject = subject.trim(),
+            htmlContent = sanitizedHtml,
+            totalRecipients = total,
+            createdBy = createdBy,
+            createdAt = LocalDateTime.now(),
+            targetGroup = EmailBroadcastTargetGroup.EOL_PRODUCT_USERS,
+            targetProduct = normalizedProduct
+        )
+        return emailBroadcastJobRepository.save(job)
+    }
+
     /**
      * Kicks off the send loop. Returns a CompletableFuture so callers may join during tests.
      */
@@ -105,6 +130,17 @@ open class EmailBroadcastService(
                 runJob(jobId, productAuthentication = authentication)
             } catch (e: Exception) {
                 log.error("Product email broadcast job {} crashed: {}", jobId, e.message, e)
+                markFailed(jobId, e.message ?: e.javaClass.simpleName)
+            }
+        }
+    }
+
+    fun runEolProductJobAsync(jobId: Long, authentication: Authentication): CompletableFuture<Void> {
+        return CompletableFuture.runAsync {
+            try {
+                runJob(jobId, productAuthentication = authentication)
+            } catch (e: Exception) {
+                log.error("EOL product email broadcast job {} crashed: {}", jobId, e.message, e)
                 markFailed(jobId, e.message ?: e.javaClass.simpleName)
             }
         }
@@ -206,6 +242,9 @@ open class EmailBroadcastService(
     fun productRecipientCount(productName: String, authentication: Authentication): Long =
         productBroadcastRecipientResolver.resolve(productName.trim(), authentication).size.toLong()
 
+    fun eolProductRecipientCount(productName: String, authentication: Authentication): Long =
+        eolBroadcastRecipientResolver.resolve(productName.trim(), authentication).size.toLong()
+
     /**
      * Single source of truth for "who receives this broadcast?".
      *
@@ -236,6 +275,12 @@ open class EmailBroadcastService(
             EmailBroadcastTargetGroup.PRODUCT_USERS ->
                 if (targetProduct != null && productAuthentication != null) {
                     productBroadcastRecipientResolver.resolve(targetProduct, productAuthentication)
+                } else {
+                    emptyList()
+                }
+            EmailBroadcastTargetGroup.EOL_PRODUCT_USERS ->
+                if (targetProduct != null && productAuthentication != null) {
+                    eolBroadcastRecipientResolver.resolve(targetProduct, productAuthentication)
                 } else {
                     emptyList()
                 }

--- a/src/backendng/src/main/kotlin/com/secman/service/EolBroadcastRecipientResolver.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EolBroadcastRecipientResolver.kt
@@ -1,0 +1,86 @@
+package com.secman.service
+
+import com.secman.domain.Asset
+import com.secman.domain.User
+import com.secman.domain.UserMapping
+import com.secman.repository.AssetRepository
+import com.secman.repository.EolFindingRepository
+import com.secman.repository.UserMappingRepository
+import com.secman.repository.UserRepository
+import io.micronaut.security.authentication.Authentication
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+
+/**
+ * Resolves who to email about one EOL product: the owner, creator, uploader and
+ * mapped users of every accessible asset that product is EOL or approaching EOL
+ * on. Mirrors [ProductBroadcastRecipientResolver]'s recipient-collection shape —
+ * the only difference is the affected-asset set, which here comes from
+ * [EolFindingRepository] instead of installed-product/vulnerability data.
+ *
+ * The asset id set is scoped through [AssetFilterService.getAccessibleAssetIds]
+ * before it ever reaches the repository query, so the resolver can only ever
+ * mail owners of systems the caller can already see (CLAUDE.md §A01) — callers
+ * are ADMIN/SECCHAMPION, both universal-access roles for this check.
+ */
+@Singleton
+open class EolBroadcastRecipientResolver(
+    private val eolFindingRepository: EolFindingRepository,
+    private val assetRepository: AssetRepository,
+    private val userRepository: UserRepository,
+    private val userMappingRepository: UserMappingRepository,
+    private val assetFilterService: AssetFilterService
+) {
+    @Transactional
+    open fun resolve(product: String, authentication: Authentication): List<User> {
+        val accessibleAssetIds = assetFilterService.getAccessibleAssetIds(authentication)
+        if (accessibleAssetIds.isEmpty()) return emptyList()
+
+        val affectedAssetIds = eolFindingRepository.findAssetIdsByComponentNameForAssets(product, accessibleAssetIds)
+        if (affectedAssetIds.isEmpty()) return emptyList()
+
+        val recipients = linkedMapOf<Long, User>()
+        assetRepository.findByIdIn(affectedAssetIds).forEach { asset ->
+            addUserByUsername(asset.owner, recipients)
+            addUser(asset.manualCreator, recipients)
+            addUser(asset.scanUploader, recipients)
+            addMappedUsers(asset, recipients)
+        }
+        return recipients.values.toList()
+    }
+
+    private fun addMappedUsers(asset: Asset, recipients: MutableMap<Long, User>) {
+        asset.cloudAccountId?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { userMappingRepository.findByAwsAccountId(it) }
+            ?.forEach { addMappedUser(it, recipients) }
+
+        asset.adDomain?.trim()
+            ?.lowercase()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { userMappingRepository.findByDomain(it) }
+            ?.forEach { addMappedUser(it, recipients) }
+    }
+
+    private fun addMappedUser(mapping: UserMapping, recipients: MutableMap<Long, User>) {
+        mapping.user?.let {
+            addUser(it, recipients)
+            return
+        }
+
+        userRepository.findByEmailIgnoreCase(mapping.email).ifPresent { addUser(it, recipients) }
+    }
+
+    private fun addUserByUsername(username: String?, recipients: MutableMap<Long, User>) {
+        username?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { userRepository.findByUsername(it) }
+            ?.ifPresent { addUser(it, recipients) }
+    }
+
+    private fun addUser(user: User?, recipients: MutableMap<Long, User>) {
+        val userId = user?.id ?: return
+        if (user.lastLogin == null) return
+        recipients.putIfAbsent(userId, user)
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/EolQueryService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EolQueryService.kt
@@ -160,6 +160,33 @@ open class EolQueryService(
             .map { it.toResponse() }
     }
 
+    /**
+     * Findings for one exact product name (e.g. "Internet Explorer"), scoped to
+     * the caller's accessible assets — the drilldown behind the "Top 10 Most
+     * Often EOL Products" table on the vulnerability statistics page, which
+     * groups by this same `componentName` field.
+     */
+    open fun findingsForProduct(
+        authentication: Authentication,
+        product: String,
+        page: Int?,
+        pageSize: Int?
+    ): EolFindingListResponse {
+        val effectivePage = (page ?: 0).coerceIn(0, MAX_PAGE)
+        val effectiveSize = (pageSize ?: DEFAULT_PAGE_SIZE).coerceIn(1, MAX_PAGE_SIZE)
+        val assetIds = accessibleAssetIdsCache.get(authentication)
+        if (assetIds.isEmpty()) {
+            return EolFindingListResponse(emptyList(), 0, effectivePage, effectiveSize)
+        }
+
+        val normalizedProduct = product.trim().take(512)
+        val findings = eolFindingRepository.findByComponentNameForAssets(
+            normalizedProduct, assetIds, Pageable.from(effectivePage, effectiveSize)
+        )
+        val total = eolFindingRepository.countByComponentNameForAssets(normalizedProduct, assetIds)
+        return EolFindingListResponse(findings.map { it.toResponse() }, total, effectivePage, effectiveSize)
+    }
+
     /** ADMIN / SECCHAMPION only — the controller enforces it. */
     open fun topRepositories(limit: Int?): EolTopRepositoriesResponse {
         val effectiveLimit = (limit ?: DEFAULT_TOP_REPOSITORIES).coerceIn(1, MAX_TOP_REPOSITORIES)

--- a/src/backendng/src/test/kotlin/com/secman/service/EmailBroadcastServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/EmailBroadcastServiceTest.kt
@@ -20,11 +20,13 @@ class EmailBroadcastServiceTest {
     private val userRepository = mockk<UserRepository>()
     private val emailService = mockk<EmailService>()
     private val productBroadcastRecipientResolver = mockk<ProductBroadcastRecipientResolver>()
+    private val eolBroadcastRecipientResolver = mockk<EolBroadcastRecipientResolver>()
     private val service = EmailBroadcastService(
         emailBroadcastJobRepository = emailBroadcastJobRepository,
         userRepository = userRepository,
         emailService = emailService,
-        productBroadcastRecipientResolver = productBroadcastRecipientResolver
+        productBroadcastRecipientResolver = productBroadcastRecipientResolver,
+        eolBroadcastRecipientResolver = eolBroadcastRecipientResolver
     )
 
     @Test
@@ -90,6 +92,54 @@ class EmailBroadcastServiceTest {
 
         io.mockk.verify(exactly = 1) {
             productBroadcastRecipientResolver.resolve("Chrome", authentication)
+        }
+    }
+
+    @Test
+    fun `createEolProductJob stores sanitized html and scoped recipient total`() {
+        val authentication = Authentication.build("champion", listOf("SECCHAMPION"), mapOf("userId" to 2L))
+        val jobSlot = slot<EmailBroadcastJob>()
+        every { eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication) } returns listOf(activeUser())
+        every { emailBroadcastJobRepository.save(capture(jobSlot)) } answers { jobSlot.captured }
+
+        val job = service.createEolProductJob(
+            subject = "EOL notice",
+            htmlContent = """<h2>Update</h2><a href="javascript:alert(1)">details</a>""",
+            createdBy = "champion",
+            productName = " Internet Explorer ",
+            authentication = authentication
+        )
+
+        assertThat(job.totalRecipients).isEqualTo(1)
+        assertThat(job.targetGroup).isEqualTo(EmailBroadcastTargetGroup.EOL_PRODUCT_USERS)
+        assertThat(job.targetProduct).isEqualTo("Internet Explorer")
+        assertThat(job.htmlContent).contains("<h2>Update</h2>")
+        assertThat(job.htmlContent).doesNotContain("javascript:")
+    }
+
+    @Test
+    fun `runEolProductJobAsync resolves EOL product recipients with authentication`() {
+        val authentication = Authentication.build("champion", listOf("SECCHAMPION"), mapOf("userId" to 2L))
+        val job = EmailBroadcastJob(
+            id = 43,
+            subject = "EOL notice",
+            htmlContent = "<p>Update</p>",
+            totalRecipients = 1,
+            createdBy = "champion",
+            targetGroup = EmailBroadcastTargetGroup.EOL_PRODUCT_USERS,
+            targetProduct = "Internet Explorer"
+        )
+        every { emailBroadcastJobRepository.findById(43) } returns Optional.of(job)
+        every { emailBroadcastJobRepository.update(any<EmailBroadcastJob>()) } answers { firstArg() }
+        every { eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication) } returns listOf(activeUser())
+        every {
+            emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any())
+        } returns CompletableFuture.completedFuture(true)
+
+        service.runEolProductJobAsync(43, authentication).get()
+
+        io.mockk.verify(exactly = 1) {
+            eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication)
         }
     }
 

--- a/src/backendng/src/test/kotlin/com/secman/service/EolBroadcastRecipientResolverTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/EolBroadcastRecipientResolverTest.kt
@@ -1,0 +1,149 @@
+package com.secman.service
+
+import com.secman.domain.Asset
+import com.secman.domain.User
+import com.secman.domain.UserMapping
+import com.secman.repository.AssetRepository
+import com.secman.repository.EolFindingRepository
+import com.secman.repository.UserMappingRepository
+import com.secman.repository.UserRepository
+import io.micronaut.security.authentication.Authentication
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Optional
+
+class EolBroadcastRecipientResolverTest {
+
+    private val eolFindingRepository = mockk<EolFindingRepository>()
+    private val assetRepository = mockk<AssetRepository>()
+    private val userRepository = mockk<UserRepository>()
+    private val userMappingRepository = mockk<UserMappingRepository>()
+    private val assetFilterService = mockk<AssetFilterService>()
+    private val resolver = EolBroadcastRecipientResolver(
+        eolFindingRepository = eolFindingRepository,
+        assetRepository = assetRepository,
+        userRepository = userRepository,
+        userMappingRepository = userMappingRepository,
+        assetFilterService = assetFilterService
+    )
+
+    @Test
+    fun `resolves active users responsible for systems affected by the product`() {
+        val owner = user(1, "owner", "owner@example.com", active = true)
+        val awsUser = user(3, "aws-user", "aws-user@example.com", active = true)
+        val domainUser = user(4, "domain-user", "domain-user@example.com", active = true)
+        val manualCreator = user(5, "creator", "creator@example.com", active = true)
+        val authentication = adminAuthentication()
+
+        every { assetFilterService.getAccessibleAssetIds(authentication) } returns setOf(201L)
+        every {
+            eolFindingRepository.findAssetIdsByComponentNameForAssets("Internet Explorer", setOf(201L))
+        } returns listOf(201L)
+        every { assetRepository.findByIdIn(listOf(201L)) } returns listOf(
+            asset(
+                owner = "owner",
+                cloudAccountId = "123456789012",
+                adDomain = "Example.COM",
+                manualCreator = manualCreator
+            ).also { it.id = 201 }
+        )
+        every { userRepository.findByUsername("owner") } returns Optional.of(owner)
+        every { userMappingRepository.findByAwsAccountId("123456789012") } returns listOf(
+            UserMapping(email = "aws-user@example.com", user = awsUser, awsAccountId = "123456789012", domain = null)
+        )
+        every { userMappingRepository.findByDomain("example.com") } returns listOf(
+            UserMapping(email = "domain-user@example.com", user = domainUser, awsAccountId = null, domain = "example.com")
+        )
+
+        val recipients = resolver.resolve("Internet Explorer", authentication)
+
+        assertThat(recipients.map { it.email })
+            .containsExactlyInAnyOrder(
+                "owner@example.com",
+                "aws-user@example.com",
+                "domain-user@example.com",
+                "creator@example.com"
+            )
+    }
+
+    @Test
+    fun `secchampion recipients are limited to scoped assets`() {
+        val inScopeOwner = user(20, "in-scope-owner", "in-scope@example.com", active = true)
+        val authentication = secchampionAuthentication()
+
+        every { assetFilterService.getAccessibleAssetIds(authentication) } returns setOf(201L)
+        every {
+            eolFindingRepository.findAssetIdsByComponentNameForAssets("Firefox", setOf(201L))
+        } returns listOf(201L)
+        every { assetRepository.findByIdIn(listOf(201L)) } returns listOf(
+            asset(owner = "in-scope-owner").also { it.id = 201 }
+        )
+        every { userRepository.findByUsername("in-scope-owner") } returns Optional.of(inScopeOwner)
+
+        val recipients = resolver.resolve("Firefox", authentication)
+
+        assertThat(recipients.map { it.email }).containsExactly("in-scope@example.com")
+    }
+
+    @Test
+    fun `no accessible assets returns no recipients without querying findings`() {
+        val authentication = secchampionAuthentication()
+        every { assetFilterService.getAccessibleAssetIds(authentication) } returns emptySet()
+
+        val recipients = resolver.resolve("Firefox", authentication)
+
+        assertThat(recipients).isEmpty()
+    }
+
+    @Test
+    fun `inactive owner is excluded from recipients`() {
+        val inactiveOwner = user(2, "inactive", "inactive@example.com", active = false)
+        val authentication = adminAuthentication()
+
+        every { assetFilterService.getAccessibleAssetIds(authentication) } returns setOf(202L)
+        every {
+            eolFindingRepository.findAssetIdsByComponentNameForAssets("Internet Explorer", setOf(202L))
+        } returns listOf(202L)
+        every { assetRepository.findByIdIn(listOf(202L)) } returns listOf(
+            asset(owner = "inactive").also { it.id = 202 }
+        )
+        every { userRepository.findByUsername("inactive") } returns Optional.of(inactiveOwner)
+
+        val recipients = resolver.resolve("Internet Explorer", authentication)
+
+        assertThat(recipients).isEmpty()
+    }
+
+    private fun user(id: Long, username: String, email: String, active: Boolean): User =
+        User(
+            id = id,
+            username = username,
+            email = email,
+            passwordHash = "x",
+            lastLogin = if (active) Instant.now() else null
+        )
+
+    private fun asset(
+        owner: String,
+        cloudAccountId: String? = null,
+        adDomain: String? = null,
+        manualCreator: User? = null
+    ): Asset =
+        Asset(
+            name = "host-$owner",
+            type = "SERVER",
+            owner = owner,
+            cloudAccountId = cloudAccountId,
+            adDomain = adDomain,
+            manualCreator = manualCreator
+        )
+
+    private fun adminAuthentication(): Authentication =
+        Authentication.build("admin", listOf("ADMIN"), mapOf("userId" to 1L, "email" to "admin@example.com"))
+
+    private fun secchampionAuthentication(): Authentication =
+        Authentication.build("champion", listOf("SECCHAMPION"), mapOf("userId" to 2L, "email" to "champion@example.com"))
+}

--- a/src/frontend/src/components/EolProductAssetsPage.tsx
+++ b/src/frontend/src/components/EolProductAssetsPage.tsx
@@ -1,0 +1,405 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getEolFindingsForProduct, type EolFinding } from '../services/eolService';
+import {
+  createEolProductBroadcast,
+  getEolProductJob,
+  getEolProductRecipientCount,
+  type EmailBroadcastJob,
+} from '../services/emailBroadcastService';
+import { getUser } from '../utils/auth';
+import { canNotifyProductUsers } from './productNotifyAccess';
+import HtmlEditor from './admin/HtmlEditor';
+import { describeDeadline, statusBadge } from './eolFormat';
+
+const PAGE_SIZE = 100;
+const ACTIVE_STATUSES = new Set<EmailBroadcastJob['status']>(['PENDING', 'PROCESSING']);
+
+interface Props {
+  product: string;
+}
+
+/**
+ * Systems affected by one EOL product, reached by clicking a row in the
+ * "Top 10 Most Often EOL Products" table. Everything here is already
+ * asset-scoped by the backend (`GET /api/eol/products/{product}/assets`) —
+ * this component never applies its own access filter.
+ */
+const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
+  // Roles live in sessionStorage, which does not exist during Astro's server
+  // render. Reading them on the first render would make server and client HTML
+  // disagree and React would discard the island (see EolDashboard.tsx), so both
+  // sides render role-free and the Contact button appears after mount.
+  const [roles, setRoles] = useState<string[]>([]);
+  useEffect(() => {
+    setRoles(getUser()?.roles ?? []);
+  }, []);
+  const canContact = canNotifyProductUsers(roles);
+
+  const [findings, setFindings] = useState<EolFinding[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const eolCount = useMemo(() => findings.filter((f) => f.status === 'EOL').length, [findings]);
+  const approachingCount = useMemo(
+    () => findings.filter((f) => f.status === 'APPROACHING_EOL').length,
+    [findings],
+  );
+
+  const load = useCallback(() => {
+    setLoading(true);
+    getEolFindingsForProduct(product, page, PAGE_SIZE)
+      .then((response) => {
+        setFindings(response.findings);
+        setTotal(response.total);
+        setError(null);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load affected systems'))
+      .finally(() => setLoading(false));
+  }, [product, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Contact modal state
+  const [showContactModal, setShowContactModal] = useState(false);
+  const [contactSubject, setContactSubject] = useState('');
+  const [contactHtml, setContactHtml] = useState('');
+  const [recipientCount, setRecipientCount] = useState<number | null>(null);
+  const [loadingRecipients, setLoadingRecipients] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [contactJob, setContactJob] = useState<EmailBroadcastJob | null>(null);
+  const [contactError, setContactError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const openContactModal = async () => {
+    setContactSubject(`Action required: ${product} is reaching end of life`);
+    setContactHtml(
+      `<p>Hello,</p><p>please review the systems assigned to you that are running <strong>${product}</strong>, which is end of life or approaching end of life.</p>`,
+    );
+    setRecipientCount(null);
+    setContactJob(null);
+    setContactError(null);
+    setShowContactModal(true);
+    setLoadingRecipients(true);
+
+    try {
+      const count = await getEolProductRecipientCount(product);
+      setRecipientCount(count);
+    } catch (err) {
+      console.error('Failed to load EOL contact recipients:', err);
+      setContactError(err instanceof Error ? err.message : 'Failed to load recipients for this product.');
+    } finally {
+      setLoadingRecipients(false);
+    }
+  };
+
+  const closeContactModal = () => {
+    if (sending) return;
+    setShowContactModal(false);
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  };
+
+  const handleSendContact = async () => {
+    const trimmedSubject = contactSubject.trim();
+    const trimmedHtml = contactHtml.trim();
+    if (!trimmedSubject || !trimmedHtml) {
+      setContactError('Subject and message are required.');
+      return;
+    }
+
+    setSending(true);
+    setContactError(null);
+
+    try {
+      const job = await createEolProductBroadcast({
+        productName: product,
+        subject: trimmedSubject,
+        htmlContent: trimmedHtml,
+      });
+      setContactJob(job);
+      setRecipientCount(job.totalRecipients);
+
+      if (ACTIVE_STATUSES.has(job.status)) {
+        pollRef.current = setInterval(async () => {
+          try {
+            const fresh = await getEolProductJob(job.id);
+            setContactJob(fresh);
+            if (!ACTIVE_STATUSES.has(fresh.status) && pollRef.current) {
+              clearInterval(pollRef.current);
+              pollRef.current = null;
+            }
+          } catch {
+            /* ignore transient polling errors */
+          }
+        }, 2000);
+      }
+    } catch (err) {
+      console.error('Failed to send EOL contact message:', err);
+      setContactError(err instanceof Error ? err.message : 'Failed to send message.');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="container-fluid py-4">
+      <nav aria-label="breadcrumb">
+        <ol className="breadcrumb">
+          <li className="breadcrumb-item">
+            <a href="/vulnerability-statistics">Vulnerability Statistics</a>
+          </li>
+          <li className="breadcrumb-item active" aria-current="page">
+            {product}
+          </li>
+        </ol>
+      </nav>
+
+      <div className="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+        <h1 className="h3 mb-0">
+          <i className="bi bi-hourglass-bottom me-2"></i>
+          {product}
+        </h1>
+        {canContact && (
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={openContactModal}
+            disabled={loading || findings.length === 0}
+            title="Contact the owners of the affected systems"
+          >
+            <i className="bi bi-envelope me-1"></i>
+            Contact affected owners
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2"></i>
+          {error}
+        </div>
+      )}
+
+      <div className="row mb-3">
+        <div className="col-auto">
+          <span className="badge scand-critical fs-6">{eolCount} end of life</span>
+        </div>
+        <div className="col-auto">
+          <span className="badge scand-high fs-6">{approachingCount} approaching EOL</span>
+        </div>
+        <div className="col-auto">
+          <span className="badge bg-light text-dark fs-6">{total} total finding{total === 1 ? '' : 's'}</span>
+        </div>
+      </div>
+
+      <div className="card">
+        <div
+          className="card-header"
+          style={{ backgroundColor: 'var(--scand-bg-header)', color: 'var(--scand-text-light)' }}
+        >
+          <h5 className="mb-0">Affected systems</h5>
+        </div>
+        <div className="table-responsive">
+          <table className="table table-sm table-hover mb-0">
+            <thead className="table-light">
+              <tr>
+                <th>System</th>
+                <th>Owner</th>
+                <th>Cloud account</th>
+                <th>AD domain</th>
+                <th>Version</th>
+                <th>Release cycle</th>
+                <th>End of support</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={8} className="text-center py-4">
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!loading && findings.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="text-center text-muted py-4">
+                    No systems found for this product in your accessible scope.
+                  </td>
+                </tr>
+              )}
+              {!loading &&
+                findings.map((finding) => {
+                  const badge = statusBadge(finding.status);
+                  return (
+                    <tr key={finding.id}>
+                      <td>
+                        {finding.assetId ? (
+                          <a href={`/assets/${finding.assetId}`}>{finding.assetName}</a>
+                        ) : (
+                          finding.assetName || '-'
+                        )}
+                      </td>
+                      <td>{finding.assetOwner || '-'}</td>
+                      <td>{finding.cloudAccountId || '-'}</td>
+                      <td>{finding.adDomain || '-'}</td>
+                      <td>{finding.componentVersion || '-'}</td>
+                      <td>{finding.cycle}</td>
+                      <td>{describeDeadline(finding.eolDate, finding.daysUntilEol)}</td>
+                      <td>
+                        <span className={badge.className}>{badge.label}</span>
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+        <div className="card-footer d-flex justify-content-between align-items-center">
+          <span className="text-muted small">
+            {total} system{total === 1 ? '' : 's'} · page {page + 1} of {totalPages}
+          </span>
+          <div className="btn-group">
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              disabled={page === 0}
+              onClick={() => setPage((current) => Math.max(0, current - 1))}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              disabled={page + 1 >= totalPages}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {showContactModal && (
+        <>
+          <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true">
+            <div className="modal-dialog modal-lg modal-dialog-centered">
+              <div className="modal-content">
+                <div className="modal-header">
+                  <h2 className="modal-title h5">
+                    <i className="bi bi-envelope me-2"></i>
+                    Contact affected owners
+                  </h2>
+                  <button
+                    type="button"
+                    className="btn-close"
+                    onClick={closeContactModal}
+                    aria-label="Close"
+                    disabled={sending}
+                  ></button>
+                </div>
+                <div className="modal-body">
+                  <div className="d-flex flex-wrap align-items-center gap-2 mb-3">
+                    <span className="badge bg-secondary">{product}</span>
+                    {loadingRecipients ? (
+                      <span className="text-muted small">
+                        <span className="spinner-border spinner-border-sm me-1" role="status"></span>
+                        Loading recipients...
+                      </span>
+                    ) : (
+                      <span className="text-muted small">
+                        {recipientCount ?? 0} recipient{recipientCount === 1 ? '' : 's'}
+                      </span>
+                    )}
+                  </div>
+
+                  {contactError && (
+                    <div className="alert alert-danger" role="alert">
+                      <i className="bi bi-exclamation-triangle me-2"></i>
+                      {contactError}
+                    </div>
+                  )}
+
+                  {contactJob && (
+                    <div className="alert alert-success" role="alert">
+                      <i className="bi bi-check-circle me-2"></i>
+                      Message queued for {contactJob.totalRecipients} recipient
+                      {contactJob.totalRecipients === 1 ? '' : 's'}
+                      {ACTIVE_STATUSES.has(contactJob.status)
+                        ? ` — sending (${contactJob.sentCount + contactJob.failedCount}/${contactJob.totalRecipients})…`
+                        : ` — ${contactJob.sentCount} sent${contactJob.failedCount > 0 ? `, ${contactJob.failedCount} failed` : ''}.`}
+                    </div>
+                  )}
+
+                  <div className="mb-3">
+                    <label htmlFor="eolContactSubject" className="form-label">
+                      Subject
+                    </label>
+                    <input
+                      id="eolContactSubject"
+                      type="text"
+                      className="form-control"
+                      value={contactSubject}
+                      onChange={(e) => setContactSubject(e.target.value)}
+                      disabled={sending || Boolean(contactJob)}
+                      maxLength={255}
+                    />
+                  </div>
+
+                  <div className="mb-0">
+                    <label className="form-label">Message</label>
+                    <HtmlEditor value={contactHtml} onChange={setContactHtml} minHeight={220} />
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={closeContactModal}
+                    disabled={sending}
+                  >
+                    Close
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={handleSendContact}
+                    disabled={sending || loadingRecipients || Boolean(contactJob) || recipientCount === 0}
+                  >
+                    {sending ? (
+                      <>
+                        <span className="spinner-border spinner-border-sm me-1" role="status"></span>
+                        Sending...
+                      </>
+                    ) : (
+                      <>
+                        <i className="bi bi-send me-1"></i>
+                        Send message
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop show"></div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default EolProductAssetsPage;

--- a/src/frontend/src/components/statistics/MostEolProducts.tsx
+++ b/src/frontend/src/components/statistics/MostEolProducts.tsx
@@ -66,7 +66,14 @@ export default function MostEolProducts({ domain, awsHosted }: MostEolProductsPr
             </thead>
             <tbody>
               {data.map((product, index) => (
-                <tr key={`${product.product}-${index}`}>
+                <tr
+                  key={`${product.product}-${index}`}
+                  onClick={() => {
+                    window.location.href = `/vulnerabilities/eol/products/${encodeURIComponent(product.product)}`;
+                  }}
+                  style={{ cursor: 'pointer' }}
+                  title={`Click to view systems affected by ${product.product}`}
+                >
                   <td className="align-middle">{index + 1}</td>
                   <td className="align-middle">
                     <strong>{product.product}</strong>
@@ -100,6 +107,7 @@ export default function MostEolProducts({ domain, awsHosted }: MostEolProductsPr
         <i className="bi bi-info-circle me-1"></i>
         Showing top 10 products ranked by the number of systems running a version that is past
         end-of-life. A system counts once per product, however many of its versions are affected.
+        Click any row for the affected systems.
       </div>
     </div>
   );

--- a/src/frontend/src/pages/vulnerabilities/eol/products/[product].astro
+++ b/src/frontend/src/pages/vulnerabilities/eol/products/[product].astro
@@ -1,0 +1,29 @@
+---
+/**
+ * Systems affected by one EOL product.
+ *
+ * Reached by clicking a row in the "Top 10 Most Often EOL Products" table on
+ * the vulnerability statistics page. Access control is enforced entirely by
+ * the backend (`GET /api/eol/products/{product}/assets` is asset-scoped) — this
+ * page requires only authentication, handled by Layout.
+ */
+
+import Layout from '../../../../layouts/Layout.astro';
+import EolProductAssetsPage from '../../../../components/EolProductAssetsPage';
+
+const { product } = Astro.params;
+const productName = product ?? '';
+---
+
+<Layout title={`${productName} | End of life | SecMan`}>
+  <main>
+    <EolProductAssetsPage client:load product={productName} />
+  </main>
+</Layout>
+
+<style>
+  main {
+    min-height: 100vh;
+    padding-bottom: 2rem;
+  }
+</style>

--- a/src/frontend/src/services/emailBroadcastService.ts
+++ b/src/frontend/src/services/emailBroadcastService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const API_BASE = import.meta.env.PUBLIC_API_URL || '/api';
 const ROOT = `${API_BASE}/admin/email-broadcast`;
+const EOL_ROOT = `${ROOT}/eol`;
 
 export type EmailBroadcastStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
 
@@ -10,7 +11,8 @@ export type EmailBroadcastTargetGroup =
   | 'ADMINS_ONLY'
   | 'ADMINS_AND_SECCHAMPIONS'
   | 'SELF'
-  | 'PRODUCT_USERS';
+  | 'PRODUCT_USERS'
+  | 'EOL_PRODUCT_USERS';
 
 export interface EmailBroadcastJob {
   id: number;
@@ -76,5 +78,29 @@ export async function listJobs(): Promise<EmailBroadcastJob[]> {
 
 export async function getJob(id: number): Promise<EmailBroadcastJob> {
   const res = await axios.get<EmailBroadcastJob>(`${ROOT}/jobs/${id}`);
+  return res.data;
+}
+
+/**
+ * "Contact affected owners" for the EOL product drilldown page. `productName`
+ * here means an `EolFinding.componentName`, not a vulnerable installed product
+ * (see [ProductBroadcastRequest]) — the two share this request shape but hit a
+ * distinct backend recipient resolver.
+ */
+export async function getEolProductRecipientCount(productName: string): Promise<number> {
+  const res = await axios.get<{ count: number; productName: string }>(
+    `${EOL_ROOT}/product-recipients`,
+    { params: { productName } },
+  );
+  return res.data.count;
+}
+
+export async function createEolProductBroadcast(payload: ProductBroadcastRequest): Promise<EmailBroadcastJob> {
+  const res = await axios.post<EmailBroadcastJob>(`${EOL_ROOT}/product`, payload);
+  return res.data;
+}
+
+export async function getEolProductJob(id: number): Promise<EmailBroadcastJob> {
+  const res = await axios.get<EmailBroadcastJob>(`${EOL_ROOT}/jobs/${id}`);
   return res.data;
 }

--- a/src/frontend/src/services/eolService.ts
+++ b/src/frontend/src/services/eolService.ts
@@ -127,6 +127,36 @@ export async function getEolSummary(): Promise<EolSummary> {
   };
 }
 
+/**
+ * Findings for one exact product name (e.g. "Internet Explorer"), scoped to the
+ * caller's accessible assets. Backs the drilldown page reached by clicking a row
+ * in the "Top 10 Most Often EOL Products" table, which groups by this same
+ * component name.
+ */
+export async function getEolFindingsForProduct(
+  product: string,
+  page = 0,
+  pageSize = 100,
+): Promise<EolFindingList> {
+  const params = new URLSearchParams();
+  params.append('page', String(page));
+  params.append('pageSize', String(pageSize));
+
+  const response = await authenticatedGet(
+    `/api/eol/products/${encodeURIComponent(product)}/assets?${params.toString()}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch systems for EOL product: ${response.status}`);
+  }
+  const data = await response.json();
+  return {
+    findings: data.findings ?? [],
+    total: data.total ?? 0,
+    page: data.page ?? 0,
+    pageSize: data.pageSize ?? pageSize,
+  };
+}
+
 export async function getEolFindingsForAsset(assetId: number): Promise<EolFinding[]> {
   const response = await authenticatedGet(`/api/eol/assets/${assetId}`);
   if (response.status === 404) return [];


### PR DESCRIPTION
## Summary

- Rows in the "Top 10 Most Often EOL Products" table (vulnerability statistics page) are now clickable and open a new page listing every accessible system affected by that product.
- On that page, ADMIN/SECCHAMPION users get a "Contact affected owners" button that opens an in-browser editor to compose and send a message to the owners/creators/uploaders/mapped-users of the affected systems.

## Changes

- **New endpoint** `GET /api/eol/products/{product}/assets` (`EolController`/`EolQueryService`/`EolFindingRepository`) — findings for one exact `componentName`, asset-scoped exactly like the rest of the EOL API (`AccessibleAssetIdsCache`).
- **New page** `/vulnerabilities/eol/products/{product}` (`EolProductAssetsPage.tsx` + Astro route) — systems table with owner, cloud account, AD domain, version, cycle, EOL date and status.
- **New "contact affected owners" broadcast path**, mirroring the existing vulnerable-product notify feature but scoped to EOL findings instead of installed products:
  - `EolBroadcastRecipientResolver` (new) resolves owners/creators/uploaders/mapped-users for the accessible assets a product is EOL/approaching-EOL on.
  - `EmailBroadcastTargetGroup.EOL_PRODUCT_USERS` (new enum value) + `EmailBroadcastService.createEolProductJob/runEolProductJobAsync/eolProductRecipientCount`.
  - `EolProductEmailBroadcastController` (new, `@Secured("ADMIN", "SECCHAMPION")`) at `/api/admin/email-broadcast/eol/{product-recipients,product,jobs/{id}}`. The `jobs/{id}` read is scoped to `EOL_PRODUCT_USERS` jobs only, so a SECCHAMPION calling it cannot read the body of an unrelated ADMIN-only broadcast by id.
  - Frontend reuses the existing `HtmlEditor` compose UI and async job-progress polling pattern from `ProductsOverview.tsx`'s "Notify users" modal.
- `MostEolProducts.tsx` rows are now clickable (`cursor: pointer`, navigates to the new page), matching the existing `MostVulnerableProducts.tsx` row-click convention.
- `docs/EOL.md` and `CLAUDE.md` updated with the two new endpoint groups.

## Testing

- [ ] `./gradlew build` — **could not run**: this sandboxed session's egress policy blocks `services.gradle.org`, `plugins.gradle.org` and `repo.maven.apache.org` (confirmed via the proxy status endpoint), so the Gradle 9.7.0 wrapper distribution and dependencies cannot be fetched. Needs verification in CI or locally.
- [ ] `./scripts/startbackenddev.sh` — same reason, not run.
- [x] `cd src/frontend && npm ci && npm run build` exits 0
- [x] New/updated unit tests cover the change: `EolBroadcastRecipientResolverTest` (new) + `EmailBroadcastServiceTest` extended for `createEolProductJob`/`runEolProductJobAsync` (not executed here for the same Gradle reason, but reviewed against the mirrored `ProductBroadcastRecipientResolverTest` pattern)
- [ ] `/e2ejs` / `/e2evulnexception` — not run (needs a running stack + `pass-cli`, unavailable in this session)
- `./scripts/owasp-check.sh` — 0 BLOCK, 45 REVIEW (unchanged from pre-existing baseline plus the expected "confirm scoping" heuristic on every new parameterized `@Query`/handler, all of which resolve `assetIds` via `AssetFilterService`/`AccessibleAssetIdsCache` before querying — verified by inspection)
- `cd src/frontend && npm test` — 222/222 passing

## Backend contract changes

- [x] N/A — no backend contract changes (only new endpoints; nothing renamed/retyped, no `extensions/` client touches any EOL or email-broadcast path)

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI: read endpoint inherits `IS_AUTHENTICATED` + asset scoping; contact/broadcast endpoints are `@Secured("ADMIN", "SECCHAMPION")` and the Contact button is hidden client-side for other roles via the existing `canNotifyProductUsers` helper.
- [x] Input validation reviewed: product name path/query values are bound JPQL parameters only (no concatenation); broadcast HTML is sanitized via the existing `EmailBroadcastService.sanitizeBroadcastHtml` (Jsoup Safelist) before storage and send.
- [x] No secrets hardcoded.

## Related issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_014kZnwQihok75YdKk7Z1Hqo)_