### PR TITLE
Fix IDOR in ResponseController assessment endpoints (A01)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/ResponseController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/ResponseController.kt
@@ -92,12 +92,12 @@ open class ResponseController(
         return try {
             val username = authentication.name
             val userOptional = userRepository.findByUsername(username)
-            
+
             if (userOptional.isEmpty) {
                 log.error("User not found for username: {}", username)
                 return null
             }
-            
+
             val user = userOptional.get()
             log.debug("Found user email: {} for username: {}", user.email, username)
             user.email
@@ -105,6 +105,22 @@ open class ResponseController(
             log.error("Error getting current user email", e)
             null
         }
+    }
+
+    /**
+     * A01 access boundary for assessment-scoped endpoints below: ADMIN/RISK/SECCHAMPION
+     * (mirrors RiskAssessmentController's class-level @Secured) or the assessment's own
+     * assessor/requestor/respondent, since those can be regular users with no RISK role.
+     */
+    private fun canAccessAssessment(assessment: RiskAssessment, authentication: Authentication): Boolean {
+        val roles = authentication.roles
+        if (roles.contains("ADMIN") || roles.contains("RISK") || roles.contains("SECCHAMPION")) {
+            return true
+        }
+        val username = authentication.name
+        return username == assessment.assessor.username ||
+            username == assessment.requestor.username ||
+            username == assessment.respondent?.username
     }
 
     @Get("/assessment/{token:[a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9][a-fA-F0-9]}")
@@ -264,13 +280,16 @@ open class ResponseController(
     @Get("/assessment/{id}")
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Transactional(readOnly = true)
-    open fun getAllResponses(id: Long): HttpResponse<*> {
+    open fun getAllResponses(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching all responses for assessment: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             val responses = responseRepository.findByRiskAssessmentId(id)
             
             // Force loading of related entities
@@ -289,10 +308,16 @@ open class ResponseController(
     @Get("/assessment/{id}/email/{email}")
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Transactional(readOnly = true)
-    open fun getResponsesByEmail(id: Long, email: String): HttpResponse<*> {
+    open fun getResponsesByEmail(id: Long, email: String, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching responses for assessment: {} and email: {}", id, email)
-            
+
+            val assessment = riskAssessmentRepository.findById(id).orElse(null)
+                ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             val responses = responseRepository.findByRiskAssessmentIdAndEmail(id, email)
             
             // Force loading of related entities
@@ -311,29 +336,34 @@ open class ResponseController(
     @Get("/assessment/{id}/authenticated")
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Transactional(readOnly = true)
-    open fun getAssessmentAuthenticated(id: Long): HttpResponse<*> {
+    open fun getAssessmentAuthenticated(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching assessment for authenticated user: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             // Get requirements for this assessment
             val requirements = getRequirementsForAssessment(assessment)
-            
+
             // Get existing responses
             val responses = responseRepository.findByRiskAssessmentId(assessment.id!!)
-            
+
             // Calculate completion
             val completionPercentage = if (requirements.isNotEmpty()) {
                 (responses.size * 100) / requirements.size
             } else {
                 0
             }
-            
+
             // Check permissions - can edit if assessor or respondent, can review if requestor or admin
             val canEdit = assessment.status == "STARTED"
-            val canReview = true // In production, check if user is requestor or admin
+            val canReview = authentication.roles.let {
+                it.contains("ADMIN") || it.contains("SECCHAMPION")
+            } || authentication.name == assessment.requestor.username
             
             val assessmentData = AssessmentData(
                 assessment = assessment,
@@ -369,19 +399,22 @@ open class ResponseController(
             
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             if (assessment.status != "STARTED") {
                 return HttpResponse.badRequest(ErrorResponse("ASSESSMENT_LOCKED", "Assessment is not open for editing"))
             }
-            
+
             // Validate requirement exists
             val requirement = requirementRepository.findById(request.requirementId).orElse(null)
                 ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Requirement not found"))
-            
+
             // Check if response already exists for this requirement and assessment
             val existingResponse = responseRepository
                 .findByRiskAssessmentIdAndRequirementId(assessment.id!!, request.requirementId)
-            
+
             val response = if (existingResponse != null) {
                 // Feature 088 provenance flip: see bulkSaveResponsesAuthenticated.
                 val incomingComment = request.comment?.trim()?.takeIf { it.isNotBlank() }
@@ -432,11 +465,14 @@ open class ResponseController(
             
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             if (assessment.status != "STARTED") {
                 return HttpResponse.badRequest(ErrorResponse("ASSESSMENT_LOCKED", "Assessment is not open for editing"))
             }
-            
+
             val savedResponses = mutableListOf<Response>()
             val errors = mutableListOf<String>()
             
@@ -513,13 +549,16 @@ open class ResponseController(
     @Get("/assessment/{id}/requirements-with-responses")
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Transactional(readOnly = true)
-    open fun getRequirementsWithResponses(id: Long): HttpResponse<*> {
+    open fun getRequirementsWithResponses(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching requirements with responses for assessment: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             val requirements = getRequirementsForAssessment(assessment)
             val responses = responseRepository.findByRiskAssessmentId(id)
             val responseMap = responses.associateBy { it.requirement.id }
@@ -544,13 +583,16 @@ open class ResponseController(
     @Post("/assessment/{id}/create-risk")
     @Secured(SecurityRule.IS_AUTHENTICATED)
     @Transactional
-    open fun createRiskFromAssessment(id: Long, @Valid @Body request: CreateRiskFromResponseRequest): HttpResponse<*> {
+    open fun createRiskFromAssessment(id: Long, @Valid @Body request: CreateRiskFromResponseRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Creating risk from assessment: {} for requirement: {}", id, request.requirementId)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
-            
+            if (!canAccessAssessment(assessment, authentication)) {
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Assessment not found"))
+            }
+
             val requirement = requirementRepository.findById(request.requirementId).orElse(null)
                 ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Requirement not found"))
             

--- a/src/backendng/src/test/kotlin/com/secman/controller/ResponseControllerAccessControlTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/ResponseControllerAccessControlTest.kt
@@ -1,0 +1,140 @@
+package com.secman.controller
+
+import com.secman.domain.Asset
+import com.secman.domain.RiskAssessment
+import com.secman.repository.AssetRepository
+import com.secman.repository.RiskAssessmentRepository
+import com.secman.repository.UserRepository
+import com.secman.service.AuthCookieService
+import com.secman.testutil.BaseIntegrationTest
+import com.secman.testutil.TestDataFactory
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+/**
+ * A01 Broken Access Control regression coverage for ResponseController's
+ * "authenticated" (non-token) assessment endpoints. Prior to this fix, any
+ * authenticated user could read and mutate another user's risk-assessment
+ * responses by guessing/incrementing the assessment id, since the endpoints
+ * only checked @Secured(IS_AUTHENTICATED) and never verified the caller was
+ * the assessment's assessor/requestor/respondent or held a privileged role.
+ */
+@MicronautTest(environments = ["test"], transactional = false)
+@DisplayName("ResponseController Access Control Tests")
+class ResponseControllerAccessControlTest : BaseIntegrationTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var assetRepository: AssetRepository
+
+    @Inject
+    lateinit var riskAssessmentRepository: RiskAssessmentRepository
+
+    @Serdeable
+    data class LoginRequest(val username: String, val password: String)
+
+    @Serdeable
+    data class LoginResponse(val username: String)
+
+    @Serdeable
+    data class BulkSaveResponseBody(val responses: List<Map<String, Any>>)
+
+    private fun login(username: String): io.micronaut.http.cookie.Cookie {
+        val response = client.toBlocking().exchange(
+            HttpRequest.POST("/api/auth/login", LoginRequest(username, TestDataFactory.DEFAULT_PASSWORD)),
+            LoginResponse::class.java
+        )
+        return response.cookies.get(AuthCookieService.AUTH_COOKIE_NAME)
+            ?: throw IllegalStateException("Login response did not include ${AuthCookieService.AUTH_COOKIE_NAME} cookie")
+    }
+
+    private fun setUp(suffix: Long): Triple<RiskAssessment, String, String> {
+        val assessor = userRepository.save(
+            TestDataFactory.createRegularUser(username = "resp-assessor-$suffix", email = "resp-assessor-$suffix@test.com")
+        )
+        val outsider = userRepository.save(
+            TestDataFactory.createRegularUser(username = "resp-outsider-$suffix", email = "resp-outsider-$suffix@test.com")
+        )
+        val asset = assetRepository.save(TestDataFactory.createAsset(name = "resp-asset-$suffix"))
+        val assessment = riskAssessmentRepository.save(
+            RiskAssessment(
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(7),
+                asset = asset,
+                assessor = assessor,
+                requestor = assessor
+            )
+        )
+        return Triple(assessment, assessor.username, outsider.username)
+    }
+
+    @Test
+    fun `unrelated authenticated user cannot read another user's assessment responses`() {
+        val (assessment, _, outsiderUsername) = setUp(System.nanoTime())
+        val cookie = login(outsiderUsername)
+
+        val ex = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.GET<Any>("/api/responses/assessment/${assessment.id}/authenticated").cookie(cookie)
+            )
+        }
+        assertThat(ex.status).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `unrelated authenticated user cannot bulk-save another user's assessment responses`() {
+        val (assessment, _, outsiderUsername) = setUp(System.nanoTime())
+        val cookie = login(outsiderUsername)
+
+        val ex = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/responses/assessment/${assessment.id}/bulk-save",
+                    BulkSaveResponseBody(responses = emptyList())
+                ).cookie(cookie)
+            )
+        }
+        assertThat(ex.status).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `assessment's own assessor can read their assessment responses`() {
+        val (assessment, assessorUsername, _) = setUp(System.nanoTime())
+        val cookie = login(assessorUsername)
+
+        val response = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/responses/assessment/${assessment.id}/authenticated").cookie(cookie)
+        )
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `admin can read any assessment's responses`() {
+        val (assessment, _, _) = setUp(System.nanoTime())
+        val admin = userRepository.save(
+            TestDataFactory.createAdminUser(username = "resp-admin-${System.nanoTime()}", email = "resp-admin-${System.nanoTime()}@test.com")
+        )
+        val cookie = login(admin.username)
+
+        val response = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/responses/assessment/${assessment.id}/authenticated").cookie(cookie)
+        )
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+    }
+}


### PR DESCRIPTION
## Summary

- **CRITICAL — A01 Broken Access Control (IDOR):** seven `ResponseController` endpoints resolved a `RiskAssessment` straight from a user-supplied `{id}` path variable with only `@Secured(SecurityRule.IS_AUTHENTICATED)` and no ownership or role check, so any authenticated user could read and mutate another team's risk-assessment responses/comments, and fabricate a `Risk` against it, just by guessing/incrementing the assessment id.
- Found by a scheduled security-code-review routine auditing the `secman` codebase against the OWASP checklist in `CLAUDE.md`.

## Changes

- `ResponseController.kt`: added a private `canAccessAssessment(assessment, authentication)` helper — allows `ADMIN`/`RISK`/`SECCHAMPION` (mirroring `RiskAssessmentController`'s class-level `@Secured`), **or** the assessment's own `assessor`/`requestor`/`respondent`, since those can be arbitrary non-privileged users (resolved via `UserResolutionService`, no role restriction) who legitimately fill out their own assigned assessment through this exact controller (see `AssessmentPerformance.tsx`). A blanket role restriction would have broken that self-service flow.
- Applied the check, immediately after `riskAssessmentRepository.findById(id)`, to all seven previously-unchecked endpoints: `getAllResponses`, `getResponsesByEmail`, `getAssessmentAuthenticated`, `saveResponseAuthenticated`, `bulkSaveResponsesAuthenticated`, `getRequirementsWithResponses`, `createRiskFromAssessment`. A failed check returns `404 NOT_FOUND` — the same "not found" pattern already used elsewhere in this file — rather than `403`, so the check doesn't leak which assessment ids exist to an unauthorized caller.
- `getAssessmentAuthenticated` also had `val canReview = true // In production, check if user is requestor or admin` — a literal TODO stub. Replaced with a real check: ADMIN/SECCHAMPION or the assessment's requestor.
- Added `ResponseControllerAccessControlTest.kt` (integration test, `BaseIntegrationTest`/`TestAuthHelper` pattern already used elsewhere in this suite): asserts an unrelated authenticated user gets `404` from `GET .../authenticated` and `POST .../bulk-save`, while the assessment's own assessor and an ADMIN both get `200`.

## Testing

- [ ] `./gradlew build` is clean
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes)
- [x] New/updated unit or integration tests cover the change (`ResponseControllerAccessControlTest`)
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user)
- [ ] `/e2evulnexception` passes with 0 failures

**Note:** this PR was produced by an automated review session running in a sandboxed remote environment with no outbound access to Maven Central / the Gradle Plugin Portal (network policy denies it), so `./gradlew build` and `./scripts/startbackenddev.sh` could not be executed here. The static, offline `./scripts/owasp-check.sh --verbose` gate was run and is clean modulo one expected `REVIEW` finding (see below). **A human or CI must run the full build/startup/E2E gates before merging.**

`./scripts/owasp-check.sh --verbose`: 1 REVIEW finding, 0 BLOCK — `A01-findbyid` fired generically on `riskAssessmentRepository.findById(id)` (it's tuned for Asset ids / `AssetFilterService`). Decision: this id is a `RiskAssessment`, not an `Asset`, so `AssetFilterService` doesn't apply here; the new `canAccessAssessment()` check immediately following the `findById` is the equivalent boundary for this entity.

## Backend contract changes

- [x] N/A — no backend contract changes (path, method, request/response shapes and roles are unchanged; only an additional server-side ownership check was added)

## Security

- [x] RBAC enforced at controller (`@Secured`) — this PR *adds* the missing ownership boundary the controller-level annotation alone didn't cover
- [x] Input validation / file handling reviewed for new attack surface — no new attack surface, an existing gap was closed
- [x] No secrets hardcoded

`OWASP: A01 touched — clean (1 REVIEW, decision stated above)`


---
_Generated by [Claude Code](https://claude.ai/code/session_019ZZ24DYuCzbaZyRZqF6Myq)_