### PR TITLE
Fix broken access control on demand-to-asset linking (A01)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/DemandController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/DemandController.kt
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
+import com.secman.service.AssetFilterService
 
 @Controller("/api/demands")
 @Secured(SecurityRule.IS_AUTHENTICATED)
@@ -28,7 +29,8 @@ open class DemandController(
     private val demandRepository: DemandRepository,
     private val assetRepository: AssetRepository,
     private val userRepository: UserRepository,
-    private val entityManager: EntityManager
+    private val entityManager: EntityManager,
+    private val assetFilterService: AssetFilterService
 ) {
     
     private val log = LoggerFactory.getLogger(DemandController::class.java)
@@ -237,6 +239,14 @@ open class DemandController(
             // Validate asset information based on demand type
             val existingAsset = if (request.demandType == DemandType.CHANGE) {
                 request.existingAssetId?.let { assetId ->
+                    // SECURITY (A01): existingAssetId is request-supplied and must be resolved
+                    // through the unified asset-access boundary, not a bare findById — otherwise
+                    // any authenticated user could link a demand (which they can then read back
+                    // via GET /api/demands/{id}, since demand access is requestor-scoped) to an
+                    // asset outside their workgroup/ownership and read its name/ip/owner/etc.
+                    if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                        return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Existing asset not found"))
+                    }
                     assetRepository.findById(assetId).orElse(null)
                         ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Existing asset not found"))
                 } ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Existing asset ID required for CHANGE demand"))
@@ -317,6 +327,10 @@ open class DemandController(
             // Update asset information based on demand type
             if (demand.demandType == DemandType.CHANGE) {
                 request.existingAssetId?.let { assetId ->
+                    // SECURITY (A01): same unified-access check as createDemand — see comment there.
+                    if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                        return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
+                    }
                     val asset = assetRepository.findById(assetId).orElse(null)
                         ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
                     demand.existingAsset = asset


### PR DESCRIPTION
## Summary

- Targeted security sweep of the highest-risk surfaces (native SQL, `@Secured` coverage, asset access boundary, HTML sinks, file upload/XML parsing, SSRF-prone outbound calls, MCP tool guards, secrets/logging).
- One HIGH finding fixed: `DemandController` resolved a CHANGE demand's `existingAssetId` via a bare `assetRepository.findById()`, bypassing `AssetFilterService` entirely.

## Changes

- `src/backendng/src/main/kotlin/com/secman/controller/DemandController.kt`: `createDemand` and `updateDemand` now call `assetFilterService.canAccessAsset(assetId, authentication)` before resolving `existingAssetId`, matching the pattern already used in `AssetController`.

### Finding detail (A01 — Broken Access Control)

`DemandController` is class-level `@Secured(IS_AUTHENTICATED)` — any authenticated user, any role. Demand read/update is correctly scoped to the requestor (or ADMIN) elsewhere in the controller (`listDemands`, `getDemand`, `updateDemand` all check `demand.requestor.id == userId`). However, for a `CHANGE`-type demand, both `createDemand` and `updateDemand` resolved `request.existingAssetId` with a bare `assetRepository.findById(assetId)` — no call into `AssetFilterService`, the codebase's documented sole auth boundary for asset access (`docs/ARCHITECTURE.md` §Unified Asset Access, `CLAUDE.md` A01).

Impact: any authenticated user (plain `USER` role is sufficient) could create or update their own demand with `existingAssetId` set to **any** asset ID in the system — outside their workgroup, not owned/uploaded/shared with them — and then read that asset's `name`/`ip`/`type`/`owner`/`description` back via `GET /api/demands/{id}` (which they can legitimately view, since they are the demand's own requestor) or the create/update response body. This is a straightforward IDOR/enumeration path (asset IDs are small sequential integers) that discloses infrastructure data across the workgroup/ownership boundary the rest of the codebase enforces carefully.

Fix: both call sites now reject the request with the same "not found" error a real access-control boundary would give, before the asset is ever attached to the demand — reusing `AssetFilterService.canAccessAsset`, not a new check.

## Testing

- [ ] `./gradlew build` is clean — **not run**: this sandbox has no network route to `services.gradle.org`/Maven Central for the pinned Gradle 9.7.0 / Kotlin 2.4.10 toolchain (infra limitation, unrelated to this change).
- [ ] `./scripts/startbackenddev.sh` starts cleanly — **not run**: no `pass-cli` secrets or MariaDB in this sandbox.
- [x] `cd src/frontend && npm ci && npm run build` exits 0 — N/A, backend-only change.
- [ ] New/updated unit or integration tests cover the change — **not added**: no DB/test-runner available in this sandbox to write and verify a passing `DemandControllerTest`; recommend adding one asserting a non-privileged user's `existingAssetId` outside their access scope is rejected.
- [ ] `/e2ejs` — not run (no running stack in this sandbox).
- [ ] `/e2evulnexception` — not run (unrelated surface; not applicable to this change).
- [x] The diff was hand-reviewed against the exact pattern used in `AssetController.update()` (same `canAccessAsset` call, same error shape) to minimize the risk of a subtle regression despite the untested toolchain.

`./scripts/owasp-check.sh` (diff-scoped static gate): **OK — no static findings.**

## Backend contract changes

- [x] N/A — no backend contract changes (no path/method/field/`@Secured` change; only an added authorization check).

## Security

- [x] RBAC enforced at controller (`@Secured`) and in the UI where applicable — unchanged; the fix adds row-level scoping under the existing `@Secured(IS_AUTHENTICATED)`.
- [x] Input validation / file handling reviewed for new attack surface — this *is* the fix (request-supplied `existingAssetId` now goes through the access boundary).
- [x] No secrets hardcoded (uses `pass-cli`) — unaffected.

## Other findings from the sweep (not fixed — MEDIUM/LOW or not-a-finding)

- `McpToolPermissions.CALLING` omits `list_workgroup_aws_accounts`, `add_workgroup_aws_account`, `remove_workgroup_aws_account`, `list_workgroup_ad_domains`, `add_workgroup_ad_domain`, `remove_workgroup_ad_domain` (present in `LISTING` only). This is **fail-closed** (the tool becomes uncallable regardless of role), a functionality bug rather than a security bug, so left out of scope per the "HIGH/CRITICAL only" instruction — flagging for a follow-up.
- Native SQL (`VulnerabilityRepository`, `WorkgroupRepository`, `AwsAccountSharingRepository`, others), XXE handling (`NmapParserService`/`MasscanParserService`), HTML sinks (`RichContent.tsx`, `HtmlEditor.tsx`, `EmailBroadcastManager.tsx`), file-upload validation (`ImportController`), and SSRF guards (`SlackClient`, `TelegramClient`, `IdentityProviderController`'s `validateOAuthEndpointUrl`) were all reviewed and found to already implement the controls `CLAUDE.md` names — no changes needed.

## Related issues

N/A — scheduled security-audit routine, no linked issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNYfAqWGhPzHg2PTFCW3e6)_