### PR TITLE
Make vulnerability export respect the active filters

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/VulnerabilityManagementController.kt
@@ -14,6 +14,7 @@ import com.secman.dto.ExportJobDto
 import com.secman.dto.PaginatedVulnerabilitiesResponse
 import com.secman.dto.StartExportResponse
 import com.secman.dto.VulnerabilityCountResponse
+import com.secman.dto.VulnerabilityExportFilters
 import com.secman.service.AccessibleAssetIdsCache
 import com.secman.service.AssetFilterService
 import com.secman.service.DeadlockRetry
@@ -273,14 +274,26 @@ open class VulnerabilityManagementController(
      *
      * The export runs in the background. Use the status endpoint to track progress
      * and the download endpoint to retrieve the file when complete.
+     *
+     * The optional body carries the same filters as GET /api/vulnerabilities/current, so the
+     * workbook contains exactly the rows the caller is looking at. An absent body means "no
+     * filters", which is the historical behaviour and keeps older clients working.
+     *
+     * Filters only ever NARROW the result set - asset scoping is derived from the
+     * authentication inside ExportJobService and is not influenced by this body.
      */
     @Post("/api/vulnerabilities/export")
     @Secured("ADMIN", "VULN", "SECCHAMPION")
-    open fun startExport(authentication: Authentication): HttpResponse<*> {
+    open fun startExport(
+        authentication: Authentication,
+        @Nullable @Body filters: VulnerabilityExportFilters?
+    ): HttpResponse<*> {
         return try {
-            log.info("Starting vulnerability export job for user: {}", authentication.name)
+            val effectiveFilters = (filters ?: VulnerabilityExportFilters.NONE).normalized()
+            log.info("Starting vulnerability export job for user: {} - filters: {}",
+                authentication.name, effectiveFilters.describe())
 
-            val jobDto = exportJobService.startExport(authentication)
+            val jobDto = exportJobService.startExport(authentication, filters = effectiveFilters)
 
             log.info("Export job created: {} for user {}", jobDto.jobId, authentication.name)
             HttpResponse.status<StartExportResponse>(HttpStatus.ACCEPTED)

--- a/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityExportFilters.kt
+++ b/src/backendng/src/main/kotlin/com/secman/dto/VulnerabilityExportFilters.kt
@@ -1,0 +1,83 @@
+package com.secman.dto
+
+import io.micronaut.serde.annotation.Serdeable
+
+/**
+ * Filters carried by a vulnerability export job.
+ *
+ * These mirror the query parameters of GET /api/vulnerabilities/current one-for-one, so an
+ * export reproduces exactly the rows the user is looking at. Before this existed the export
+ * hardcoded every filter to null and silently exported the caller's whole accessible set -
+ * selecting an AD domain narrowed the table but not the workbook.
+ *
+ * NOT included on purpose: sort / sortDir. The export pages through the entire result set,
+ * and ordering by a non-unique column makes OFFSET paging unstable (rows repeat across pages
+ * or vanish). The export keeps the service's deterministic default ordering.
+ *
+ * These filters only ever NARROW the result. Asset scoping (isAdmin / accessibleAssetIds) is
+ * computed separately from the authentication and is never influenced by this object.
+ */
+@Serdeable
+data class VulnerabilityExportFilters(
+    val severity: String? = null,
+    val system: String? = null,
+    val exceptionStatus: String? = null,
+    val product: String? = null,
+    val cve: String? = null,
+    val adDomain: String? = null,
+    val cloudAccountId: String? = null,
+
+    /**
+     * Opt back in to installer/setup payload findings ("Chrome Installer", "Photon Setup").
+     * Default false, matching the list endpoint: these are excluded from every list, count,
+     * export and statistic unless a caller asks for them explicitly.
+     */
+    val includeInstallerFindings: Boolean = false
+) {
+    /**
+     * Normalize into the shape the query layer expects:
+     * - blank strings become null, so an empty input never degrades into LIKE '%%'
+     * - a blank/absent exceptionStatus defaults to "not_excepted", identical to
+     *   VulnerabilityManagementController.getCurrentVulnerabilities
+     */
+    fun normalized(): VulnerabilityExportFilters = VulnerabilityExportFilters(
+        severity = severity?.trim()?.takeIf { it.isNotBlank() },
+        system = system?.trim()?.takeIf { it.isNotBlank() },
+        exceptionStatus = exceptionStatus?.trim()?.takeIf { it.isNotBlank() } ?: DEFAULT_EXCEPTION_STATUS,
+        product = product?.trim()?.takeIf { it.isNotBlank() },
+        cve = cve?.trim()?.takeIf { it.isNotBlank() },
+        adDomain = adDomain?.trim()?.takeIf { it.isNotBlank() },
+        cloudAccountId = cloudAccountId?.trim()?.takeIf { it.isNotBlank() },
+        includeInstallerFindings = includeInstallerFindings
+    )
+
+    /**
+     * Compact, log-safe description. CR/LF is stripped from every user-supplied value so a
+     * crafted filter cannot forge extra log lines (A09).
+     */
+    fun describe(): String {
+        val parts = buildList<String> {
+            severity?.let { add("severity=${sanitizeForLog(it)}") }
+            system?.let { add("system=${sanitizeForLog(it)}") }
+            exceptionStatus?.let { add("exceptionStatus=${sanitizeForLog(it)}") }
+            product?.let { add("product=${sanitizeForLog(it)}") }
+            cve?.let { add("cve=${sanitizeForLog(it)}") }
+            adDomain?.let { add("adDomain=${sanitizeForLog(it)}") }
+            cloudAccountId?.let { add("cloudAccountId=${sanitizeForLog(it)}") }
+            if (includeInstallerFindings) add("includeInstallerFindings=true")
+        }
+        return if (parts.isEmpty()) "none" else parts.joinToString(", ")
+    }
+
+    companion object {
+        const val DEFAULT_EXCEPTION_STATUS = "not_excepted"
+
+        /** Filters for an unfiltered export - what a client sending no body gets. */
+        val NONE = VulnerabilityExportFilters().normalized()
+
+        private val CR_LF = Regex("[\\r\\n]")
+
+        private fun sanitizeForLog(value: String): String =
+            CR_LF.replace(value, "_").take(120)
+    }
+}

--- a/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/ExportJobService.kt
@@ -6,6 +6,7 @@ import com.secman.domain.ExportJob
 import com.secman.domain.ExportJobStatus
 import com.secman.domain.ExportType
 import com.secman.dto.ExportJobDto
+import com.secman.dto.VulnerabilityExportFilters
 import com.secman.dto.VulnerabilityExportDto
 import com.secman.repository.ExportJobRepository
 import io.micronaut.context.annotation.Value
@@ -105,12 +106,19 @@ open class ExportJobService(
      *
      * @param authentication Current user authentication
      * @param exportType Type of export (default: VULNERABILITIES)
+     * @param filters Row filters to apply, mirroring GET /api/vulnerabilities/current.
+     *        Defaults to no filters. These only narrow the result - asset scoping is
+     *        computed from [authentication] below and is never widened by them.
      * @return Created job DTO
      * @throws IllegalStateException if rate limits exceeded
      */
-    open fun startExport(authentication: Authentication, exportType: ExportType = ExportType.VULNERABILITIES): ExportJobDto {
+    open fun startExport(
+        authentication: Authentication,
+        exportType: ExportType = ExportType.VULNERABILITIES,
+        filters: VulnerabilityExportFilters = VulnerabilityExportFilters.NONE
+    ): ExportJobDto {
         val username = authentication.name
-        log.info("Starting export job for user: {}, type: {}", username, exportType)
+        log.info("Starting export job for user: {}, type: {}, filters: {}", username, exportType, filters.describe())
 
         // Check rate limits
         val runningStatuses = listOf(ExportJobStatus.PENDING, ExportJobStatus.PROCESSING)
@@ -166,8 +174,11 @@ open class ExportJobService(
                 .toSet()
         }
 
+        // The filters ride this closure into the background thread. They are deliberately not
+        // persisted on the job row: nothing ever re-runs a job from the DB (autoResetStaleJobs
+        // and resetStuckJobs only mark stale jobs FAILED), so the in-memory hand-off is complete.
         executorService.submit {
-            processExportInBackground(jobId, username, isAdmin, accessibleAssetIds)
+            processExportInBackground(jobId, username, isAdmin, accessibleAssetIds, filters)
         }
 
         return ExportJobDto.fromEntity(savedJob)
@@ -377,12 +388,14 @@ open class ExportJobService(
      * @param username Username for logging
      * @param isAdmin Whether user is admin (for access control)
      * @param accessibleAssetIds Pre-computed set of accessible asset IDs
+     * @param filters Row filters to apply to every query this job runs
      */
     private fun processExportInBackground(
         jobId: String,
         username: String,
         isAdmin: Boolean,
-        accessibleAssetIds: Set<Long>
+        accessibleAssetIds: Set<Long>,
+        filters: VulnerabilityExportFilters
     ) {
         val shortId = jobId.take(8)
         val originalThreadName = Thread.currentThread().name
@@ -415,7 +428,7 @@ open class ExportJobService(
             updateJobStage(jobId, STAGE_STARTING)
 
             when (job.exportType) {
-                ExportType.VULNERABILITIES -> processVulnerabilityExport(jobId, isAdmin, accessibleAssetIds)
+                ExportType.VULNERABILITIES -> processVulnerabilityExport(jobId, isAdmin, accessibleAssetIds, filters)
                 else -> throw IllegalArgumentException("Unsupported export type: ${job.exportType}")
             }
 
@@ -581,21 +594,27 @@ open class ExportJobService(
     open fun fetchVulnerabilityPageForExport(
         accessibleAssetIds: Set<Long>,
         isAdmin: Boolean,
+        filters: VulnerabilityExportFilters,
         page: Int,
         size: Int
     ): com.secman.dto.PaginatedVulnerabilitiesResponse {
+        // Every filter comes from the caller so the workbook matches what the UI is showing.
+        // These previously were hardcoded nulls, which is why an exported file ignored the
+        // selected AD domain (and every other filter) and contained the whole accessible set.
+        // No sort/sortDir on purpose - see VulnerabilityExportFilters.
         return vulnerabilityService.getCurrentVulnerabilitiesOptimized(
             accessibleAssetIds = accessibleAssetIds,
             isAdmin = isAdmin,
-            severity = null,
-            system = null,
-            exceptionStatus = "not_excepted",
-            product = null,
-            cve = null,
-            adDomain = null,
-            cloudAccountId = null,
+            severity = filters.severity,
+            system = filters.system,
+            exceptionStatus = filters.exceptionStatus,
+            product = filters.product,
+            cve = filters.cve,
+            adDomain = filters.adDomain,
+            cloudAccountId = filters.cloudAccountId,
             page = page,
-            size = size
+            size = size,
+            includeInstallerFindings = filters.includeInstallerFindings
         )
     }
 
@@ -607,8 +626,9 @@ open class ExportJobService(
      *   STARTING -> COUNTING -> EXPORTING -> WRITING_FILE -> FINALIZING -> (COMPLETED)
      *
      * Correctness notes:
-     * - Count query and export loop now share identical filters ("not_excepted"),
-     *   so processedItems == totalItems on success (previously diverged and progress
+     * - Count query and export loop share the caller's filters verbatim (both go through
+     *   fetchVulnerabilityPageForExport with the same [filters] instance), so
+     *   processedItems == totalItems on success (previously diverged and progress
      *   never reached 100%).
      * - processedItems increments by actual returned rows, not (page+1)*batchSize,
      *   so the final (partial) batch doesn't over-count.
@@ -616,14 +636,15 @@ open class ExportJobService(
     private fun processVulnerabilityExport(
         jobId: String,
         isAdmin: Boolean,
-        accessibleAssetIds: Set<Long>
+        accessibleAssetIds: Set<Long>,
+        filters: VulnerabilityExportFilters
     ) {
         val shortId = jobId.take(8)
 
         // --- STAGE 1: COUNTING ------------------------------------------------
         updateJobStage(jobId, STAGE_COUNTING)
-        log.info("[export {}] COUNTING started (isAdmin={}, accessibleAssets={})",
-            shortId, isAdmin, if (isAdmin) "ALL" else accessibleAssetIds.size.toString())
+        log.info("[export {}] COUNTING started (isAdmin={}, accessibleAssets={}, filters={})",
+            shortId, isAdmin, if (isAdmin) "ALL" else accessibleAssetIds.size.toString(), filters.describe())
 
         val countStart = System.currentTimeMillis()
         // IMPORTANT: use the SAME filter as the export loop below. If this
@@ -632,6 +653,7 @@ open class ExportJobService(
         val firstPage = fetchVulnerabilityPageForExport(
             accessibleAssetIds = accessibleAssetIds,
             isAdmin = isAdmin,
+            filters = filters,
             page = 0,
             size = 1
         )
@@ -680,6 +702,7 @@ open class ExportJobService(
                 val response = fetchVulnerabilityPageForExport(
                     accessibleAssetIds = accessibleAssetIds,
                     isAdmin = isAdmin,
+                    filters = filters,
                     page = page,
                     size = batchSize
                 )

--- a/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExportService.kt
+++ b/src/backendng/src/main/kotlin/com/secman/service/VulnerabilityExportService.kt
@@ -36,6 +36,12 @@ import java.time.format.DateTimeFormatter
  * - When streamingExportsEnabled=true: Write directly to Excel during fetch (write-on-fetch)
  * - When streamingExportsEnabled=false: Accumulate all records first (original behavior)
  * - Controlled by MEMORY_STREAMING_EXPORTS environment variable
+ *
+ * NOTE: this service is currently wired to no endpoint. Both entry points below pass hardcoded
+ * nulls for every row filter (severity/system/product/cve/adDomain/cloudAccountId) and so export
+ * the caller's entire accessible set - the exact defect that was fixed in ExportJobService. If
+ * either method is ever wired up, give it a VulnerabilityExportFilters parameter first and thread
+ * it into getCurrentVulnerabilitiesOptimized the same way ExportJobService does.
  */
 @Singleton
 class VulnerabilityExportService(

--- a/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityExportFilterTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/service/VulnerabilityExportFilterTest.kt
@@ -1,0 +1,292 @@
+package com.secman.service
+
+import com.secman.config.MemoryOptimizationConfig
+import com.secman.dto.PaginatedVulnerabilitiesResponse
+import com.secman.dto.VulnerabilityExportFilters
+import com.secman.repository.ExportJobRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ExecutorService
+
+/**
+ * The vulnerability export used to hardcode every row filter to null, so selecting an AD domain
+ * in the Analytics view narrowed the on-screen table but the downloaded workbook still contained
+ * the caller's entire accessible set.
+ *
+ * These tests pin the two halves of the fix:
+ *  - VulnerabilityExportFilters normalizes the request the way the list endpoint does.
+ *  - ExportJobService.fetchVulnerabilityPageForExport forwards those filters verbatim, and the
+ *    COUNTING pass and the EXPORTING loop necessarily agree because both go through it.
+ */
+class VulnerabilityExportFilterTest {
+
+    // ---------- VulnerabilityExportFilters ----------
+
+    @Test
+    fun `blank filters normalize to null so they never become an empty LIKE pattern`() {
+        val normalized = VulnerabilityExportFilters(
+            severity = "",
+            system = "   ",
+            product = "\t",
+            cve = "",
+            adDomain = "  ",
+            cloudAccountId = ""
+        ).normalized()
+
+        assertThat(normalized.severity).isNull()
+        assertThat(normalized.system).isNull()
+        assertThat(normalized.product).isNull()
+        assertThat(normalized.cve).isNull()
+        assertThat(normalized.adDomain).isNull()
+        assertThat(normalized.cloudAccountId).isNull()
+    }
+
+    @Test
+    fun `filter values are trimmed but otherwise preserved`() {
+        val normalized = VulnerabilityExportFilters(adDomain = "  ad.glpoly.net  ").normalized()
+
+        assertThat(normalized.adDomain).isEqualTo("ad.glpoly.net")
+    }
+
+    @Test
+    fun `a blank or absent exceptionStatus defaults to not_excepted like the list endpoint`() {
+        val blanks = listOf<String?>(null, "", "   ")
+        for (value in blanks) {
+            val normalized = VulnerabilityExportFilters(exceptionStatus = value).normalized()
+            assertThat(normalized.exceptionStatus).isEqualTo("not_excepted")
+        }
+        assertThat(VulnerabilityExportFilters.NONE.exceptionStatus).isEqualTo("not_excepted")
+    }
+
+    @Test
+    fun `an explicit exceptionStatus survives normalization`() {
+        val normalized = VulnerabilityExportFilters(exceptionStatus = "excepted").normalized()
+
+        assertThat(normalized.exceptionStatus).isEqualTo("excepted")
+    }
+
+    @Test
+    fun `describe strips CR and LF so a crafted filter cannot forge log lines`() {
+        val description = VulnerabilityExportFilters(
+            adDomain = "ad.glpoly.net\nINFO evil: forged line",
+            system = "host\r\nmore"
+        ).describe()
+
+        assertThat(description).doesNotContain("\n")
+        assertThat(description).doesNotContain("\r")
+        assertThat(description).contains("ad.glpoly.net")
+    }
+
+    @Test
+    fun `describe reports none when nothing is set`() {
+        assertThat(VulnerabilityExportFilters().describe()).isEqualTo("none")
+        // NONE is normalized, so it carries the default exception status and nothing else.
+        assertThat(VulnerabilityExportFilters.NONE.describe()).isEqualTo("exceptionStatus=not_excepted")
+    }
+
+    // ---------- ExportJobService.fetchVulnerabilityPageForExport ----------
+
+    private val vulnerabilityService = mockk<VulnerabilityService>()
+
+    private val service = ExportJobService(
+        exportJobRepository = mockk<ExportJobRepository>(relaxed = true),
+        vulnerabilityService = vulnerabilityService,
+        assetFilterService = mockk<AssetFilterService>(relaxed = true),
+        executorService = mockk<ExecutorService>(relaxed = true),
+        entityManager = mockk<EntityManager>(relaxed = true),
+        memoryConfig = mockk<MemoryOptimizationConfig>(relaxed = true),
+        exportDirectory = System.getProperty("java.io.tmpdir") + "/secman-export-filter-test",
+        maxConcurrentPerUser = 1,
+        maxConcurrentGlobal = 5,
+        fileRetentionHours = 24L
+    )
+
+    private val emptyPage = PaginatedVulnerabilitiesResponse(
+        content = emptyList(),
+        totalElements = 0L,
+        totalPages = 0,
+        currentPage = 0,
+        pageSize = 1,
+        hasNext = false,
+        hasPrevious = false
+    )
+
+    /** Accept any query and return an empty page, so each test can verify what was asked for. */
+    private fun stubQuery() {
+        every {
+            vulnerabilityService.getCurrentVulnerabilitiesOptimized(
+                accessibleAssetIds = any(),
+                isAdmin = any(),
+                severity = any(),
+                system = any(),
+                exceptionStatus = any(),
+                product = any(),
+                cve = any(),
+                adDomain = any(),
+                cloudAccountId = any(),
+                page = any(),
+                size = any(),
+                sort = any(),
+                sortDir = any(),
+                knownTotal = any(),
+                countMode = any(),
+                includeInstallerFindings = any()
+            )
+        } returns emptyPage
+    }
+
+    @Test
+    fun `the selected AD domain reaches the query instead of a hardcoded null`() {
+        stubQuery()
+
+        service.fetchVulnerabilityPageForExport(
+            accessibleAssetIds = emptySet(),
+            isAdmin = true,
+            filters = VulnerabilityExportFilters(adDomain = "ad.glpoly.net").normalized(),
+            page = 0,
+            size = 100
+        )
+
+        verify(exactly = 1) {
+            vulnerabilityService.getCurrentVulnerabilitiesOptimized(
+                accessibleAssetIds = emptySet(),
+                isAdmin = true,
+                severity = null,
+                system = null,
+                exceptionStatus = "not_excepted",
+                product = null,
+                cve = null,
+                adDomain = "ad.glpoly.net",
+                cloudAccountId = null,
+                page = 0,
+                size = 100,
+                sort = null,
+                sortDir = null,
+                knownTotal = null,
+                countMode = null,
+                includeInstallerFindings = false
+            )
+        }
+    }
+
+    @Test
+    fun `every filter is forwarded verbatim to the query layer`() {
+        stubQuery()
+
+        service.fetchVulnerabilityPageForExport(
+            accessibleAssetIds = emptySet(),
+            isAdmin = true,
+            filters = VulnerabilityExportFilters(
+                severity = "Critical",
+                system = "THMTPPI1",
+                exceptionStatus = "overdue",
+                product = "Edge (Chromium-Based)",
+                cve = "CVE-2026-19557",
+                adDomain = "ad.glpoly.net",
+                cloudAccountId = "123456789012",
+                includeInstallerFindings = true
+            ).normalized(),
+            page = 2,
+            size = 500
+        )
+
+        verify(exactly = 1) {
+            vulnerabilityService.getCurrentVulnerabilitiesOptimized(
+                accessibleAssetIds = emptySet(),
+                isAdmin = true,
+                severity = "Critical",
+                system = "THMTPPI1",
+                exceptionStatus = "overdue",
+                product = "Edge (Chromium-Based)",
+                cve = "CVE-2026-19557",
+                adDomain = "ad.glpoly.net",
+                cloudAccountId = "123456789012",
+                page = 2,
+                size = 500,
+                sort = null,
+                sortDir = null,
+                knownTotal = null,
+                countMode = null,
+                includeInstallerFindings = true
+            )
+        }
+    }
+
+    @Test
+    fun `an unfiltered export still excludes excepted and installer findings`() {
+        stubQuery()
+
+        service.fetchVulnerabilityPageForExport(
+            accessibleAssetIds = emptySet(),
+            isAdmin = true,
+            filters = VulnerabilityExportFilters.NONE,
+            page = 0,
+            size = 100
+        )
+
+        verify(exactly = 1) {
+            vulnerabilityService.getCurrentVulnerabilitiesOptimized(
+                accessibleAssetIds = emptySet(),
+                isAdmin = true,
+                severity = null,
+                system = null,
+                exceptionStatus = "not_excepted",
+                product = null,
+                cve = null,
+                adDomain = null,
+                cloudAccountId = null,
+                page = 0,
+                size = 100,
+                sort = null,
+                sortDir = null,
+                knownTotal = null,
+                countMode = null,
+                includeInstallerFindings = false
+            )
+        }
+    }
+
+    @Test
+    fun `the counting pass and the export loop send identical filters`() {
+        // Progress only reaches 100% when totalElements is counted with the same filters the
+        // export loop pages with. Both call sites go through fetchVulnerabilityPageForExport,
+        // so the count-shaped call and the batch-shaped call differ only in page and size.
+        stubQuery()
+        val filters = VulnerabilityExportFilters(
+            adDomain = "ad.glpoly.net",
+            severity = "High"
+        ).normalized()
+
+        // COUNTING pass: one row, just to read totalElements.
+        service.fetchVulnerabilityPageForExport(emptySet(), true, filters, page = 0, size = 1)
+        // EXPORTING loop: a full batch.
+        service.fetchVulnerabilityPageForExport(emptySet(), true, filters, page = 3, size = 500)
+
+        for (pageAndSize in listOf(0 to 1, 3 to 500)) {
+            verify(exactly = 1) {
+                vulnerabilityService.getCurrentVulnerabilitiesOptimized(
+                    accessibleAssetIds = emptySet(),
+                    isAdmin = true,
+                    severity = "High",
+                    system = null,
+                    exceptionStatus = "not_excepted",
+                    product = null,
+                    cve = null,
+                    adDomain = "ad.glpoly.net",
+                    cloudAccountId = null,
+                    page = pageAndSize.first,
+                    size = pageAndSize.second,
+                    sort = null,
+                    sortDir = null,
+                    knownTotal = null,
+                    countMode = null,
+                    includeInstallerFindings = false
+                )
+            }
+        }
+    }
+}

--- a/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
+++ b/src/frontend/src/components/CurrentVulnerabilitiesTable.tsx
@@ -38,6 +38,10 @@ import ExceptionRequestModal from "./ExceptionRequestModal";
 import CveLink from "./CveLink";
 import { isAdmin, hasRole, hasVulnAccess } from "../utils/auth";
 import SearchableSelect from "./SearchableSelect";
+import {
+  buildVulnerabilityExportFilters,
+  describeExportScope,
+} from "./currentVulnerabilitiesExportFilters";
 
 function formatDuration(totalSec: number): string {
   if (totalSec < 60) return `${totalSec}s`;
@@ -328,6 +332,19 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
     fetchVulnerabilities();
   };
 
+  // Filters the Export button will send. Uses the DEBOUNCED system/CVE values so the export
+  // matches the rows actually rendered rather than a half-typed search box.
+  const exportFilters = buildVulnerabilityExportFilters({
+    severityFilter,
+    systemFilter: debouncedSystemFilter,
+    exceptionFilter,
+    productFilter,
+    cveFilter: debouncedCveFilter,
+    adDomainFilter,
+    cloudAccountIdFilter,
+    includeInstallerFindings,
+  });
+
   const handleCleanupDuplicates = async () => {
     try {
       setCleanupLoading(true);
@@ -360,6 +377,9 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
    * - Polls for progress (updates UI every 2 seconds)
    * - Downloads file when complete
    * - Supports cancellation
+   *
+   * The export sends the SAME filters the table is currently showing, so the workbook matches
+   * the screen. Previously it sent none, and e.g. a selected AD domain was silently ignored.
    */
   const handleExport = async () => {
     try {
@@ -370,6 +390,7 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
       setError(null);
 
       await exportVulnerabilitiesServerSide({
+        filters: exportFilters,
         onProgress: (update) => {
           setExportProgress(update.job);
           setExportJobId(update.job.jobId);
@@ -726,7 +747,7 @@ const CurrentVulnerabilitiesTable: React.FC = () => {
                     title={
                       exportLoading && exportProgress
                         ? `${describeExportStage(exportProgress)} — ${exportProgress.processedItems.toLocaleString()} / ${exportProgress.totalItems.toLocaleString()}`
-                        : "Export all vulnerabilities to Excel"
+                        : describeExportScope(exportFilters)
                     }
                   >
                     {exportLoading ? (

--- a/src/frontend/src/components/currentVulnerabilitiesExportFilters.test.ts
+++ b/src/frontend/src/components/currentVulnerabilitiesExportFilters.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildVulnerabilityExportFilters,
+  countActiveExportFilters,
+  describeExportScope,
+  type CurrentVulnerabilitiesFilterState,
+} from './currentVulnerabilitiesExportFilters';
+
+const empty: CurrentVulnerabilitiesFilterState = {
+  severityFilter: '',
+  systemFilter: '',
+  exceptionFilter: 'not_excepted',
+  productFilter: '',
+  cveFilter: '',
+  adDomainFilter: '',
+  cloudAccountIdFilter: '',
+  includeInstallerFindings: false,
+};
+
+test('the AD domain reaches the export payload', () => {
+  const filters = buildVulnerabilityExportFilters({
+    ...empty,
+    adDomainFilter: 'ad.glpoly.net',
+  });
+
+  assert.equal(filters.adDomain, 'ad.glpoly.net');
+});
+
+test('every filter maps to its request field', () => {
+  const filters = buildVulnerabilityExportFilters({
+    severityFilter: 'Critical',
+    systemFilter: 'THMTPPI1',
+    exceptionFilter: 'overdue',
+    productFilter: 'Edge (Chromium-Based)',
+    cveFilter: 'CVE-2026-19557',
+    adDomainFilter: 'ad.glpoly.net',
+    cloudAccountIdFilter: '123456789012',
+    includeInstallerFindings: true,
+  });
+
+  assert.deepEqual(filters, {
+    severity: 'Critical',
+    system: 'THMTPPI1',
+    exceptionStatus: 'overdue',
+    product: 'Edge (Chromium-Based)',
+    cve: 'CVE-2026-19557',
+    adDomain: 'ad.glpoly.net',
+    cloudAccountId: '123456789012',
+    includeInstallerFindings: true,
+  });
+});
+
+test('blank and whitespace-only filters are dropped, never sent as empty strings', () => {
+  const filters = buildVulnerabilityExportFilters({
+    ...empty,
+    severityFilter: '   ',
+    systemFilter: '',
+    adDomainFilter: '\t',
+  });
+
+  assert.equal(filters.severity, undefined);
+  assert.equal(filters.system, undefined);
+  assert.equal(filters.adDomain, undefined);
+  // JSON.stringify drops undefined keys, so the backend sees them as absent -> null.
+  assert.equal(JSON.parse(JSON.stringify(filters)).adDomain, undefined);
+});
+
+test('filter values are trimmed', () => {
+  const filters = buildVulnerabilityExportFilters({
+    ...empty,
+    adDomainFilter: '  ad.glpoly.net  ',
+  });
+
+  assert.equal(filters.adDomain, 'ad.glpoly.net');
+});
+
+test('includeInstallerFindings is carried through in both states', () => {
+  assert.equal(
+    buildVulnerabilityExportFilters({ ...empty, includeInstallerFindings: true })
+      .includeInstallerFindings,
+    true,
+  );
+  assert.equal(
+    buildVulnerabilityExportFilters(empty).includeInstallerFindings,
+    false,
+  );
+});
+
+test('the default exceptionStatus is still sent so the export matches the default table view', () => {
+  assert.equal(buildVulnerabilityExportFilters(empty).exceptionStatus, 'not_excepted');
+});
+
+test('active filter count ignores the always-present exceptionStatus', () => {
+  assert.equal(countActiveExportFilters(buildVulnerabilityExportFilters(empty)), 0);
+  assert.equal(
+    countActiveExportFilters(
+      buildVulnerabilityExportFilters({ ...empty, adDomainFilter: 'ad.glpoly.net' }),
+    ),
+    1,
+  );
+  assert.equal(
+    countActiveExportFilters(
+      buildVulnerabilityExportFilters({
+        ...empty,
+        adDomainFilter: 'ad.glpoly.net',
+        severityFilter: 'High',
+        cveFilter: 'CVE-2026-19557',
+      }),
+    ),
+    3,
+  );
+});
+
+test('the export button no longer claims to export everything when a filter is set', () => {
+  assert.equal(
+    describeExportScope(buildVulnerabilityExportFilters(empty)),
+    'Export all vulnerabilities to Excel',
+  );
+  assert.equal(
+    describeExportScope(
+      buildVulnerabilityExportFilters({ ...empty, adDomainFilter: 'ad.glpoly.net' }),
+    ),
+    'Export to Excel using the 1 active filter',
+  );
+  assert.match(
+    describeExportScope(
+      buildVulnerabilityExportFilters({
+        ...empty,
+        adDomainFilter: 'ad.glpoly.net',
+        severityFilter: 'High',
+      }),
+    ),
+    /2 active filters/,
+  );
+});

--- a/src/frontend/src/components/currentVulnerabilitiesExportFilters.ts
+++ b/src/frontend/src/components/currentVulnerabilitiesExportFilters.ts
@@ -1,0 +1,79 @@
+/**
+ * Builds the filter payload for POST /api/vulnerabilities/export from the
+ * CurrentVulnerabilitiesTable filter state.
+ *
+ * Lives in its own .ts module (not inside the .tsx) so the node:test unit tier can import it —
+ * Node's TypeScript stripping cannot parse JSX.
+ *
+ * Why it exists: the export used to send no filters at all, so selecting an AD domain narrowed
+ * the on-screen table but the downloaded workbook still contained every accessible row.
+ */
+import type { VulnerabilityExportFilters } from "../services/vulnerabilityManagementService";
+
+export interface CurrentVulnerabilitiesFilterState {
+  severityFilter: string;
+  /** Use the DEBOUNCED value: the export must match the rows currently rendered. */
+  systemFilter: string;
+  exceptionFilter: string;
+  productFilter: string;
+  /** Use the DEBOUNCED value: the export must match the rows currently rendered. */
+  cveFilter: string;
+  adDomainFilter: string;
+  cloudAccountIdFilter: string;
+  includeInstallerFindings: boolean;
+}
+
+/** Blank/whitespace-only input means "no filter", never an empty LIKE pattern. */
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function buildVulnerabilityExportFilters(
+  state: CurrentVulnerabilitiesFilterState,
+): VulnerabilityExportFilters {
+  return {
+    severity: clean(state.severityFilter),
+    system: clean(state.systemFilter),
+    exceptionStatus: clean(state.exceptionFilter),
+    product: clean(state.productFilter),
+    cve: clean(state.cveFilter),
+    adDomain: clean(state.adDomainFilter),
+    cloudAccountId: clean(state.cloudAccountIdFilter),
+    includeInstallerFindings: state.includeInstallerFindings,
+  };
+}
+
+/**
+ * How many row filters are actually narrowing the export. Drives the Export button's tooltip
+ * so it no longer claims to export "all vulnerabilities" when it does not.
+ *
+ * exceptionStatus is excluded on purpose: it always carries a value ("not_excepted" by default),
+ * so counting it would report a filter the user never chose.
+ */
+export function countActiveExportFilters(
+  filters: VulnerabilityExportFilters,
+): number {
+  const narrowing = [
+    filters.severity,
+    filters.system,
+    filters.product,
+    filters.cve,
+    filters.adDomain,
+    filters.cloudAccountId,
+  ];
+  return narrowing.filter((value) => value !== undefined).length;
+}
+
+/** Tooltip/label text for the Export button, given the filters it would send. */
+export function describeExportScope(
+  filters: VulnerabilityExportFilters,
+): string {
+  const count = countActiveExportFilters(filters);
+  if (count === 0) {
+    return "Export all vulnerabilities to Excel";
+  }
+  return count === 1
+    ? "Export to Excel using the 1 active filter"
+    : `Export to Excel using the ${count} active filters`;
+}

--- a/src/frontend/src/services/vulnerabilityManagementService.ts
+++ b/src/frontend/src/services/vulnerabilityManagementService.ts
@@ -612,16 +612,40 @@ export interface StartExportResponse {
 }
 
 /**
+ * Row filters for an export job. Mirrors the backend VulnerabilityExportFilters DTO and the
+ * query parameters of GET /api/vulnerabilities/current, so an export reproduces exactly the
+ * rows the table is showing.
+ *
+ * No sort/sortDir: the export pages through the whole result set and a non-unique sort makes
+ * OFFSET paging unstable, so the backend keeps its deterministic default ordering.
+ */
+export interface VulnerabilityExportFilters {
+    severity?: string;
+    system?: string;
+    exceptionStatus?: string;
+    product?: string;
+    cve?: string;
+    adDomain?: string;
+    cloudAccountId?: string;
+    includeInstallerFindings?: boolean;
+}
+
+/**
  * Start a vulnerability export job
  * Feature: Vulnerability Export Performance Optimization - Background Job Pattern
  *
  * Creates a background export job and returns immediately with the job ID.
  * Use pollExportStatus() to track progress.
  *
+ * @param filters Row filters to apply. Omit for an unfiltered export.
  * @returns StartExportResponse with job ID
  */
-export async function startVulnerabilityExport(): Promise<StartExportResponse> {
-    const response = await authenticatedPost('/api/vulnerabilities/export', null);
+export async function startVulnerabilityExport(
+    filters?: VulnerabilityExportFilters,
+): Promise<StartExportResponse> {
+    // The body used to be a hardcoded null, which is why the export ignored every filter
+    // (including the selected AD domain) and returned the caller's entire accessible set.
+    const response = await authenticatedPost('/api/vulnerabilities/export', filters ?? {});
 
     if (!response.ok) {
         if (response.status === 429) {
@@ -738,6 +762,8 @@ function chooseInterval(pollCount: number): number {
 export interface ExportVulnerabilitiesOptions {
     onProgress?: (update: ExportProgressUpdate) => void;
     onStall?: (update: ExportProgressUpdate) => void;
+    /** Row filters for the export. Omit (or pass the legacy bare callback) for an unfiltered export. */
+    filters?: VulnerabilityExportFilters;
 }
 
 // ---------------------------------------------------------------------------
@@ -800,7 +826,7 @@ export async function exportVulnerabilitiesServerSide(
         ? { onProgress: (u) => onProgressOrOptions(u.job) }
         : onProgressOrOptions ?? {};
 
-    const startResponse = await startVulnerabilityExport();
+    const startResponse = await startVulnerabilityExport(opts.filters);
     const jobId = startResponse.jobId;
     const shortId = jobId.slice(0, 8);
     const startMs = Date.now();


### PR DESCRIPTION
## Summary

- Selecting an AD domain on **Analytics → Current Vulnerabilities** narrowed the table but not the **Export** — the workbook still contained every accessible row.
- The export path was filter-blind at three independent layers, so the AD domain was dropped three times over. Fixing only `adDomain` would have left the identical defect on the other seven filters, so all of them are now threaded end to end.
- No schema change, and an unfiltered export behaves exactly as before.

**Root cause, per layer:**

| Layer | Defect |
|---|---|
| Frontend | `handleExport` called `exportVulnerabilitiesServerSide` with no filters; `startVulnerabilityExport` POSTed a literal `null` body |
| Controller | `POST /api/vulnerabilities/export` had no `@Body` and no `@QueryValue` — no filter could reach the server |
| Background job | `fetchVulnerabilityPageForExport` hardcoded `null` for severity/system/product/cve/adDomain/cloudAccountId, pinned `exceptionStatus` to `"not_excepted"`, and let `includeInstallerFindings` default to `false` |

## Changes

**New** `dto/VulnerabilityExportFilters.kt` — mirrors the query params of `GET /api/vulnerabilities/current` one-for-one, with `normalized()` (blank → null; blank/absent `exceptionStatus` → `not_excepted`, matching the list endpoint) and a CR/LF-stripping `describe()` for logging.

**`VulnerabilityManagementController.startExport`** — takes `@Nullable @Body VulnerabilityExportFilters?`. An absent body resolves to `VulnerabilityExportFilters.NONE`, preserving the historical unfiltered behaviour.

**`ExportJobService`** — filters threaded through `startExport` → the `executorService.submit` closure → `processExportInBackground` → `processVulnerabilityExport` → `fetchVulnerabilityPageForExport`, where the hardcoded nulls are replaced.

**Frontend** — new pure `components/currentVulnerabilitiesExportFilters.ts` (extracted to a `.ts` sibling so the `node:test` tier can import it — Node cannot parse JSX); `startVulnerabilityExport(filters?)` POSTs the object instead of `null`; `CurrentVulnerabilitiesTable` sends the **debounced** system/CVE values so the export matches the rendered rows; the Export button tooltip no longer claims "Export all vulnerabilities" when filters are set.

**`VulnerabilityExportService`** — comment only. It has the same hardcoded nulls but is wired to no endpoint; flagged so it isn't wired up as-is.

**Deliberate omissions / preserved behaviour:**
- No `sort`/`sortDir` in the filters: the export pages through the whole result set and a non-unique sort makes OFFSET paging unstable.
- **No schema change.** The filters ride the `executorService.submit` closure into the background thread; nothing ever re-runs a job from its DB row (`autoResetStaleJobs` and `resetStuckJobs` only mark stale jobs `FAILED`).
- The COUNTING pass and the EXPORTING loop both go through `fetchVulnerabilityPageForExport`, so they stay filter-identical and progress still reaches 100%.
- The "export all" button on Asset Management uses the legacy bare-callback form and stays unfiltered.

## Testing

- [x] `cd src/frontend && npm ci && npm run build` exits 0 (frontend changes)
- [x] New/updated unit or integration tests cover the change — `VulnerabilityExportFilterTest.kt` (8 cases: filter forwarding, normalization, log-forging, COUNTING/EXPORTING agreement) and `currentVulnerabilitiesExportFilters.test.ts` (8 cases); `npm test` is **252 pass / 0 fail**
- [ ] `./gradlew build` is clean — **NOT RUN, see below**
- [ ] `./scripts/startbackenddev.sh` starts cleanly (backend changes) — **NOT RUN, see below**
- [ ] `/e2ejs` reports 0 JS errors (admin + normal user) — **NOT RUN, see below**
- [ ] `/e2evulnexception` passes with 0 failures — **NOT RUN, see below**

> **The backend gates could not run in this environment and must be run before merge.** The egress policy returns 403 for `services.gradle.org`, `plugins.gradle.org` and `repo1.maven.org`; there is no Gradle 9.7.0 distribution and the Gradle module cache is empty, so no Kotlin in this repo can be compiled or tested here (the locally installed Gradle is 8.14.3 and cannot resolve the Kotlin 2.4.10 plugin offline). The Kotlin changes were reviewed by hand but are **unverified by a compiler**. The E2E gates additionally need a running stack and `pass-cli`.
>
> Frontend verification did run: `astro build` passes, and `tsc --noEmit` shows **no new** type errors (8 with the change vs. 9 pre-existing on `main`).

## Backend contract changes

- [x] Contract changed — additive only, no client update needed. `POST /api/vulnerabilities/export` gains an **optional** request body; path, method, `@Secured("ADMIN","VULN","SECCHAMPION")` and every response shape are unchanged, and a client sending no body keeps its current behaviour. The endpoint is not in the `extensions/` client surface (those use `/api/auth/login`, `/api/vulnerabilities/cli-add`, `/api/vulnerabilities/current`, `/api/assets/import` and `/mcp`). The `extensions/` repos are gitignored and not present in this clone, so the sweep could not be executed here.

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — `@Secured` unchanged; `isAdmin` / `accessibleAssetIds` are still derived from the authentication inside `ExportJobService` and are untouched by the request body. Filters only ever **narrow** the result, never widen scope.
- [x] Input validation / file handling reviewed for new attack surface — every filter value flows into the pre-existing bound `:param` placeholders in `VulnerabilityRepository`; no new SQL is written and nothing is concatenated. Blank values normalize to `null` rather than degrading to `LIKE '%%'`. Filter values are CR/LF-stripped and length-capped before reaching a log line.
- [x] No secrets hardcoded (uses `pass-cli`)

`./scripts/owasp-check.sh`: **0 block, 91 review** — all 91 pre-existing, none in the changed code. `OWASP: A01/A03/A09 touched — clean`.

## Related issues

<!-- none -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRm6jpPm9U3MZN5ZAcZriC)_