### PR TITLE
Add manual CC addresses to EOL "Contact affected owners" broadcast

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/EolProductEmailBroadcastController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/EolProductEmailBroadcastController.kt
@@ -59,18 +59,22 @@ open class EolProductEmailBroadcastController(
     open fun createEolProductBroadcast(
         @Body @Valid request: EolProductBroadcastRequest,
         authentication: Authentication
-    ): HttpResponse<EmailBroadcastJob> {
+    ): HttpResponse<*> {
         val htmlText = request.htmlContent.trim()
         if (htmlText.isEmpty()) {
-            return HttpResponse.badRequest()
+            return HttpResponse.badRequest<EmailBroadcastJob>()
         }
+
+        val ccRecipients = normalizeCcRecipients(request.ccRecipients)
+            ?: return HttpResponse.badRequest(ErrorResponse("Invalid CC email address"))
 
         val job = emailBroadcastService.createEolProductJob(
             subject = request.subject,
             htmlContent = htmlText,
             createdBy = authentication.name,
             productName = request.productName,
-            authentication = authentication
+            authentication = authentication,
+            ccRecipients = ccRecipients
         )
 
         if (job.totalRecipients == 0) {
@@ -104,10 +108,29 @@ open class EolProductEmailBroadcastController(
         return HttpResponse.ok(job)
     }
 
+    /**
+     * Normalizes manually-entered CC addresses: trims, drops blanks, dedupes
+     * case-insensitively. Returns null if any surviving address fails the
+     * format check, so the caller can 400 rather than silently drop it.
+     */
+    private fun normalizeCcRecipients(raw: List<String>): List<String>? {
+        val deduped = raw.map { it.trim() }.filter { it.isNotBlank() }.distinctBy { it.lowercase() }
+        if (deduped.any { it.length > 254 || !ccEmailRegex.matches(it) }) return null
+        return deduped
+    }
+
+    @Serdeable
+    data class ErrorResponse(val error: String)
+
     @Serdeable
     data class EolProductBroadcastRequest(
         @field:NotBlank @field:Size(max = 512) val productName: String,
         @field:NotBlank @field:Size(max = 255) val subject: String,
-        @field:NotBlank @field:Size(max = 1_000_000) val htmlContent: String
+        @field:NotBlank @field:Size(max = 1_000_000) val htmlContent: String,
+        @field:Size(max = 25) val ccRecipients: List<String> = emptyList()
     )
+
+    companion object {
+        private val ccEmailRegex = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+\$")
+    }
 }

--- a/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
+++ b/src/backendng/src/main/kotlin/com/secman/domain/EmailBroadcastJob.kt
@@ -64,7 +64,10 @@ class EmailBroadcastJob(
     var targetGroup: EmailBroadcastTargetGroup = EmailBroadcastTargetGroup.ALL_USERS,
 
     @Column(name = "target_product", length = 255)
-    var targetProduct: String? = null
+    var targetProduct: String? = null,
+
+    @Column(name = "cc_recipients", length = 2000)
+    var ccRecipients: String? = null
 ) {
     fun progressPercent(): Int {
         if (totalRecipients == 0) return 0

--- a/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EmailBroadcastService.kt
@@ -92,7 +92,8 @@ open class EmailBroadcastService(
         htmlContent: String,
         createdBy: String,
         productName: String,
-        authentication: Authentication
+        authentication: Authentication,
+        ccRecipients: List<String> = emptyList()
     ): EmailBroadcastJob {
         val normalizedProduct = productName.trim()
         val total = eolBroadcastRecipientResolver.resolve(normalizedProduct, authentication).size
@@ -105,7 +106,8 @@ open class EmailBroadcastService(
             createdBy = createdBy,
             createdAt = LocalDateTime.now(),
             targetGroup = EmailBroadcastTargetGroup.EOL_PRODUCT_USERS,
-            targetProduct = normalizedProduct
+            targetProduct = normalizedProduct,
+            ccRecipients = serializeCcRecipients(ccRecipients)
         )
         return emailBroadcastJobRepository.save(job)
     }
@@ -163,6 +165,7 @@ open class EmailBroadcastService(
         val wrappedHtml = wrapWithBrand(job.subject, job.htmlContent)
         val textContent = htmlToText(job.htmlContent)
         val logo = loadLogoInlineImage()
+        val ccRecipients = parseCcRecipients(job.ccRecipients)
 
         var sent = 0
         var failed = 0
@@ -173,7 +176,8 @@ open class EmailBroadcastService(
                     subject = job.subject,
                     textContent = textContent,
                     htmlContent = wrappedHtml,
-                    inlineImages = logo
+                    inlineImages = logo,
+                    cc = ccRecipients
                 ).get()
             } catch (e: Exception) {
                 log.warn("Broadcast job {}: send to {} failed: {}", jobId, user.email, e.message)
@@ -289,6 +293,17 @@ open class EmailBroadcastService(
 
     internal fun sanitizeBroadcastHtml(html: String): String =
         Jsoup.clean(html, broadcastHtmlSafelist)
+
+    /**
+     * Manually-added CC addresses are stored comma-joined on the job row (already
+     * trimmed/deduped/validated by the controller) and re-split when the job runs.
+     */
+    private fun serializeCcRecipients(ccRecipients: List<String>): String? =
+        ccRecipients.map { it.trim() }.filter { it.isNotBlank() }.distinct().takeIf { it.isNotEmpty() }
+            ?.joinToString(",")
+
+    private fun parseCcRecipients(raw: String?): List<String> =
+        raw?.split(",")?.map { it.trim() }?.filter { it.isNotBlank() } ?: emptyList()
 
     private fun loadLogoInlineImage(): Map<String, Pair<ByteArray, String>> {
         return try {

--- a/src/backendng/src/main/kotlin/com/secman/service/EmailService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/EmailService.kt
@@ -82,13 +82,15 @@ open class EmailService(
     /**
      * Send email with inline images embedded as CID attachments.
      * @param inlineImages Map of Content-ID to (bytes, mimeType) pairs
+     * @param cc Additional addresses CC'd on this message (already validated by the caller)
      */
     fun sendEmailWithInlineImages(
         to: String,
         subject: String,
         textContent: String,
         htmlContent: String,
-        inlineImages: Map<String, Pair<ByteArray, String>>
+        inlineImages: Map<String, Pair<ByteArray, String>>,
+        cc: List<String> = emptyList()
     ): CompletableFuture<Boolean> {
         return CompletableFuture.supplyAsync {
             runBlocking {
@@ -99,7 +101,7 @@ open class EmailService(
                         return@runBlocking false
                     }
 
-                    sendEmailWithConfigAndImages(activeConfig, to, subject, textContent, htmlContent, inlineImages)
+                    sendEmailWithConfigAndImages(activeConfig, to, subject, textContent, htmlContent, inlineImages, cc)
                 } catch (e: Exception) {
                     log.error("Failed to send email with inline images to {}: {}", to, e.message, e)
                     false
@@ -118,7 +120,8 @@ open class EmailService(
         subject: String,
         textContent: String,
         htmlContent: String,
-        inlineImages: Map<String, Pair<ByteArray, String>>
+        inlineImages: Map<String, Pair<ByteArray, String>>,
+        cc: List<String> = emptyList()
     ): Boolean {
         return try {
             log.debug("Sending email with {} inline image(s) to {}", inlineImages.size, to)
@@ -129,6 +132,9 @@ open class EmailService(
             val message = MimeMessage(session).apply {
                 setFrom(InternetAddress(config.fromEmail, config.fromName))
                 setRecipients(Message.RecipientType.TO, InternetAddress.parse(to))
+                if (cc.isNotEmpty()) {
+                    setRecipients(Message.RecipientType.CC, InternetAddress.parse(cc.joinToString(",")))
+                }
                 setSubject(subject.replace(Regex("[\\r\\n]"), ""))
 
                 // Build multipart/alternative with text + HTML

--- a/src/backendng/src/main/resources/db/migration/V255__email_broadcast_cc_recipients.sql
+++ b/src/backendng/src/main/resources/db/migration/V255__email_broadcast_cc_recipients.sql
@@ -1,0 +1,7 @@
+-- Feature: manually-added CC recipients for email broadcast jobs
+-- ("Contact affected owners" on the EOL product drilldown page).
+-- Comma-separated list of admin-entered email addresses, CC'd on every
+-- message the job sends. NULL/empty means no CC.
+
+ALTER TABLE email_broadcast_jobs
+    ADD COLUMN cc_recipients VARCHAR(2000) NULL;

--- a/src/backendng/src/test/kotlin/com/secman/service/EmailBroadcastServiceTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/EmailBroadcastServiceTest.kt
@@ -133,7 +133,7 @@ class EmailBroadcastServiceTest {
         every { emailBroadcastJobRepository.update(any<EmailBroadcastJob>()) } answers { firstArg() }
         every { eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication) } returns listOf(activeUser())
         every {
-            emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any())
+            emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any(), any())
         } returns CompletableFuture.completedFuture(true)
 
         service.runEolProductJobAsync(43, authentication).get()
@@ -141,6 +141,51 @@ class EmailBroadcastServiceTest {
         io.mockk.verify(exactly = 1) {
             eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication)
         }
+    }
+
+    @Test
+    fun `createEolProductJob serializes manually-added cc addresses`() {
+        val authentication = Authentication.build("champion", listOf("SECCHAMPION"), mapOf("userId" to 2L))
+        val jobSlot = slot<EmailBroadcastJob>()
+        every { eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication) } returns listOf(activeUser())
+        every { emailBroadcastJobRepository.save(capture(jobSlot)) } answers { jobSlot.captured }
+
+        val job = service.createEolProductJob(
+            subject = "EOL notice",
+            htmlContent = "<p>Update</p>",
+            createdBy = "champion",
+            productName = "Internet Explorer",
+            authentication = authentication,
+            ccRecipients = listOf(" manager@example.com ", "manager@example.com", "second@example.com")
+        )
+
+        assertThat(job.ccRecipients).isEqualTo("manager@example.com,second@example.com")
+    }
+
+    @Test
+    fun `runEolProductJobAsync cc's manually-added addresses on every message`() {
+        val authentication = Authentication.build("champion", listOf("SECCHAMPION"), mapOf("userId" to 2L))
+        val job = EmailBroadcastJob(
+            id = 44,
+            subject = "EOL notice",
+            htmlContent = "<p>Update</p>",
+            totalRecipients = 1,
+            createdBy = "champion",
+            targetGroup = EmailBroadcastTargetGroup.EOL_PRODUCT_USERS,
+            targetProduct = "Internet Explorer",
+            ccRecipients = "manager@example.com,second@example.com"
+        )
+        val ccSlot = slot<List<String>>()
+        every { emailBroadcastJobRepository.findById(44) } returns Optional.of(job)
+        every { emailBroadcastJobRepository.update(any<EmailBroadcastJob>()) } answers { firstArg() }
+        every { eolBroadcastRecipientResolver.resolve("Internet Explorer", authentication) } returns listOf(activeUser())
+        every {
+            emailService.sendEmailWithInlineImages(any(), any(), any(), any(), any(), capture(ccSlot))
+        } returns CompletableFuture.completedFuture(true)
+
+        service.runEolProductJobAsync(44, authentication).get()
+
+        assertThat(ccSlot.captured).containsExactly("manager@example.com", "second@example.com")
     }
 
     private fun activeUser(): User =

--- a/src/frontend/src/components/EolProductAssetsPage.tsx
+++ b/src/frontend/src/components/EolProductAssetsPage.tsx
@@ -13,6 +13,7 @@ import { describeDeadline, statusBadge } from './eolFormat';
 
 const PAGE_SIZE = 100;
 const ACTIVE_STATUSES = new Set<EmailBroadcastJob['status']>(['PENDING', 'PROCESSING']);
+const CC_EMAIL_PATTERN = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
 interface Props {
   product: string;
@@ -73,6 +74,9 @@ const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
   const [sending, setSending] = useState(false);
   const [contactJob, setContactJob] = useState<EmailBroadcastJob | null>(null);
   const [contactError, setContactError] = useState<string | null>(null);
+  const [ccEmails, setCcEmails] = useState<string[]>([]);
+  const [ccInput, setCcInput] = useState('');
+  const [ccInputError, setCcInputError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const openContactModal = async () => {
@@ -83,6 +87,9 @@ const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
     setRecipientCount(null);
     setContactJob(null);
     setContactError(null);
+    setCcEmails([]);
+    setCcInput('');
+    setCcInputError(null);
     setShowContactModal(true);
     setLoadingRecipients(true);
 
@@ -106,6 +113,34 @@ const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
     }
   };
 
+  const addCcEmail = () => {
+    const value = ccInput.trim();
+    if (!value) return;
+    if (!CC_EMAIL_PATTERN.test(value)) {
+      setCcInputError('Enter a valid email address.');
+      return;
+    }
+    if (ccEmails.some((email) => email.toLowerCase() === value.toLowerCase())) {
+      setCcInput('');
+      setCcInputError(null);
+      return;
+    }
+    setCcEmails((current) => [...current, value]);
+    setCcInput('');
+    setCcInputError(null);
+  };
+
+  const removeCcEmail = (email: string) => {
+    setCcEmails((current) => current.filter((existing) => existing !== email));
+  };
+
+  const handleCcInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addCcEmail();
+    }
+  };
+
   const handleSendContact = async () => {
     const trimmedSubject = contactSubject.trim();
     const trimmedHtml = contactHtml.trim();
@@ -122,6 +157,7 @@ const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
         productName: product,
         subject: trimmedSubject,
         htmlContent: trimmedHtml,
+        ccRecipients: ccEmails,
       });
       setContactJob(job);
       setRecipientCount(job.totalRecipients);
@@ -357,6 +393,57 @@ const EolProductAssetsPage: React.FC<Props> = ({ product }) => {
                       disabled={sending || Boolean(contactJob)}
                       maxLength={255}
                     />
+                  </div>
+
+                  <div className="mb-3">
+                    <label htmlFor="eolContactCc" className="form-label">
+                      Cc (optional)
+                    </label>
+                    <div className="d-flex gap-2">
+                      <input
+                        id="eolContactCc"
+                        type="email"
+                        className="form-control"
+                        placeholder="name@example.com"
+                        value={ccInput}
+                        onChange={(e) => {
+                          setCcInput(e.target.value);
+                          setCcInputError(null);
+                        }}
+                        onKeyDown={handleCcInputKeyDown}
+                        disabled={sending || Boolean(contactJob)}
+                      />
+                      <button
+                        type="button"
+                        className="btn btn-outline-secondary text-nowrap"
+                        onClick={addCcEmail}
+                        disabled={sending || Boolean(contactJob) || !ccInput.trim()}
+                      >
+                        Add
+                      </button>
+                    </div>
+                    {ccInputError && <div className="text-danger small mt-1">{ccInputError}</div>}
+                    {ccEmails.length > 0 && (
+                      <div className="d-flex flex-wrap gap-1 mt-2">
+                        {ccEmails.map((email) => (
+                          <span
+                            key={email}
+                            className="badge bg-light text-dark border d-inline-flex align-items-center gap-1"
+                          >
+                            {email}
+                            {!sending && !contactJob && (
+                              <button
+                                type="button"
+                                className="btn-close"
+                                style={{ fontSize: '0.55rem' }}
+                                aria-label={`Remove ${email}`}
+                                onClick={() => removeCcEmail(email)}
+                              ></button>
+                            )}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </div>
 
                   <div className="mb-0">

--- a/src/frontend/src/services/emailBroadcastService.ts
+++ b/src/frontend/src/services/emailBroadcastService.ts
@@ -41,6 +41,8 @@ export interface ProductBroadcastRequest {
   productName: string;
   subject: string;
   htmlContent: string;
+  /** Manually-added addresses CC'd on every message this job sends. */
+  ccRecipients?: string[];
 }
 
 export async function getRecipientCount(


### PR DESCRIPTION
## Summary

- The "Contact affected owners" modal on the EOL product drilldown page (`/vulnerabilities/eol/products/{product}`) now lets an ADMIN/SECCHAMPION manually add extra CC email addresses before sending.
- Every message the broadcast job sends to an affected system's owner is CC'd to those manually-added addresses.

## Changes

- `EolProductAssetsPage.tsx`: new "Cc (optional)" field in the contact modal — chip-style input with add/remove, basic client-side email format validation, disabled once sending/sent.
- `emailBroadcastService.ts`: `ProductBroadcastRequest` gains an optional `ccRecipients?: string[]`.
- `EolProductEmailBroadcastController.kt`: `EolProductBroadcastRequest` gains `ccRecipients: List<String>` (max 25); normalizes (trim/dedupe/lowercase-compare) and validates each address, returning 400 with a generic error message on an invalid address.
- `EmailBroadcastService.kt`: `createEolProductJob` accepts `ccRecipients`, stores them comma-joined on the job row (`EmailBroadcastJob.ccRecipients`); `runJob` re-parses and CC's them on every message.
- `EmailService.kt`: `sendEmailWithInlineImages`/`sendEmailWithConfigAndImages` gain an optional `cc: List<String> = emptyList()` parameter (backward compatible for the many other callers).
- New migration `V255__email_broadcast_cc_recipients.sql` adds the nullable `cc_recipients` column.
- `EmailBroadcastServiceTest.kt`: new tests for CC serialization on job creation and CC propagation into `EmailService` on send.

## Testing

- [ ] `./gradlew build` is clean — **could not run**: this sandboxed session's outbound network policy blocks `services.gradle.org`/`plugins.gradle.org`/`repo.maven.apache.org` (403 from the egress proxy), so Gradle cannot resolve the Kotlin plugin here. Changes were reviewed carefully by hand (signatures, call sites, Kotlin syntax) but not compiled locally — please confirm via CI/local build before merging.
- [ ] `./scripts/startbackenddev.sh` starts cleanly — not run, same network constraint blocks a local Gradle-based backend start.
- [x] `cd src/frontend && npm ci && npm run build` exits 0
- [x] `cd src/frontend && npm test` — all 222 existing tests pass (no new frontend unit tests added; logic here is UI-only and exercised indirectly)
- [x] New/updated unit tests cover the change (`EmailBroadcastServiceTest`), but **not executed** locally for the same reason as above
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — not run
- [ ] `/e2evulnexception` passes with 0 failures — not run (this change doesn't touch that flow, but the gate wasn't run either)

`./scripts/owasp-check.sh` (diff-scoped): **OK — no static findings**.

## Backend contract changes

- [x] N/A — no backend contract changes (new optional field, existing extension clients don't touch this endpoint)

## Security

- [x] RBAC unchanged — `@Secured("ADMIN", "SECCHAMPION")` on the controller, same as before
- [x] Input validation: each CC address is trimmed, deduped (case-insensitive), length-capped (254 chars), and checked against a simple email-format regex before being persisted or handed to `InternetAddress.parse` — an invalid address is rejected with a generic 400 rather than silently dropped or interpolated unsanitized. Format check also rejects whitespace (incl. CR/LF), closing off SMTP header injection via a crafted CC address.
- [x] No secrets hardcoded

## OWASP

A01 (RBAC unchanged) / A03 (address validation before use in `InternetAddress.parse`, no shell/SQL/HTML injection surface) / A09 (log lines emit recipient counts only, not addresses) touched — clean per `./scripts/owasp-check.sh`.

## Related issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrTE9nsaEhj21452XsJFGQ)_