### PR TITLE
Fix: add_requirement MCP tool had no role guard, bypassing RequirementController's RBAC

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/mcp/McpToolPermissions.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/McpToolPermissions.kt
@@ -134,6 +134,13 @@ object McpToolPermissions {
             setOf(ASSETS_WRITE) to listOf(
                 "create_asset", "update_asset",
             ),
+            // Was missing from CALLING entirely, so tools/call unconditionally denied
+            // add_requirement regardless of caller — a fail-closed bug (functionality,
+            // not authorization) uncovered while adding the role guard this tool was
+            // also missing (see requireAnyRole call in AddRequirementTool.execute()).
+            setOf(REQUIREMENTS_WRITE) to listOf(
+                "add_requirement",
+            ),
             setOf(VULNERABILITIES_READ) to listOf(
                 "get_vulnerabilities", "search_vulnerabilities",
                 "get_all_vulnerabilities_detail", "get_asset_most_vulnerabilities",

--- a/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddRequirementTool.kt
+++ b/src/backendng/src/main/kotlin/com/secman/mcp/tools/AddRequirementTool.kt
@@ -58,6 +58,17 @@ class AddRequirementTool(
     )
 
     override suspend fun execute(arguments: Map<String, Any>, context: McpExecutionContext): McpToolResult {
+        // Mirrors RequirementController's own @Secured("ADMIN", "REQ", "SECCHAMPION") boundary —
+        // the requirement corpus is not asset/owner-scoped, so a role gate is the right control
+        // here rather than a row-scope check. Without this, any delegated caller holding only
+        // the coarse REQUIREMENTS_WRITE MCP permission (McpToolPermissions.LISTING/.CALLING)
+        // could create arbitrary requirements, bypassing the controller's role restriction.
+        requireAnyRole(
+            context, "ADMIN", "REQ", "SECCHAMPION",
+            code = "ROLE_REQUIRED",
+            message = "ADMIN, REQ or SECCHAMPION role required to add requirements"
+        )?.let { return it }
+
         val shortreq = arguments["shortreq"] as? String
             ?: return McpToolResult.error("VALIDATION_ERROR", "Short requirement text is required")
 

--- a/src/backendng/src/test/kotlin/com/secman/mcp/McpToolPermissionsTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/mcp/McpToolPermissionsTest.kt
@@ -94,6 +94,16 @@ class McpToolPermissionsTest {
     }
 
     @Test
+    fun `add_requirement is in BOTH tables`() {
+        // Regression: add_requirement was present in LISTING (REQUIREMENTS_WRITE) but absent
+        // from CALLING entirely, so tools/call unconditionally denied it for every caller
+        // regardless of role — fail-closed, but still a bug (§A01, see McpToolPermissions.kt).
+        assertThat(McpToolPermissions.LISTING).describedAs("LISTING/add_requirement").containsKey("add_requirement")
+        assertThat(McpToolPermissions.CALLING).describedAs("CALLING/add_requirement").containsKey("add_requirement")
+        assertThat(McpToolPermissions.CALLING["add_requirement"]).isEqualTo(setOf(McpPermission.REQUIREMENTS_WRITE))
+    }
+
+    @Test
     fun `no tool is mapped to an empty permission set`() {
         val tables = mapOf("LISTING" to McpToolPermissions.LISTING, "CALLING" to McpToolPermissions.CALLING)
         tables.forEach { (name, table) ->

--- a/src/backendng/src/test/kotlin/com/secman/mcp/tools/AddRequirementToolTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/mcp/tools/AddRequirementToolTest.kt
@@ -1,0 +1,68 @@
+package com.secman.mcp.tools
+
+import com.secman.domain.Requirement
+import com.secman.dto.mcp.McpExecutionContext
+import com.secman.service.RequirementService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `add_requirement` has no asset/owner scoping — like RequirementController and
+ * ExportRequirementsTool, access must be gated by role alone. Regression coverage for
+ * the missing-guard finding: this tool used to have no role check at all, so any
+ * MCP-delegated identity holding only the coarse REQUIREMENTS_WRITE permission
+ * (including a plain USER) could create requirements, bypassing RequirementController's
+ * `@Secured("ADMIN", "REQ", "SECCHAMPION")` boundary.
+ */
+class AddRequirementToolTest {
+
+    private val service = mockk<RequirementService>(relaxed = true)
+    private val tool = AddRequirementTool(service)
+
+    private fun ctx(isAdmin: Boolean, roles: Set<String>) =
+        mockk<McpExecutionContext>().also {
+            every { it.isAdmin } returns isAdmin
+            every { it.delegatedUserRoles } returns roles
+        }
+
+    private fun args(shortreq: String = "Some requirement") = mapOf("shortreq" to shortreq)
+
+    @Test
+    fun `plain USER role is rejected`() = runBlocking<Unit> {
+        val result = tool.execute(args(), ctx(isAdmin = false, roles = setOf("USER")))
+
+        assertThat(result.isError).isTrue()
+        val error = result as McpToolResult.Error
+        assertThat(error.code).isEqualTo("ROLE_REQUIRED")
+    }
+
+    @Test
+    fun `REQ role is accepted`() = runBlocking {
+        every { service.createRequirement(any()) } returns Requirement(shortreq = "Some requirement").apply { id = 1L }
+
+        val result = tool.execute(args(), ctx(isAdmin = false, roles = setOf("REQ")))
+
+        assertThat(result.isError).isFalse()
+    }
+
+    @Test
+    fun `SECCHAMPION role is accepted`() = runBlocking {
+        every { service.createRequirement(any()) } returns Requirement(shortreq = "Some requirement").apply { id = 1L }
+
+        val result = tool.execute(args(), ctx(isAdmin = false, roles = setOf("SECCHAMPION")))
+
+        assertThat(result.isError).isFalse()
+    }
+
+    @Test
+    fun `admin API key bypasses the role check regardless of delegated role`() = runBlocking {
+        every { service.createRequirement(any()) } returns Requirement(shortreq = "Some requirement").apply { id = 1L }
+
+        val result = tool.execute(args(), ctx(isAdmin = true, roles = setOf("USER")))
+
+        assertThat(result.isError).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Whole-codebase OWASP Top 10:2021 security audit (Kotlin backend, Astro/React frontend, CLI, Go relay) against the checklist in `CLAUDE.md` §OWASP Top 10 Compliance. One genuine HIGH-severity finding (A01 Broken Access Control) confirmed and fixed; everything else investigated turned out to already be covered by an existing control or was a false positive from `./scripts/owasp-check.sh --all` (which is diff-scoped by design and very noisy across the whole tree — 77 BLOCK / 1160 REVIEW hits, the overwhelming majority pre-existing, already-mitigated, or misfires on code that only superficially matches the grep patterns, e.g. `BCryptPasswordEncoder` itself flagged as "weak hash", a same-origin `URI` parse flagged as "outbound URL", `localStorage.removeItem` flagged as "token storage").

## Finding: `add_requirement` MCP tool — missing role guard (A01, HIGH)

**Vulnerability.** `AddRequirementTool.execute()` called no `McpToolGuards` check at all — no `requireAnyRole`, `requireAnyUserRole`, or `requireDelegation`. Every other requirement-mutating path in the codebase (`RequirementController`, and the sibling `export_requirements` MCP tool per a prior fix already in `docs/CHANGELOG.md`) enforces `@Secured("ADMIN", "REQ", "SECCHAMPION")` — the requirement corpus is not asset/owner-scoped, so role is the only boundary. `AddRequirementTool` had none.

**Concrete exploit scenario.** An MCP API key granted only the coarse `REQUIREMENTS_WRITE` permission, delegated to (or acting as) a plain `USER` with none of `ADMIN`/`REQ`/`SECCHAMPION`, could call `add_requirement` via `tools/call` and create arbitrary security requirements in the compliance corpus — content a `USER` has no business writing, and which flows into exports, audits, and the public standard-download surface.

**Compounding bug found while fixing it.** `add_requirement` was also completely absent from `McpToolPermissions.CALLING` (present only in `LISTING`). Per the map's own fail-safe design, an absent `CALLING` entry means `tools/call` denies *every* caller regardless of role — so in the *current* `main`, the tool is actually unreachable for anyone (fail-closed), which is why this was a live, dangerous-if-exposed authorization gap rather than an actively-exploited one today. Adding only the role guard without restoring the `CALLING` entry would have left the tool permanently broken; adding only the `CALLING` entry without the guard would have reopened exactly the fail-open hole described above. Both are fixed together in this PR, matching the exact pattern CLAUDE.md documents for `export_requirements`.

**Fix.**
- `AddRequirementTool.kt`: added `requireAnyRole(context, "ADMIN", "REQ", "SECCHAMPION", code = "ROLE_REQUIRED", ...)` at the top of `execute()`, copied verbatim in style from `ExportRequirementsTool.kt`.
- `McpToolPermissions.kt`: added `add_requirement` to `CALLING` under `REQUIREMENTS_WRITE`, matching its existing `LISTING` entry.
- Tests: `AddRequirementToolTest.kt` (new) mirrors the existing `GetRequirementsToolTest.kt` regression-test shape — asserts a plain `USER` is rejected with `ROLE_REQUIRED`, that `REQ`/`SECCHAMPION` are accepted, and that an admin API key bypasses the delegated-role check. `McpToolPermissionsTest.kt` gained an assertion that `add_requirement` is present in both `LISTING` and `CALLING` with the expected permission.

## Other areas investigated, no action taken

- **A01** — swept ~35 other MCP tools flagged by `owasp-check.sh --all` as "missing from CALLING"; all of them are genuinely fail-closed only (confirmed by reading `McpToolPermissionService.checkPermissionSetForTool`), i.e. functionality bugs, not access-control vulnerabilities — out of scope per the task's HIGH/CRITICAL bar. Grepped every MCP tool for a WRITE/DELETE `operation` with zero guard calls; `AddRequirementTool` was the only one.
- **A01** — spot-checked `EolController`/`EolQueryService` (asset-scoped reads correctly resolve via the caller's accessible-asset-id cache, 404 on out-of-scope ids), `IdentityProviderController` (SSRF-validates `tokenUrl`/`userInfoUrl`/`authorizationUrl`/`jwksUri`; `discoveryUrl` is stored/exported only and never dereferenced server-side, so its lack of validation is not exploitable), `ApplicationRegisterController.checkGithubUrl` (already host-allowlisted to github.com with redirects disabled, comment documents a prior SSRF fix).
- **A03** — no string-concatenated native/`@Query` SQL in `VulnerabilityRepository`/`WorkgroupRepository`/`AwsAccountSharingRepository` or elsewhere; the one `owasp-check` hit (`VulnerabilityService.kt:523`) is the existing `SORT_FIELD_MAP` allowlist pattern working as designed. No `createQuery`/`createNativeQuery` call concatenates request-derived text.
- **A05** — CORS is an explicit origin allowlist (no `*`).
- **A08** — no new XML parser lacking the XXE-disabled block; multipart uploads across `ConfigBundleController`, `GithubRepositoryController`, `ImportController` all validate size/extension/emptiness before parsing. `DemandClassificationController.importRules` (ADMIN-only JSON rule import) skips that validation and deserializes straight into a typed DTO list — a real gap against the stated principle, but ADMIN-only, bounded by the global 100MB multipart cap, and not a polymorphic-deserialization risk, so judged MEDIUM rather than HIGH/CRITICAL and left unfixed per the task's scope (not flagged as a nitpick to silently ignore — noting it here for visibility).
- **A10** — every other `owasp-check.sh` "outbound URL from a variable" hit (RelayClient, GithubAppClientService, CveLookupService, CrowdStrikeVulnerabilityService, WebAuthnService, OAuthController) resolved to either an operator-fixed/hardcoded host, an already-validated `https`-only + allowlisted config, or a same-process URI parse with no outbound call at all.

## Verification

- `./scripts/owasp-check.sh` (diff-scoped) on the final commit: **`owasp-check: OK — no static findings`**.
- Manual re-read of the diff against A01–A10: only A01 touched, and it now matches the codebase's established `requireAnyRole` pattern exactly.
- **Not run, environment limitation:** `cd src/backendng && ../../gradlew compileKotlin compileTestKotlin` — the Gradle 9.7.0 wrapper distribution cannot be downloaded in this sandbox (egress to `services.gradle.org` is blocked by the environment's proxy policy, a 403), and the system-installed Gradle 8.14.3 fails even further back, unable to resolve the `org.jetbrains.kotlin.jvm:2.4.10` plugin from the Gradle Plugin Portal (also blocked). This is a sandbox networking limitation, not something to work around per this session's proxy guidance — confirmed by attempting both paths. The two changed source files were instead verified by hand against files in the same package that already compile and are used identically (`ExportRequirementsTool.kt` for the guard call, the existing `table(...)` builder in `McpToolPermissions.kt` for the new `CALLING` entry), and the new/edited tests mirror an existing, presumably-passing test (`GetRequirementsToolTest.kt`) line for line in structure.
- **Not run, environment limitation:** Hard Principle 5's full `./gradlew build` + `./scripts/startbackenddev.sh` startup gate, and the mandatory `/e2ejs` / `/e2evulnexception` E2E gates — none of `pass-cli`, a reachable test/dev MariaDB, or a live `SECMAN_HOST` are available in this sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4FdDXnr8xUpqJcCa4MmcB)_