### PR TITLE
Fix broken access control on Risk/RiskAssessment asset linking (A01)

### DIFF
--- a/src/backendng/src/main/kotlin/com/secman/controller/RiskAssessmentController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RiskAssessmentController.kt
@@ -3,6 +3,7 @@ package com.secman.controller
 import com.secman.domain.*
 import com.secman.event.RiskAssessmentCreatedEvent
 import com.secman.repository.*
+import com.secman.service.AssetFilterService
 import com.secman.service.UserResolutionService
 import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.core.annotation.Nullable
@@ -12,6 +13,7 @@ import io.micronaut.http.annotation.*
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.transaction.annotation.Transactional
@@ -28,9 +30,13 @@ import java.time.LocalDateTime
  * Feature: 025-role-based-access-control
  *
  * Access Control:
- * - ADMIN: Full access to all risk assessment operations
- * - RISK: Full access to all risk assessment operations
- * - SECCHAMPION: Full access to all risk assessment operations
+ * - ADMIN, SECCHAMPION: universal access to all risk assessment operations (Unified Asset Access).
+ * - RISK: access to a risk assessment is additionally gated on the caller being able to access
+ *   the assessment's linked asset (its own `asset`, or `demand.existingAsset` for a CHANGE-demand
+ *   basis) via `AssetFilterService`. An assessment with no linked asset (a NEW-demand basis, or a
+ *   basis whose asset was deleted) carries no asset detail and stays visible. This was tightened
+ *   from an earlier "RISK has full access" design once the workgroup-based Unified Asset Access
+ *   model (see project CLAUDE.md) made that a cross-tenant asset-detail disclosure.
  * - Other roles: Access denied (403 Forbidden)
  */
 @Controller("/api/risk-assessments")
@@ -47,10 +53,27 @@ open class RiskAssessmentController(
     private val requirementRepository: RequirementRepository,
     private val entityManager: EntityManager,
     private val eventPublisher: ApplicationEventPublisher<RiskAssessmentCreatedEvent>,
-    private val userResolutionService: UserResolutionService
+    private val userResolutionService: UserResolutionService,
+    private val assetFilterService: AssetFilterService
 ) {
 
     private val log = LoggerFactory.getLogger(RiskAssessmentController::class.java)
+
+    /**
+     * SECURITY (A01): the asset id whose accessibility gates visibility of [assessment] for a
+     * non-universal-access (RISK-only) caller. `null` means the assessment carries no linked
+     * asset detail (e.g. a NEW-demand basis) and is not asset-gated.
+     */
+    @Suppress("DEPRECATION")
+    private fun linkedAssetId(assessment: RiskAssessment): Long? = when (assessment.assessmentBasisType) {
+        AssessmentBasisType.ASSET -> assessment.asset?.id
+        AssessmentBasisType.DEMAND -> assessment.demand?.existingAsset?.id
+    }
+
+    private fun canAccessAssessment(assessment: RiskAssessment, authentication: Authentication): Boolean {
+        val assetId = linkedAssetId(assessment)
+        return assetId == null || assetFilterService.canAccessAsset(assetId, authentication)
+    }
 
     @Serdeable
     data class CreateRiskAssessmentRequest(
@@ -144,28 +167,31 @@ open class RiskAssessmentController(
 
     @Get
     @Transactional(readOnly = true)
-    open fun listRiskAssessments(): HttpResponse<List<RiskAssessment>> {
+    open fun listRiskAssessments(authentication: Authentication): HttpResponse<List<RiskAssessment>> {
         return try {
-            log.debug("Fetching all risk assessments")
-            
+            log.debug("Fetching all risk assessments for user: {}", authentication.name)
+
             val assessments = entityManager.createQuery(
                 """
-                SELECT DISTINCT ra FROM RiskAssessment ra 
+                SELECT DISTINCT ra FROM RiskAssessment ra
                 LEFT JOIN FETCH ra.demand d
-                LEFT JOIN FETCH d.existingAsset 
-                LEFT JOIN FETCH d.requestor 
+                LEFT JOIN FETCH d.existingAsset
+                LEFT JOIN FETCH d.requestor
                 LEFT JOIN FETCH ra.asset a
-                LEFT JOIN FETCH ra.assessor 
-                LEFT JOIN FETCH ra.requestor 
-                LEFT JOIN FETCH ra.respondent 
-                LEFT JOIN FETCH ra.useCases 
+                LEFT JOIN FETCH ra.assessor
+                LEFT JOIN FETCH ra.requestor
+                LEFT JOIN FETCH ra.respondent
+                LEFT JOIN FETCH ra.useCases
                 ORDER BY ra.createdAt DESC
                 """,
                 RiskAssessment::class.java
             ).resultList
-            
-            log.debug("Found {} risk assessments", assessments.size)
-            HttpResponse.ok(assessments)
+
+            // SECURITY (A01): see canAccessAssessment() — RISK is not a universal-asset-access role.
+            val visibleAssessments = assessments.filter { canAccessAssessment(it, authentication) }
+
+            log.debug("Found {} risk assessments ({} visible) for user {}", assessments.size, visibleAssessments.size, authentication.name)
+            HttpResponse.ok(visibleAssessments)
         } catch (e: Exception) {
             log.error("Error fetching risk assessments", e)
             HttpResponse.serverError<List<RiskAssessment>>()
@@ -174,33 +200,40 @@ open class RiskAssessmentController(
 
     @Get("/{id}")
     @Transactional(readOnly = true)
-    open fun getRiskAssessment(id: Long): HttpResponse<*> {
+    open fun getRiskAssessment(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risk assessment with id: {}", id)
-            
+
             val assessment = entityManager.createQuery(
                 """
-                SELECT ra FROM RiskAssessment ra 
+                SELECT ra FROM RiskAssessment ra
                 LEFT JOIN FETCH ra.demand d
-                LEFT JOIN FETCH d.existingAsset 
-                LEFT JOIN FETCH d.requestor 
+                LEFT JOIN FETCH d.existingAsset
+                LEFT JOIN FETCH d.requestor
                 LEFT JOIN FETCH ra.asset a
-                LEFT JOIN FETCH ra.assessor 
-                LEFT JOIN FETCH ra.requestor 
-                LEFT JOIN FETCH ra.respondent 
-                LEFT JOIN FETCH ra.useCases 
+                LEFT JOIN FETCH ra.assessor
+                LEFT JOIN FETCH ra.requestor
+                LEFT JOIN FETCH ra.respondent
+                LEFT JOIN FETCH ra.useCases
                 WHERE ra.id = :id
                 """,
                 RiskAssessment::class.java
             ).setParameter("id", id).resultList.firstOrNull()
-            
-            if (assessment != null) {
-                log.debug("Found risk assessment: {}", assessment.id)
-                HttpResponse.ok(assessment)
-            } else {
+
+            if (assessment == null) {
                 log.debug("Risk assessment not found with id: {}", id)
-                HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
             }
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied access to risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
+            log.debug("Found risk assessment: {}", assessment.id)
+            HttpResponse.ok(assessment)
         } catch (e: Exception) {
             log.error("Error fetching risk assessment with id: {}", id, e)
             HttpResponse.serverError<Any>()
@@ -209,12 +242,14 @@ open class RiskAssessmentController(
 
     @Get("/demand/{demandId}")
     @Transactional(readOnly = true)
-    open fun getRiskAssessmentsByDemand(demandId: Long): HttpResponse<*> {
+    open fun getRiskAssessmentsByDemand(demandId: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risk assessments for demand: {}", demandId)
-            
+
             val assessments = riskAssessmentRepository.findByDemandId(demandId)
-            
+                // SECURITY (A01): see canAccessAssessment().
+                .filter { canAccessAssessment(it, authentication) }
+
             // Force loading of related entities
             assessments.forEach { assessment ->
                 @Suppress("DEPRECATION")
@@ -226,7 +261,7 @@ open class RiskAssessmentController(
                 assessment.respondent?.username // Force loading
                 assessment.useCases.size // Force loading
             }
-            
+
             log.debug("Found {} risk assessments for demand {}", assessments.size, demandId)
             HttpResponse.ok(assessments)
         } catch (e: Exception) {
@@ -237,15 +272,22 @@ open class RiskAssessmentController(
 
     @Get("/asset/{assetId}")
     @Transactional(readOnly = true)
-    open fun getRiskAssessmentsByAsset(assetId: Long): HttpResponse<*> {
+    open fun getRiskAssessmentsByAsset(assetId: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risk assessments for asset: {}", assetId)
-            
+
+            // SECURITY (A01): assetId is caller-supplied; resolve it through the unified
+            // access boundary before returning anything scoped to it.
+            if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                log.warn("User {} denied access to risk assessments for asset {}", authentication.name, assetId)
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Asset not found"))
+            }
+
             // Find both direct asset assessments and demand-based assessments that involve this asset
             val directAssessments = riskAssessmentRepository.findByAssetId(assetId)
             val demandBasedAssessments = riskAssessmentRepository.findByExistingAssetId(assetId)
             val allAssessments = (directAssessments + demandBasedAssessments).distinctBy { it.id }
-            
+
             // Force loading of related entities
             allAssessments.forEach { assessment ->
                 when (assessment.assessmentBasisType) {
@@ -276,12 +318,14 @@ open class RiskAssessmentController(
 
     @Get("/basis/{basisType}/{basisId}")
     @Transactional(readOnly = true)
-    open fun getRiskAssessmentsByBasis(basisType: AssessmentBasisType, basisId: Long): HttpResponse<*> {
+    open fun getRiskAssessmentsByBasis(basisType: AssessmentBasisType, basisId: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risk assessments for basis type: {} and ID: {}", basisType, basisId)
-            
+
             val assessments = riskAssessmentRepository.findByAssessmentBasisTypeAndAssessmentBasisId(basisType, basisId)
-            
+                // SECURITY (A01): see canAccessAssessment().
+                .filter { canAccessAssessment(it, authentication) }
+
             // Force loading of related entities
             assessments.forEach { assessment ->
                 when (assessment.assessmentBasisType) {
@@ -312,20 +356,25 @@ open class RiskAssessmentController(
 
     @Post
     @Transactional
-    open fun createRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequest): HttpResponse<*> {
+    open fun createRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             // Validate request
             val validationError = request.validate()
             if (validationError != null) {
                 return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", validationError))
             }
-            
+
             val basisType = request.getBasisType()
             val basisId = request.getBasisId()
-            
+
             log.debug("Creating risk assessment with basis type: {} and ID: {}", basisType, basisId)
 
             // 1. PRE-VALIDATE BASIS first so a missing basis doesn't orphan a lazy-created User row
+            // SECURITY (A01): basisId is caller-supplied. For an ASSET basis it names an asset
+            // directly; for a DEMAND basis, a CHANGE demand's existingAsset is echoed back in the
+            // response (title/description/asset name) once the assessment is created. Both must be
+            // resolved through the unified asset-access boundary — never a bare findById() whose
+            // result is returned — matching the fix already applied to DemandController.
             val resolvedBasis: Any = when (basisType) {
                 AssessmentBasisType.DEMAND -> {
                     val demand = demandRepository.findById(basisId).orElse(null)
@@ -334,9 +383,16 @@ open class RiskAssessmentController(
                         return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR",
                             "Only approved demands can have risk assessments created"))
                     }
+                    val existingAssetId = demand.existingAsset?.id
+                    if (existingAssetId != null && !assetFilterService.canAccessAsset(existingAssetId, authentication)) {
+                        return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Demand not found"))
+                    }
                     demand
                 }
                 AssessmentBasisType.ASSET -> {
+                    if (!assetFilterService.canAccessAsset(basisId, authentication)) {
+                        return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
+                    }
                     assetRepository.findById(basisId).orElse(null)
                         ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
                 }
@@ -479,13 +535,20 @@ open class RiskAssessmentController(
 
     @Put("/{id}")
     @Transactional
-    open fun updateRiskAssessment(id: Long, @Valid @Body request: UpdateRiskAssessmentRequest): HttpResponse<*> {
+    open fun updateRiskAssessment(id: Long, @Valid @Body request: UpdateRiskAssessmentRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Updating risk assessment with id: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
-            
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied update of risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
             // Update fields if provided
             request.endDate?.let { assessment.endDate = it }
             request.notes?.let { assessment.notes = it.trim().takeIf { it.isNotBlank() } }
@@ -546,13 +609,20 @@ open class RiskAssessmentController(
 
     @Delete("/{id}")
     @Transactional
-    open fun deleteRiskAssessment(id: Long): HttpResponse<*> {
+    open fun deleteRiskAssessment(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Deleting risk assessment with id: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
-            
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied delete of risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
             // Delete related responses and tokens first
             responseRepository.deleteByRiskAssessmentId(id)
             assessmentTokenRepository.deleteByRiskAssessmentId(id)
@@ -569,13 +639,20 @@ open class RiskAssessmentController(
 
     @Post("/{id}/token")
     @Transactional
-    open fun generateAssessmentToken(id: Long, @Valid @Body request: NotificationRequest): HttpResponse<*> {
+    open fun generateAssessmentToken(id: Long, @Valid @Body request: NotificationRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Generating assessment token for risk assessment: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
-            
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied token generation for risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
             // Check if valid token already exists for this email and assessment
             val existingToken = assessmentTokenRepository
                 .findValidTokensByRiskAssessmentId(id, LocalDateTime.now())
@@ -608,15 +685,22 @@ open class RiskAssessmentController(
 
     @Post("/{id}/notify")
     @Transactional
-    open fun notifyRespondent(id: Long, @Valid @Body request: NotificationRequest): HttpResponse<*> {
+    open fun notifyRespondent(id: Long, @Valid @Body request: NotificationRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Sending notification for risk assessment: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
-            
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied notification for risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
             // Generate or get existing token
-            val tokenResponse = generateAssessmentToken(id, request)
+            val tokenResponse = generateAssessmentToken(id, request, authentication)
             if (tokenResponse.status.code != 200 && tokenResponse.status.code != 201) {
                 return tokenResponse
             }
@@ -637,13 +721,20 @@ open class RiskAssessmentController(
 
     @Post("/{id}/remind")
     @Transactional
-    open fun sendReminder(id: Long, @Valid @Body request: NotificationRequest): HttpResponse<*> {
+    open fun sendReminder(id: Long, @Valid @Body request: NotificationRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Sending reminder for risk assessment: {}", id)
-            
+
             val assessment = riskAssessmentRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
-            
+
+            // SECURITY (A01): see canAccessAssessment().
+            if (!canAccessAssessment(assessment, authentication)) {
+                log.warn("User {} denied reminder for risk assessment {} (linked asset {} not accessible)",
+                    authentication.name, id, linkedAssetId(assessment))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk assessment not found"))
+            }
+
             // TODO: Implement reminder email logic here
             // This would send a reminder email about the pending assessment
             
@@ -663,7 +754,7 @@ open class RiskAssessmentController(
     @Transactional
     @Deprecated("Use main POST /api/risk-assessments endpoint with demandId instead")
     @Suppress("DEPRECATION")
-    open fun createDemandBasedRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequestDemand): HttpResponse<*> {
+    open fun createDemandBasedRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequestDemand, authentication: Authentication): HttpResponse<*> {
         log.debug("Legacy demand-based risk assessment creation called")
         @Suppress("DEPRECATION")
         return createRiskAssessment(CreateRiskAssessmentRequest(
@@ -677,14 +768,14 @@ open class RiskAssessmentController(
             assetId = null,
             assessorRef = request.assessorRef,
             respondentRef = request.respondentRef
-        ))
+        ), authentication)
     }
 
     @Post("/asset-based")
     @Transactional
     @Deprecated("Use main POST /api/risk-assessments endpoint with assetId instead")
     @Suppress("DEPRECATION")
-    open fun createAssetBasedRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequestAsset): HttpResponse<*> {
+    open fun createAssetBasedRiskAssessment(@Valid @Body request: CreateRiskAssessmentRequestAsset, authentication: Authentication): HttpResponse<*> {
         log.debug("Legacy asset-based risk assessment creation called")
         @Suppress("DEPRECATION")
         return createRiskAssessment(CreateRiskAssessmentRequest(
@@ -698,7 +789,7 @@ open class RiskAssessmentController(
             assetId = request.assetId,
             assessorRef = request.assessorRef,
             respondentRef = request.respondentRef
-        ))
+        ), authentication)
     }
 
     /**

--- a/src/backendng/src/main/kotlin/com/secman/controller/RiskController.kt
+++ b/src/backendng/src/main/kotlin/com/secman/controller/RiskController.kt
@@ -4,6 +4,7 @@ import com.secman.domain.Risk
 import com.secman.repository.AssetRepository
 import com.secman.repository.RiskRepository
 import com.secman.repository.UserRepository
+import com.secman.service.AssetFilterService
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -11,6 +12,7 @@ import io.micronaut.http.annotation.*
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.transaction.annotation.Transactional
@@ -29,7 +31,8 @@ open class RiskController(
     private val riskRepository: RiskRepository,
     private val assetRepository: AssetRepository,
     private val userRepository: UserRepository,
-    private val entityManager: EntityManager
+    private val entityManager: EntityManager,
+    private val assetFilterService: AssetFilterService
 ) {
     
     private val log = LoggerFactory.getLogger(RiskController::class.java)
@@ -68,22 +71,33 @@ open class RiskController(
 
     @Get
     @Transactional(readOnly = true)
-    open fun listRisks(): HttpResponse<List<Risk>> {
+    open fun listRisks(authentication: Authentication): HttpResponse<List<Risk>> {
         return try {
-            log.debug("Fetching all risks")
-            
+            log.debug("Fetching all risks for user: {}", authentication.name)
+
             val risks = entityManager.createQuery(
                 """
-                SELECT DISTINCT r FROM Risk r 
-                LEFT JOIN FETCH r.owner 
-                LEFT JOIN FETCH r.asset 
+                SELECT DISTINCT r FROM Risk r
+                LEFT JOIN FETCH r.owner
+                LEFT JOIN FETCH r.asset
                 ORDER BY r.riskLevel DESC, r.createdAt DESC
                 """,
                 Risk::class.java
             ).resultList
-            
-            log.debug("Found {} risks", risks.size)
-            HttpResponse.ok(risks)
+
+            // SECURITY (A01): RISK is not a universal-asset-access role (Unified Asset
+            // Access grants that only to ADMIN/SECCHAMPION). A risk linked to an asset
+            // outside the caller's workgroup/ownership must not disclose that asset's
+            // name/ip/type/owner. Risks with no linked asset carry no asset detail and
+            // stay visible to any RISK-role caller.
+            val accessibleAssetIds = assetFilterService.getAccessibleAssetIds(authentication)
+            val visibleRisks = risks.filter { risk ->
+                val assetId = risk.asset?.id
+                assetId == null || accessibleAssetIds.contains(assetId)
+            }
+
+            log.debug("Found {} risks ({} visible) for user {}", risks.size, visibleRisks.size, authentication.name)
+            HttpResponse.ok(visibleRisks)
         } catch (e: Exception) {
             log.error("Error fetching risks", e)
             HttpResponse.serverError<List<Risk>>()
@@ -92,27 +106,35 @@ open class RiskController(
 
     @Get("/{id}")
     @Transactional(readOnly = true)
-    open fun getRisk(id: Long): HttpResponse<*> {
+    open fun getRisk(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risk with id: {}", id)
-            
+
             val risk = entityManager.createQuery(
                 """
-                SELECT r FROM Risk r 
-                LEFT JOIN FETCH r.owner 
-                LEFT JOIN FETCH r.asset 
+                SELECT r FROM Risk r
+                LEFT JOIN FETCH r.owner
+                LEFT JOIN FETCH r.asset
                 WHERE r.id = :id
                 """,
                 Risk::class.java
             ).setParameter("id", id).resultList.firstOrNull()
-            
-            if (risk != null) {
-                log.debug("Found risk: {}", risk.name)
-                HttpResponse.ok(risk)
-            } else {
+
+            if (risk == null) {
                 log.debug("Risk not found with id: {}", id)
-                HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
             }
+
+            // SECURITY (A01): see listRisks() — a risk linked to an inaccessible asset
+            // must not be readable by id either.
+            val assetId = risk.asset?.id
+            if (assetId != null && !assetFilterService.canAccessAsset(assetId, authentication)) {
+                log.warn("User {} denied access to risk {} (linked asset {} not accessible)", authentication.name, id, assetId)
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
+            }
+
+            log.debug("Found risk: {}", risk.name)
+            HttpResponse.ok(risk)
         } catch (e: Exception) {
             log.error("Error fetching risk with id: {}", id, e)
             HttpResponse.serverError<Any>()
@@ -121,18 +143,25 @@ open class RiskController(
 
     @Get("/asset/{assetId}")
     @Transactional(readOnly = true)
-    open fun getRisksByAsset(assetId: Long): HttpResponse<*> {
+    open fun getRisksByAsset(assetId: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Fetching risks for asset: {}", assetId)
-            
+
+            // SECURITY (A01): assetId is caller-supplied; resolve it through the unified
+            // access boundary before returning anything scoped to it.
+            if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                log.warn("User {} denied access to risks for asset {}", authentication.name, assetId)
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Asset not found"))
+            }
+
             val risks = riskRepository.findByAssetId(assetId)
-            
+
             // Force loading of related entities
             risks.forEach { risk ->
                 risk.owner?.username // Force loading
                 risk.asset?.name // Force loading
             }
-            
+
             log.debug("Found {} risks for asset {}", risks.size, assetId)
             HttpResponse.ok(risks)
         } catch (e: Exception) {
@@ -143,24 +172,30 @@ open class RiskController(
 
     @Post
     @Transactional
-    open fun createRisk(@Valid @Body request: CreateRiskRequest): HttpResponse<*> {
+    open fun createRisk(@Valid @Body request: CreateRiskRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Creating risk with name: {}", request.name)
-            
+
             val trimmedName = request.name.trim()
-            
+
             if (trimmedName.isBlank()) {
                 return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Name cannot be empty"))
             }
-            
+
             // Validate owner if provided
             val owner = request.ownerId?.let { ownerId ->
                 userRepository.findById(ownerId).orElse(null)
                     ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Owner not found"))
             }
-            
+
             // Validate asset if provided
+            // SECURITY (A01): assetId is caller-supplied and must be resolved through the
+            // unified asset-access boundary — otherwise a RISK-role user could link a risk
+            // to an arbitrary asset ID and read its details back via GET /api/risks/{id}.
             val asset = request.assetId?.let { assetId ->
+                if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                    return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
+                }
                 assetRepository.findById(assetId).orElse(null)
                     ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
             }
@@ -196,13 +231,22 @@ open class RiskController(
 
     @Put("/{id}")
     @Transactional
-    open fun updateRisk(id: Long, @Valid @Body request: UpdateRiskRequest): HttpResponse<*> {
+    open fun updateRisk(id: Long, @Valid @Body request: UpdateRiskRequest, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Updating risk with id: {}", id)
-            
+
             val risk = riskRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
-            
+
+            // SECURITY (A01): same unified-access check as getRisk() — a risk already
+            // linked to an asset outside the caller's access must not be readable/writable
+            // via update either.
+            val currentAssetId = risk.asset?.id
+            if (currentAssetId != null && !assetFilterService.canAccessAsset(currentAssetId, authentication)) {
+                log.warn("User {} denied update of risk {} (linked asset {} not accessible)", authentication.name, id, currentAssetId)
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
+            }
+
             // Update name if provided
             request.name?.let { newName ->
                 val trimmedName = newName.trim()
@@ -228,7 +272,11 @@ open class RiskController(
             }
             
             // Update asset if provided
+            // SECURITY (A01): same unified-access check as createRisk() — see comment there.
             request.assetId?.let { assetId ->
+                if (!assetFilterService.canAccessAsset(assetId, authentication)) {
+                    return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
+                }
                 val asset = assetRepository.findById(assetId).orElse(null)
                     ?: return HttpResponse.badRequest(ErrorResponse("VALIDATION_ERROR", "Asset not found"))
                 risk.asset = asset
@@ -252,13 +300,20 @@ open class RiskController(
 
     @Delete("/{id}")
     @Transactional
-    open fun deleteRisk(id: Long): HttpResponse<*> {
+    open fun deleteRisk(id: Long, authentication: Authentication): HttpResponse<*> {
         return try {
             log.debug("Deleting risk with id: {}", id)
-            
+
             val risk = riskRepository.findById(id).orElse(null)
                 ?: return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
-            
+
+            // SECURITY (A01): same unified-access check as getRisk()/updateRisk().
+            val assetId = risk.asset?.id
+            if (assetId != null && !assetFilterService.canAccessAsset(assetId, authentication)) {
+                log.warn("User {} denied delete of risk {} (linked asset {} not accessible)", authentication.name, id, assetId)
+                return HttpResponse.notFound(ErrorResponse("NOT_FOUND", "Risk not found"))
+            }
+
             riskRepository.delete(risk)
             
             log.info("Deleted risk: {} with id: {}", risk.name, id)

--- a/src/backendng/src/test/kotlin/com/secman/controller/RiskAccessControlIntegrationTest.kt
+++ b/src/backendng/src/test/kotlin/com/secman/controller/RiskAccessControlIntegrationTest.kt
@@ -1,0 +1,228 @@
+package com.secman.controller
+
+import com.secman.domain.AssessmentBasisType
+import com.secman.domain.Risk
+import com.secman.domain.RiskAssessment
+import com.secman.domain.User
+import com.secman.domain.Workgroup
+import com.secman.repository.AssetRepository
+import com.secman.repository.RiskAssessmentRepository
+import com.secman.repository.RiskRepository
+import com.secman.repository.UserRepository
+import com.secman.repository.WorkgroupRepository
+import com.secman.testutil.BaseIntegrationTest
+import com.secman.testutil.TestAuthHelper
+import com.secman.testutil.TestDataFactory
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.transaction.TransactionOperations
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.time.LocalDate
+
+/**
+ * SECURITY (A01) regression coverage for RiskController / RiskAssessmentController.
+ *
+ * A RISK-role user with no workgroup membership, ownership or mapping for an asset must
+ * not be able to read, list, link-to, or otherwise act on a Risk/RiskAssessment linked to
+ * that asset — matching the Unified Asset Access model (see project CLAUDE.md) and the
+ * fix already applied to DemandController for the same bug class.
+ */
+@MicronautTest(environments = ["test"], transactional = false)
+class RiskAccessControlIntegrationTest : BaseIntegrationTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Inject
+    lateinit var workgroupRepository: WorkgroupRepository
+
+    @Inject
+    lateinit var assetRepository: AssetRepository
+
+    @Inject
+    lateinit var riskRepository: RiskRepository
+
+    @Inject
+    lateinit var riskAssessmentRepository: RiskAssessmentRepository
+
+    @Inject
+    lateinit var transactionOperations: TransactionOperations<Connection>
+
+    private lateinit var riskUser: User
+
+    @BeforeEach
+    fun setUp() {
+        val suffix = System.nanoTime()
+        riskUser = userRepository.save(TestDataFactory.createUserWithRoles(
+            "risk-user-$suffix", "risk-user-$suffix@test.com", User.Role.USER, User.Role.RISK
+        ))
+    }
+
+    private fun assignUserToWorkgroup(userId: Long, workgroupId: Long) {
+        transactionOperations.executeWrite<Unit> { status ->
+            status.connection.prepareStatement("INSERT INTO user_workgroups (user_id, workgroup_id) VALUES (?, ?)").use { ps ->
+                ps.setLong(1, userId)
+                ps.setLong(2, workgroupId)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun assignAssetToWorkgroup(assetId: Long, workgroupId: Long) {
+        transactionOperations.executeWrite<Unit> { status ->
+            status.connection.prepareStatement("INSERT INTO asset_workgroups (asset_id, workgroup_id) VALUES (?, ?)").use { ps ->
+                ps.setLong(1, assetId)
+                ps.setLong(2, workgroupId)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `RISK user cannot list, read or delete a risk linked to an inaccessible asset`() {
+        val suffix = System.nanoTime()
+        val inaccessibleAsset = assetRepository.save(TestDataFactory.createAsset(name = "risk-hidden-asset-$suffix"))
+        val hiddenRisk = riskRepository.save(
+            Risk(name = "Hidden risk $suffix", asset = inaccessibleAsset)
+        )
+        val token = TestAuthHelper.getAuthToken(client, riskUser.username)
+
+        val risks = client.toBlocking().retrieve(
+            HttpRequest.GET<Any>("/api/risks").bearerAuth(token),
+            Argument.listOf(Risk::class.java)
+        )
+        assertThat(risks.map { it.id }).doesNotContain(hiddenRisk.id)
+
+        val getException = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.GET<Any>("/api/risks/${hiddenRisk.id}").bearerAuth(token),
+                String::class.java
+            )
+        }
+        assertThat(getException.status).isEqualTo(HttpStatus.NOT_FOUND)
+
+        val deleteException = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.DELETE<Any>("/api/risks/${hiddenRisk.id}").bearerAuth(token),
+                String::class.java
+            )
+        }
+        assertThat(deleteException.status).isEqualTo(HttpStatus.NOT_FOUND)
+
+        // Confirm the risk was NOT deleted by the denied request above.
+        assertThat(riskRepository.findById(hiddenRisk.id!!)).isPresent
+    }
+
+    @Test
+    fun `RISK user can list and read a risk linked to a workgroup-accessible asset`() {
+        val suffix = System.nanoTime()
+        val workgroup = workgroupRepository.save(Workgroup(name = "Risk WG $suffix"))
+        val accessibleAsset = assetRepository.save(TestDataFactory.createAsset(name = "risk-visible-asset-$suffix"))
+        assignUserToWorkgroup(riskUser.id!!, workgroup.id!!)
+        assignAssetToWorkgroup(accessibleAsset.id!!, workgroup.id!!)
+        val visibleRisk = riskRepository.save(
+            Risk(name = "Visible risk $suffix", asset = accessibleAsset)
+        )
+        val token = TestAuthHelper.getAuthToken(client, riskUser.username)
+
+        val risks = client.toBlocking().retrieve(
+            HttpRequest.GET<Any>("/api/risks").bearerAuth(token),
+            Argument.listOf(Risk::class.java)
+        )
+        assertThat(risks.map { it.id }).contains(visibleRisk.id)
+
+        val getResponse = client.toBlocking().exchange(
+            HttpRequest.GET<Any>("/api/risks/${visibleRisk.id}").bearerAuth(token),
+            Risk::class.java
+        )
+        assertThat(getResponse.status).isEqualTo(HttpStatus.OK)
+        assertThat(getResponse.body()!!.id).isEqualTo(visibleRisk.id)
+    }
+
+    @Test
+    fun `RISK user cannot create a risk linked to an inaccessible assetId`() {
+        val suffix = System.nanoTime()
+        val inaccessibleAsset = assetRepository.save(TestDataFactory.createAsset(name = "risk-create-hidden-$suffix"))
+        val token = TestAuthHelper.getAuthToken(client, riskUser.username)
+
+        val exception = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/risks",
+                    RiskController.CreateRiskRequest(name = "Should not link $suffix", assetId = inaccessibleAsset.id)
+                ).bearerAuth(token),
+                String::class.java
+            )
+        }
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(riskRepository.findByNameContainingIgnoreCase("Should not link $suffix")).isEmpty()
+    }
+
+    @Test
+    fun `RISK user cannot list or read an asset-based risk assessment linked to an inaccessible asset`() {
+        val suffix = System.nanoTime()
+        val inaccessibleAsset = assetRepository.save(TestDataFactory.createAsset(name = "ra-hidden-asset-$suffix"))
+        val hiddenAssessment = riskAssessmentRepository.save(
+            RiskAssessment(
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(30),
+                assessmentBasisType = AssessmentBasisType.ASSET,
+                assessmentBasisId = inaccessibleAsset.id!!,
+                asset = inaccessibleAsset,
+                assessor = riskUser,
+                requestor = riskUser
+            )
+        )
+        val token = TestAuthHelper.getAuthToken(client, riskUser.username)
+
+        val assessments = client.toBlocking().retrieve(
+            HttpRequest.GET<Any>("/api/risk-assessments").bearerAuth(token),
+            Argument.listOf(RiskAssessment::class.java)
+        )
+        assertThat(assessments.map { it.id }).doesNotContain(hiddenAssessment.id)
+
+        val getException = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.GET<Any>("/api/risk-assessments/${hiddenAssessment.id}").bearerAuth(token),
+                String::class.java
+            )
+        }
+        assertThat(getException.status).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `RISK user cannot create an asset-based risk assessment for an inaccessible asset`() {
+        val suffix = System.nanoTime()
+        val inaccessibleAsset = assetRepository.save(TestDataFactory.createAsset(name = "ra-create-hidden-$suffix"))
+        val token = TestAuthHelper.getAuthToken(client, riskUser.username)
+
+        val exception = org.junit.jupiter.api.assertThrows<HttpClientResponseException> {
+            client.toBlocking().exchange(
+                HttpRequest.POST(
+                    "/api/risk-assessments",
+                    RiskAssessmentController.CreateRiskAssessmentRequest(
+                        assessorId = riskUser.id,
+                        endDate = LocalDate.now().plusDays(30),
+                        assetId = inaccessibleAsset.id
+                    )
+                ).bearerAuth(token),
+                String::class.java
+            )
+        }
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(riskAssessmentRepository.findByAssetId(inaccessibleAsset.id!!)).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

- A scheduled security review found that `RiskController` and `RiskAssessmentController` never used `AssetFilterService`: `GET /api/risks` and `GET /api/risk-assessments` returned **every** row in the system — including the linked asset's name/ip/type/owner — to any user holding just the `RISK` role, regardless of workgroup membership, ownership, or AWS/AD mapping.
- `getRisk(id)`/`getRiskAssessment(id)` resolved by bare `findById()` with no ownership check, and `createRisk`/`updateRisk`/`createRiskAssessment` resolved a caller-supplied `assetId` (or a DEMAND basis's `existingAssetId`) the same way — letting a RISK-role user link a risk/assessment to an arbitrary asset ID and read its details back.
- This is the same bug class already fixed for `DemandController` in `8265eaa` ("Fix broken access control on demand-to-asset linking"), just unscoped here — `RISK` is not a universal-asset-access role under the Unified Asset Access model (only `ADMIN`/`SECCHAMPION` are).

## Changes

- `RiskController.kt`: `listRisks`, `getRisk`, `getRisksByAsset`, `createRisk`, `updateRisk`, `deleteRisk` now resolve the linked asset through `AssetFilterService.canAccessAsset()`/`getAccessibleAssetIds()` before returning or acting on it. A risk with no linked asset stays visible (no asset detail to protect).
- `RiskAssessmentController.kt`: same treatment for `listRiskAssessments`, `getRiskAssessment`, `getRiskAssessmentsByDemand/ByAsset/ByBasis`, `createRiskAssessment` (both `ASSET` and `DEMAND` bases — a `DEMAND` basis's `existingAsset` is echoed back in the response), `updateRiskAssessment`, `deleteRiskAssessment`, and the token/notify/remind action endpoints. Updated the class doc comment, which previously stated "RISK: Full access to all risk assessment operations" — stale from an earlier feature spec that predates the workgroup-based Unified Asset Access model.
- Added `RiskAccessControlIntegrationTest.kt` covering: a RISK user cannot list/read/delete a risk or risk-assessment linked to an inaccessible asset; a RISK user *can* see one linked to a workgroup-accessible asset; a RISK user cannot create either kind linked to an inaccessible `assetId`.

## Testing

- [ ] `./gradlew build` is clean — **could not run**: this environment's network egress policy blocks `services.gradle.org`, `plugins.gradle.org` and `repo.maven.apache.org` (confirmed via the proxy status endpoint — 403 policy denial on all three), so neither the Gradle wrapper nor the system-installed Gradle 8.14.3 could resolve the Kotlin plugin/dependencies. The change was verified by careful manual read-through of both controllers instead (types, imports, brace matching, call-site signatures for every internal caller of the now-`authentication`-taking methods). **Please run the full build and the new integration tests in CI before merging.**
- [ ] `./scripts/startbackenddev.sh` starts cleanly — not run, same environment limitation
- [x] New/updated integration tests cover the change (`RiskAccessControlIntegrationTest.kt`, not yet run against a live DB for the same reason)
- [ ] `/e2ejs` — not run (doc/backend-only change, no stack available in this session)
- [ ] `/e2evulnexception` — not run
- [x] `./scripts/owasp-check.sh` — 0 BLOCK, 1 REVIEW: `RiskAccessControlIntegrationTest.kt:126` flags a `findById` call. Decision: this is test-setup code asserting a denied delete request did not mutate the DB (never returns anything to an HTTP client), not a production endpoint resolving user-supplied input — no actual A01 exposure.

## Backend contract changes

- [x] N/A — no backend contract changes (both endpoints gained a required `authentication: Authentication` controller parameter, which Micronaut injects from the security context; the HTTP request/response shape is unchanged, so `extensions/` clients are unaffected)

## Security

- [x] RBAC enforced at controller (`@Secured`) — unchanged `@Secured("ADMIN", "RISK", "SECCHAMPION")`; this PR adds the missing per-resource asset-access boundary underneath it
- [x] Input validation / file handling reviewed for new attack surface — N/A, no new input surface
- [x] No secrets hardcoded

## Related issues

None filed — found via a scheduled autonomous security review of this repository.

---

**Note for reviewers:** because CI in this sandboxed session could not reach Maven Central/Gradle Plugin Portal, this PR has **not** been compiled or test-run locally. Please treat the usual build/test CI run on this PR as the first real verification, not a formality.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4JvRyxyatwZi8YCJ7ev8X)_