### PR TITLE
Execute source-review Phase 3 (frontend): shared fetch helper, modal extraction, export URL dedup

### DIFF
--- a/src/frontend/src/components/Export.tsx
+++ b/src/frontend/src/components/Export.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { authenticatedFetch } from '../utils/auth';
+import { extractErrorMessage } from '../utils/apiJson';
+import { buildAuthenticatedRequirementExportUrl } from './requirementDownloadUrl';
 import ReleaseSelector from './ReleaseSelector';
 import { exportApplications, exportAssets } from '../services/assetService';
 import { downloadBlob, downloadResponse } from '../utils/download';
@@ -176,14 +178,11 @@ const Export = () => {
         setIsExporting(true);
 
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        let endpoint = isTranslated
-            ? `/api/requirements/export/docx/translated/${selectedLanguage}`
-            : '/api/requirements/export/docx';
-
-        // Add releaseId parameter if a release is selected
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'docx',
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
 
         if (isTranslated && wordTemplateMode === 'ADHOC') {
             setExportStatus('Error: Ad hoc templates are not supported for translated exports yet. Please use a saved/latest template or English export.');
@@ -197,14 +196,7 @@ const Export = () => {
             const response = await requestWordExport(endpoint);
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements.'));
             }
 
             await downloadResponse(response, 'requirements.docx');
@@ -230,14 +222,12 @@ const Export = () => {
         setIsExporting(true);
         
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        let endpoint = isTranslated
-            ? `/api/requirements/export/docx/usecase/${selectedUseCase}/translated/${selectedLanguage}`
-            : `/api/requirements/export/docx/usecase/${selectedUseCase}`;
-
-        // Add releaseId parameter if a release is selected
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'docx',
+            useCaseId: selectedUseCase,
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
         
         if (isTranslated && wordTemplateMode === 'ADHOC') {
             setExportStatus('Error: Ad hoc templates are not supported for translated exports yet. Please use a saved/latest template or English export.');
@@ -254,14 +244,7 @@ const Export = () => {
             const response = await requestWordExport(endpoint);
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements.'));
             }
 
             await downloadResponse(response, 'requirements_usecase.docx');
@@ -282,14 +265,11 @@ const Export = () => {
         setIsExporting(true);
 
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        let endpoint = isTranslated
-            ? `/api/requirements/export/xlsx/translated/${selectedLanguage}`
-            : '/api/requirements/export/xlsx';
-
-        // Add releaseId parameter if a release is selected
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'xlsx',
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
 
         setExportStatus(isTranslated ? `Translating and exporting to Excel in ${selectedLanguage}...` : 'Exporting to Excel...');
         
@@ -299,14 +279,7 @@ const Export = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements to Excel.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements to Excel.'));
             }
 
             await downloadResponse(response, 'requirements_export.xlsx');
@@ -332,14 +305,12 @@ const Export = () => {
         setIsExporting(true);
         
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        let endpoint = isTranslated
-            ? `/api/requirements/export/xlsx/usecase/${selectedUseCase}/translated/${selectedLanguage}`
-            : `/api/requirements/export/xlsx/usecase/${selectedUseCase}`;
-
-        // Add releaseId parameter if a release is selected
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'xlsx',
+            useCaseId: selectedUseCase,
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
         
         const statusMsg = isTranslated 
             ? `Translating and exporting requirements for selected use case to Excel in ${selectedLanguage}...`
@@ -352,14 +323,7 @@ const Export = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements to Excel.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements to Excel.'));
             }
 
             await downloadResponse(response, 'requirements_usecase.xlsx');

--- a/src/frontend/src/components/ImportExport.tsx
+++ b/src/frontend/src/components/ImportExport.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { csrfPost } from '../utils/csrf'; // Import the CSRF-enhanced POST helper
 import { authenticatedFetch } from '../utils/auth';
+import { extractErrorMessage } from '../utils/apiJson';
+import { buildAuthenticatedRequirementExportUrl } from './requirementDownloadUrl';
 import ReleaseSelector from './ReleaseSelector';
 import { downloadResponse } from '../utils/download';
 import { summarizeImportResult } from '../services/requirementImport';
@@ -173,14 +175,11 @@ const ImportExport = () => {
         
         // Determine the endpoint based on language selection
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        let endpoint = isTranslated 
-            ? `/api/requirements/export/docx/translated/${selectedLanguage}`
-            : '/api/requirements/export/docx';
-        
-        // Add releaseId parameter if a release is selected
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'docx',
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
         
         setExportStatus(isTranslated ? `Translating and exporting to ${selectedLanguage}...` : 'Exporting to Word...');
         
@@ -190,14 +189,7 @@ const ImportExport = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements.'));
             }
 
             await downloadResponse(response, 'requirements.docx');
@@ -222,11 +214,16 @@ const ImportExport = () => {
 
         setIsExporting(true);
         
-        // Determine the endpoint based on language selection
+        // Determine the endpoint based on language selection. The shared builder also
+        // carries the selected release here — this handler had drifted from the Export
+        // screen and silently ignored the release for use-case exports.
         const isTranslated = selectedLanguage !== 'english' && translationConfigured;
-        const endpoint = isTranslated 
-            ? `/api/requirements/export/docx/usecase/${selectedUseCase}/translated/${selectedLanguage}`
-            : `/api/requirements/export/docx/usecase/${selectedUseCase}`;
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'docx',
+            useCaseId: selectedUseCase,
+            translationLanguage: isTranslated ? selectedLanguage : null,
+            releaseId: selectedReleaseId,
+        });
         
         const statusMsg = isTranslated 
             ? `Translating and exporting requirements for selected use case to ${selectedLanguage}...`
@@ -239,14 +236,7 @@ const ImportExport = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements.'));
             }
 
             await downloadResponse(response, 'requirements_usecase.docx');
@@ -267,11 +257,11 @@ const ImportExport = () => {
         setIsExporting(true);
         setExportStatus('Exporting to Excel...');
         
-        // Add releaseId parameter if a release is selected
-        let endpoint = '/api/requirements/export/xlsx';
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        // Same builder as the Export screen; xlsx stays untranslated on this page.
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'xlsx',
+            releaseId: selectedReleaseId,
+        });
         
         try {
             const response = await authenticatedFetch(endpoint, {
@@ -279,14 +269,7 @@ const ImportExport = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements to Excel.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements to Excel.'));
             }
 
             await downloadResponse(response, 'requirements_export.xlsx');
@@ -309,11 +292,12 @@ const ImportExport = () => {
         setIsExporting(true);
         setExportStatus('Exporting requirements for selected use case to Excel...');
         
-        // Add releaseId parameter if a release is selected
-        let endpoint = `/api/requirements/export/xlsx/usecase/${selectedUseCase}`;
-        if (selectedReleaseId !== null) {
-            endpoint += `?releaseId=${selectedReleaseId}`;
-        }
+        // Same builder as the Export screen; xlsx stays untranslated on this page.
+        const endpoint = buildAuthenticatedRequirementExportUrl({
+            format: 'xlsx',
+            useCaseId: selectedUseCase,
+            releaseId: selectedReleaseId,
+        });
         
         try {
             const response = await authenticatedFetch(endpoint, {
@@ -321,14 +305,7 @@ const ImportExport = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = 'Failed to export requirements to Excel.';
-                try {
-                    const errorData = await response.json();
-                    errorMsg = errorData.error || errorMsg;
-                } catch (e) {
-                    errorMsg = response.statusText || errorMsg;
-                }
-                throw new Error(errorMsg);
+                throw new Error(await extractErrorMessage(response, 'Failed to export requirements to Excel.'));
             }
 
             await downloadResponse(response, 'requirements_usecase.xlsx');

--- a/src/frontend/src/components/WorkgroupAssignAssetsModal.tsx
+++ b/src/frontend/src/components/WorkgroupAssignAssetsModal.tsx
@@ -1,0 +1,280 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { getJson, postJson, deleteJson, ApiError } from '../utils/apiJson';
+import { filterAssetsByWildcard } from './workgroupAssignLogic';
+import type { AssignedAsset, Workgroup, WorkgroupAsset } from './workgroupTypes';
+
+/**
+ * Manage the assets assigned to a workgroup, extracted from WorkgroupManagement.tsx.
+ * Owns all modal-scoped state (current assets, staged additions and removals,
+ * wildcard search) and the save API calls; the parent supplies the full asset
+ * list and learns only "saved" / "closed" / an error message.
+ *
+ * Removals are applied before additions on save: if the add step fails, the
+ * workgroup is still in its intended steady state for what succeeded.
+ */
+interface WorkgroupAssignAssetsModalProps {
+  workgroup: Workgroup;
+  /** All assets visible to the caller (the parent already fetched them). */
+  assets: WorkgroupAsset[];
+  onClose: () => void;
+  /** Called after a successful save; parent refetches and closes. */
+  onSaved: () => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+const WorkgroupAssignAssetsModal: React.FC<WorkgroupAssignAssetsModalProps> = ({
+  workgroup,
+  assets,
+  onClose,
+  onSaved,
+  onError,
+}) => {
+  const [selectedAssetIds, setSelectedAssetIds] = useState<number[]>([]);
+  const [assetSearchTerm, setAssetSearchTerm] = useState('');
+  const [assignedAssets, setAssignedAssets] = useState<AssignedAsset[]>([]);
+  const [assignedAssetsError, setAssignedAssetsError] = useState<string | null>(null);
+  // Pending removals: ids the user has marked × in the "Currently assigned" panel.
+  // Strikethrough until Save changes — keeps the operation reversible inside the modal.
+  const [assetIdsToRemove, setAssetIdsToRemove] = useState<number[]>([]);
+
+  useEffect(() => {
+    // Load the currently assigned assets when the dialog opens for a workgroup.
+    const fetchAssigned = async () => {
+      try {
+        const data = await getJson<AssignedAsset[]>(
+          `/api/workgroups/${workgroup.id}/assets`,
+          'Failed to load current assets'
+        );
+        setAssignedAssets(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setAssignedAssetsError(err instanceof Error ? err.message : 'Failed to load current assets');
+      }
+    };
+    void fetchAssigned();
+  }, [workgroup.id]);
+
+  const filteredAssets = useMemo(
+    () => filterAssetsByWildcard(assets, assetSearchTerm),
+    [assets, assetSearchTerm]
+  );
+
+  // Flip an assigned row between kept and pending-removal (applied on Save).
+  const toggleAssetRemoval = (assetId: number) => {
+    setAssetIdsToRemove(prev =>
+      prev.includes(assetId) ? prev.filter(id => id !== assetId) : [...prev, assetId]
+    );
+  };
+
+  // Stage or unstage an asset from the add picker.
+  const toggleAssetSelection = (assetId: number) => {
+    setSelectedAssetIds(prev =>
+      prev.includes(assetId) ? prev.filter(id => id !== assetId) : [...prev, assetId]
+    );
+  };
+
+  // Apply the staged changes: removals first, then additions (see component doc).
+  const submitAssignAssets = async () => {
+    if (selectedAssetIds.length === 0 && assetIdsToRemove.length === 0) {
+      onError('Select at least one asset to add or remove');
+      return;
+    }
+
+    try {
+      if (assetIdsToRemove.length > 0) {
+        await deleteJson(
+          `/api/workgroups/${workgroup.id}/assets`,
+          { assetIds: assetIdsToRemove },
+          'Failed to remove assets'
+        );
+      }
+
+      if (selectedAssetIds.length > 0) {
+        await postJson(
+          `/api/workgroups/${workgroup.id}/assets`,
+          { assetIds: selectedAssetIds },
+          'Failed to assign assets'
+        );
+      }
+
+      await onSaved();
+    } catch (err) {
+      onError(err instanceof ApiError || err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  return (
+    <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
+      <div className="modal-dialog modal-lg">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">Manage Assets in {workgroup.name}</h5>
+            <button type="button" className="btn-close" onClick={onClose}></button>
+          </div>
+          <div className="modal-body">
+            {/* Currently assigned — mirrors the Assign Users dialog. The × marks a row
+                for removal but does not call the API until "Save changes" is pressed. */}
+            <div className="mb-3 p-2 border rounded bg-light">
+              <div className="d-flex justify-content-between align-items-center mb-1">
+                <strong>Currently assigned ({assignedAssets.length})</strong>
+                {assetIdsToRemove.length > 0 && (
+                  <span className="badge bg-warning text-dark">
+                    {assetIdsToRemove.length} pending removal
+                  </span>
+                )}
+              </div>
+              {assignedAssetsError && (
+                <div className="alert alert-warning py-1 px-2 my-1 small mb-0" role="alert">
+                  {assignedAssetsError}
+                </div>
+              )}
+              {assignedAssets.length === 0 && !assignedAssetsError && (
+                <div className="text-muted small fst-italic">No assets assigned yet.</div>
+              )}
+              {assignedAssets.length > 0 && (
+                <div style={{ maxHeight: '180px', overflowY: 'auto' }}>
+                  {assignedAssets.map(a => {
+                    const pending = assetIdsToRemove.includes(a.id);
+                    return (
+                      <div
+                        key={a.id}
+                        className="d-flex justify-content-between align-items-center py-1 px-1 border-bottom"
+                      >
+                        <span
+                          style={{
+                            textDecoration: pending ? 'line-through' : 'none',
+                            color: pending ? 'var(--scand-text-secondary)' : 'inherit',
+                          }}
+                        >
+                          <strong>{a.name}</strong>
+                          {a.type && <span className="text-muted small"> ({a.type})</span>}
+                          {a.ip && <span className="text-muted small"> · {a.ip}</span>}
+                        </span>
+                        <button
+                          type="button"
+                          className={`btn btn-sm ${pending ? 'btn-outline-secondary' : 'btn-outline-danger'}`}
+                          onClick={() => toggleAssetRemoval(a.id)}
+                          title={pending ? 'Undo removal' : 'Mark for removal'}
+                        >
+                          {pending ? 'Undo' : '× Remove'}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <p className="text-muted">Add more assets to this workgroup:</p>
+
+            {/* Search input */}
+            <div className="mb-3">
+              <div className="input-group">
+                <span className="input-group-text">
+                  <i className="bi bi-search"></i>
+                </span>
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Search assets... (use * for wildcard, e.g. ip-10-* or *prod*)"
+                  value={assetSearchTerm}
+                  onChange={(e) => setAssetSearchTerm(e.target.value)}
+                  autoFocus
+                />
+                {assetSearchTerm && (
+                  <button
+                    className="btn btn-outline-secondary"
+                    type="button"
+                    onClick={() => setAssetSearchTerm('')}
+                    title="Clear search"
+                  >
+                    <i className="bi bi-x-lg"></i>
+                  </button>
+                )}
+              </div>
+              <small className="text-muted">
+                {filteredAssets.length} of {assets.length} assets shown
+                {assetSearchTerm && ` matching "${assetSearchTerm}"`}
+              </small>
+            </div>
+
+            {/* Select all filtered / Clear selection buttons */}
+            {filteredAssets.length > 0 && (() => {
+              const assignedIds = new Set(assignedAssets.map(a => a.id));
+              const addable = filteredAssets.filter(a => !assignedIds.has(a.id));
+              return (
+              <div className="mb-2">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-primary me-2"
+                  disabled={addable.length === 0}
+                  onClick={() => {
+                    const addableIds = addable.map(a => a.id);
+                    setSelectedAssetIds(prev => [...new Set([...prev, ...addableIds])]);
+                  }}
+                >
+                  Select all shown ({addable.length})
+                </button>
+                {selectedAssetIds.length > 0 && (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary"
+                    onClick={() => setSelectedAssetIds([])}
+                  >
+                    Clear selection
+                  </button>
+                )}
+              </div>
+              );
+            })()}
+
+            <div className="list-group" style={{ maxHeight: '350px', overflowY: 'auto' }}>
+              {filteredAssets.length === 0 ? (
+                <div className="list-group-item text-center text-muted">
+                  {assetSearchTerm
+                    ? `No assets found matching "${assetSearchTerm}"`
+                    : 'No assets available'}
+                </div>
+              ) : (
+                (() => {
+                  // Hide assets already in the workgroup from the "add more" picker —
+                  // they can only be removed via the Currently assigned panel. Keep
+                  // the lookup O(1) so a large dataset doesn't blow rendering.
+                  const assignedIds = new Set(assignedAssets.map(a => a.id));
+                  return filteredAssets
+                    .filter(asset => !assignedIds.has(asset.id))
+                    .map(asset => (
+                      <label key={asset.id} className="list-group-item list-group-item-action">
+                        <input
+                          type="checkbox"
+                          className="form-check-input me-2"
+                          checked={selectedAssetIds.includes(asset.id)}
+                          onChange={() => toggleAssetSelection(asset.id)}
+                        />
+                        <strong>{asset.name}</strong> ({asset.type})
+                      </label>
+                    ));
+                })()
+              )}
+            </div>
+            <p className="mt-3 text-muted">{selectedAssetIds.length} asset(s) selected</p>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={submitAssignAssets}
+              disabled={selectedAssetIds.length === 0 && assetIdsToRemove.length === 0}
+            >
+              Save changes
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkgroupAssignAssetsModal;

--- a/src/frontend/src/components/WorkgroupAssignUsersModal.tsx
+++ b/src/frontend/src/components/WorkgroupAssignUsersModal.tsx
@@ -1,0 +1,405 @@
+import React, { useState, useEffect } from 'react';
+import { getJson, postJson, deleteJson, ApiError } from '../utils/apiJson';
+import { getEffectiveAssignedUserCount } from './workgroupAssignLogic';
+import type { AssignedUser, UserRef, Workgroup, WorkgroupUser } from './workgroupTypes';
+
+/**
+ * Assign/remove workgroup members, extracted from WorkgroupManagement.tsx.
+ * Owns all modal-scoped state (current members, staged additions and removals,
+ * search, invite-by-email) and the save API calls; the parent supplies the
+ * candidate user list and learns only "saved" / "closed" / an error message.
+ *
+ * Removals are applied before additions on save: if the add step fails, the
+ * workgroup is still in its intended steady state for what succeeded.
+ */
+interface WorkgroupAssignUsersModalProps {
+  workgroup: Workgroup;
+  /** Candidate users (the non-admin-safe list the parent already fetched). */
+  users: WorkgroupUser[];
+  onClose: () => void;
+  /** Called after a successful save; parent refetches and closes. */
+  onSaved: () => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+const WorkgroupAssignUsersModal: React.FC<WorkgroupAssignUsersModalProps> = ({
+  workgroup,
+  users,
+  onClose,
+  onSaved,
+  onError,
+}) => {
+  const [selectedUserRefs, setSelectedUserRefs] = useState<UserRef[]>([]);
+  const [userSearchTerm, setUserSearchTerm] = useState('');
+  const [assignedUsers, setAssignedUsers] = useState<AssignedUser[]>([]);
+  const [assignedUsersError, setAssignedUsersError] = useState<string | null>(null);
+  // Pending removals: ids the user has marked × in the "Currently assigned" panel.
+  // Strikethrough until Save changes — keeps the operation reversible inside the modal.
+  const [userIdsToRemove, setUserIdsToRemove] = useState<number[]>([]);
+
+  useEffect(() => {
+    // Load the current membership when the dialog opens for a workgroup.
+    const fetchAssigned = async () => {
+      try {
+        const data = await getJson<AssignedUser[]>(
+          `/api/workgroups/${workgroup.id}/users`,
+          'Failed to load current members'
+        );
+        setAssignedUsers(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setAssignedUsersError(err instanceof Error ? err.message : 'Failed to load current members');
+      }
+    };
+    void fetchAssigned();
+  }, [workgroup.id]);
+
+  const modalExpectedUserCount = workgroup.userCount;
+  const modalEffectiveUserCount = getEffectiveAssignedUserCount(assignedUsers, userIdsToRemove);
+  const hasUserCountMismatch = !assignedUsersError && modalExpectedUserCount !== modalEffectiveUserCount;
+
+  // Flip a member row between kept and pending-removal (applied on Save).
+  const toggleUserRemoval = (userId: number) => {
+    setUserIdsToRemove(prev =>
+      prev.includes(userId) ? prev.filter(id => id !== userId) : [...prev, userId]
+    );
+  };
+
+  // Stage or unstage a candidate: existing users match by id, invites by email.
+  const toggleUserSelection = (user: WorkgroupUser) => {
+    setSelectedUserRefs(prev => {
+      const matches = (r: UserRef) =>
+        (user.id != null && r.id === user.id) ||
+        (user.id == null && r.email.toLowerCase() === user.email.toLowerCase());
+      if (prev.some(matches)) {
+        return prev.filter(r => !matches(r));
+      }
+      return user.id != null
+        ? [...prev, { id: user.id, email: user.email }]
+        : [...prev, { email: user.email }];
+    });
+  };
+
+  // Apply the staged changes: removals first, then additions (see component doc).
+  const submitAssignUsers = async () => {
+    if (selectedUserRefs.length === 0 && userIdsToRemove.length === 0) {
+      onError('Select at least one user to add or remove');
+      return;
+    }
+
+    try {
+      if (userIdsToRemove.length > 0) {
+        await deleteJson(
+          `/api/workgroups/${workgroup.id}/users`,
+          { userIds: userIdsToRemove },
+          'Failed to remove users'
+        );
+      }
+
+      if (selectedUserRefs.length > 0) {
+        await postJson(
+          `/api/workgroups/${workgroup.id}/users`,
+          { userRefs: selectedUserRefs },
+          'Failed to assign users'
+        );
+      }
+
+      await onSaved();
+    } catch (err) {
+      onError(err instanceof ApiError || err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  return (
+    <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
+      <div className="modal-dialog modal-lg">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">Assign Users to {workgroup.name}</h5>
+            <button type="button" className="btn-close" onClick={onClose}></button>
+          </div>
+          <div className="modal-body">
+            {/* Currently assigned members — mirrors the Manage Assets dialog. The × marks
+                a row for removal but does not call the API until "Save changes" is pressed. */}
+            <div className="mb-3 p-2 border rounded bg-light">
+              <div className="d-flex justify-content-between align-items-center mb-1">
+                <strong>Currently assigned ({assignedUsers.length})</strong>
+                {userIdsToRemove.length > 0 && (
+                  <span className="badge bg-warning text-dark">
+                    {userIdsToRemove.length} pending removal
+                  </span>
+                )}
+              </div>
+              {hasUserCountMismatch && (
+                <div className="alert alert-warning py-2 px-2 my-2 small mb-0" role="alert">
+                  <i className="bi bi-exclamation-triangle me-1"></i>
+                  Count mismatch: table shows <strong>{modalExpectedUserCount}</strong>, but current members in this
+                  dialog are <strong>{modalEffectiveUserCount}</strong>.
+                </div>
+              )}
+              {assignedUsersError && (
+                <div className="alert alert-warning py-1 px-2 my-1 small mb-0" role="alert">
+                  {assignedUsersError}
+                </div>
+              )}
+              {assignedUsers.length === 0 && !assignedUsersError && (
+                <div className="text-muted small fst-italic">No users assigned yet.</div>
+              )}
+              {assignedUsers.length > 0 && (
+                <div style={{ maxHeight: '180px', overflowY: 'auto' }}>
+                  {assignedUsers.map(u => {
+                    const pending = userIdsToRemove.includes(u.id);
+                    return (
+                      <div
+                        key={u.id}
+                        className="d-flex justify-content-between align-items-center py-1 px-1 border-bottom"
+                      >
+                        <span
+                          style={{
+                            textDecoration: pending ? 'line-through' : 'none',
+                            color: pending ? 'var(--scand-text-secondary)' : 'inherit',
+                          }}
+                        >
+                          <i className="bi bi-person-check me-1"></i>
+                          <strong>{u.username}</strong>
+                          <span className="text-muted small"> ({u.email})</span>
+                        </span>
+                        <button
+                          type="button"
+                          className={`btn btn-sm ${pending ? 'btn-outline-secondary' : 'btn-outline-danger'}`}
+                          onClick={() => toggleUserRemoval(u.id)}
+                          title={pending ? 'Undo removal' : 'Mark for removal'}
+                        >
+                          {pending ? 'Undo' : '× Remove'}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <p className="text-muted mb-2">Select users to add to this workgroup:</p>
+
+            {/* Search input — mirrors the asset-assign modal, debounced via React's controlled-input render cycle. */}
+            <div className="mb-3">
+              <div className="input-group">
+                <span className="input-group-text">
+                  <i className="bi bi-search"></i>
+                </span>
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Search existing users — or type a full email to invite someone new"
+                  value={userSearchTerm}
+                  onChange={(e) => setUserSearchTerm(e.target.value)}
+                  autoFocus
+                />
+                {userSearchTerm && (
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={() => setUserSearchTerm('')}
+                    title="Clear search"
+                  >
+                    <i className="bi bi-x-lg"></i>
+                  </button>
+                )}
+              </div>
+              {/* Persistent helper — many users never realize the search box doubles as an invite-by-email
+                  field. State the affordance up front so they don't have to discover it. */}
+              {(() => {
+                const caller = (typeof window !== 'undefined' ? window.currentUser : null) || null;
+                const dom = caller?.email?.split('@')[1] || 'your-domain.com';
+                const isAdmin = (caller?.roles || []).includes('ADMIN');
+                return (
+                  <div className="form-text mt-1">
+                    <i className="bi bi-lightbulb me-1"></i>
+                    Not in the list? Type a full email like <code>name@{dom}</code> to invite a new user.
+                    {!isAdmin && (
+                      <> New users must be at <code>@{dom}</code> (your domain).</>
+                    )}
+                  </div>
+                );
+              })()}
+            </div>
+
+            {(() => {
+              const assignedIds = new Set(assignedUsers.map(u => u.id));
+              const assignedEmails = new Set(assignedUsers.map(u => u.email.toLowerCase()));
+              const termRaw = userSearchTerm.trim();
+              const term = termRaw.toLowerCase();
+              const filtered = users.filter(u => {
+                if (!term) return true;
+                return (u.username || '').toLowerCase().includes(term)
+                    || (u.email || '').toLowerCase().includes(term);
+              });
+              // Sort: already-assigned first (so the admin sees who is in the group at a glance), then alpha by username.
+              const sorted = [...filtered].sort((a, b) => {
+                const aAssigned = (a.id != null && assignedIds.has(a.id)) || assignedEmails.has(a.email.toLowerCase());
+                const bAssigned = (b.id != null && assignedIds.has(b.id)) || assignedEmails.has(b.email.toLowerCase());
+                if (aAssigned !== bAssigned) return aAssigned ? -1 : 1;
+                return (a.username || a.email).localeCompare(b.username || b.email);
+              });
+
+              // Invite-by-email affordance: visible when the search term parses as an
+              // email that isn't already in the user list. Domain-restricted on the
+              // client (UX), enforced again on the server (security).
+              const looksLikeEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(termRaw);
+              const matchesExistingEmail = users.some(u => u.email.toLowerCase() === term);
+              const caller = (typeof window !== 'undefined' ? window.currentUser : null) || null;
+              const callerEmail = caller?.email || '';
+              const callerDomain = callerEmail.split('@')[1]?.toLowerCase() || '';
+              const callerIsAdmin = (caller?.roles || []).includes('ADMIN');
+              const inviteDomain = looksLikeEmail ? (termRaw.split('@')[1]?.toLowerCase() || '') : '';
+              const inviteShouldShow = looksLikeEmail && !matchesExistingEmail;
+              const inviteAllowed = inviteShouldShow && (callerIsAdmin || (!!callerDomain && callerDomain === inviteDomain));
+              const inviteChecked = inviteShouldShow && selectedUserRefs.some(r => r.email.toLowerCase() === term);
+
+              const inviteRow = inviteShouldShow ? (
+                <label
+                  key={`invite:${term}`}
+                  className={`list-group-item list-group-item-action ${inviteAllowed ? '' : 'list-group-item-light text-muted'}`}
+                  title={
+                    inviteAllowed
+                      ? 'Invite this email as a new pending user'
+                      : `New users must share your email domain (@${callerDomain || '?'})`
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    className="form-check-input me-2"
+                    checked={inviteChecked}
+                    disabled={!inviteAllowed}
+                    onChange={() => toggleUserSelection({ id: null, username: termRaw.split('@')[0], email: termRaw, isPending: true })}
+                  />
+                  <i className={`bi ${inviteAllowed ? 'bi-person-plus' : 'bi-shield-lock'} me-1`}></i>
+                  <strong>Invite new user:</strong> {termRaw}
+                  <span className={`badge ms-2 ${inviteAllowed ? 'scand-success' : 'scand-critical'}`}>
+                    {inviteAllowed ? 'new pending' : 'wrong domain'}
+                  </span>
+                </label>
+              ) : null;
+
+              if (sorted.length === 0 && !inviteRow) {
+                // No existing user match AND not a parseable email yet. Tell the
+                // user exactly what to type next so they don't get stuck — the
+                // common failure mode is typing a username and giving up.
+                const hasAtSign = termRaw.includes('@');
+                return (
+                  <div className="text-center text-muted py-4 border rounded bg-light">
+                    <div className="mb-2">
+                      <i className="bi bi-search me-1"></i>
+                      No users match "<strong>{userSearchTerm}</strong>"
+                    </div>
+                    <div className="small">
+                      <i className="bi bi-person-plus me-1"></i>
+                      {hasAtSign
+                        ? <>Keep typing the rest of the email address to invite a new user.</>
+                        : <>To invite someone new, type their <strong>complete email address</strong> here.</>}
+                    </div>
+                  </div>
+                );
+              }
+
+              return (
+                <div className="list-group" style={{ maxHeight: '400px', overflowY: 'auto' }}>
+                  {/* Invite row first — putting it at the top of a possibly-long list
+                      guarantees the user sees it without scrolling. */}
+                  {inviteRow}
+                  {sorted.map(user => {
+                    const isAssigned = (user.id != null && assignedIds.has(user.id))
+                      || assignedEmails.has(user.email.toLowerCase());
+                    const checked = selectedUserRefs.some(r =>
+                      (user.id != null && r.id === user.id) ||
+                      (user.id == null && r.email.toLowerCase() === user.email.toLowerCase())
+                    );
+                    return (
+                      <label
+                        key={user.id ?? `pending:${user.email}`}
+                        className={`list-group-item list-group-item-action ${isAssigned ? 'list-group-item-light' : ''}`}
+                        title={isAssigned ? 'Already a member of this workgroup' : undefined}
+                      >
+                        <input
+                          type="checkbox"
+                          className="form-check-input me-2"
+                          checked={isAssigned || checked}
+                          disabled={isAssigned}
+                          onChange={() => toggleUserSelection(user)}
+                        />
+                        <strong>{user.username}</strong> ({user.email})
+                        {isAssigned && (
+                          <span className="badge bg-success ms-2">
+                            <i className="bi bi-check-circle me-1"></i>assigned
+                          </span>
+                        )}
+                        {user.isPending && (
+                          <span
+                            className="badge bg-warning text-dark ms-2"
+                            title="This email is known via AWS / domain mapping but has never logged in. Selecting it will create an account placeholder."
+                          >
+                            pending
+                          </span>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>
+              );
+            })()}
+
+            {(() => {
+              // Show staged "new pending" invites separately from existing-user picks so
+              // the admin can audit them even after clearing the search box.
+              const knownEmails = new Set(users.map(u => u.email.toLowerCase()));
+              const stagedInvites = selectedUserRefs.filter(
+                r => r.id == null && !knownEmails.has(r.email.toLowerCase())
+              );
+              if (stagedInvites.length === 0) return null;
+              return (
+                <div className="mt-3 p-2 border rounded border-success-subtle bg-success-subtle">
+                  <div className="d-flex align-items-center mb-1">
+                    <i className="bi bi-person-plus me-1 text-success"></i>
+                    <strong className="small">Will create {stagedInvites.length} new user{stagedInvites.length !== 1 ? 's' : ''}</strong>
+                  </div>
+                  <div className="d-flex flex-wrap gap-1">
+                    {stagedInvites.map(r => (
+                      <span key={`staged:${r.email}`} className="badge scand-success">
+                        {r.email}
+                        <button
+                          type="button"
+                          className="btn-close btn-close-sm ms-2"
+                          style={{ fontSize: '0.6rem' }}
+                          aria-label={`Cancel invite for ${r.email}`}
+                          onClick={() => toggleUserSelection({ id: null, username: r.email.split('@')[0], email: r.email, isPending: true })}
+                        ></button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              );
+            })()}
+
+            <p className="mt-3 text-muted small">
+              {selectedUserRefs.length} new user(s) selected · showing {users.length} total
+            </p>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={submitAssignUsers}
+              disabled={selectedUserRefs.length === 0 && userIdsToRemove.length === 0}
+            >
+              Save changes
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkgroupAssignUsersModal;

--- a/src/frontend/src/components/WorkgroupFormModal.tsx
+++ b/src/frontend/src/components/WorkgroupFormModal.tsx
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { postJson, putJson, ApiError } from '../utils/apiJson';
+import type { Workgroup, WorkgroupCriticality } from './workgroupTypes';
+
+type WorkgroupFormData = { name: string; description: string; criticality: WorkgroupCriticality };
+
+/** The three editable fields — split out to keep the modal component itself short. */
+const WorkgroupFormFields: React.FC<{
+  formData: WorkgroupFormData;
+  onChange: (next: WorkgroupFormData) => void;
+}> = ({ formData, onChange }) => (
+  <>
+    <div className="mb-3">
+      <label className="form-label">Name *</label>
+      <input
+        type="text"
+        className="form-control"
+        value={formData.name}
+        onChange={(e) => onChange({ ...formData, name: e.target.value })}
+        required
+        pattern="[-a-zA-Z0-9 ]+"
+        maxLength={100}
+        title="Name must contain only letters, numbers, spaces, and hyphens"
+      />
+      <small className="text-muted">1-100 characters, alphanumeric + spaces + hyphens</small>
+    </div>
+    <div className="mb-3">
+      <label className="form-label">Description</label>
+      <textarea
+        className="form-control"
+        value={formData.description}
+        onChange={(e) => onChange({ ...formData, description: e.target.value })}
+        rows={3}
+        maxLength={512}
+      />
+      <small className="text-muted">Optional, max 512 characters</small>
+    </div>
+    <div className="mb-3">
+      <label className="form-label">Criticality *</label>
+      <select
+        className="form-select"
+        value={formData.criticality}
+        onChange={(e) => onChange({ ...formData, criticality: e.target.value as WorkgroupCriticality })}
+        required
+      >
+        <option value="CRITICAL">CRITICAL</option>
+        <option value="HIGH">HIGH</option>
+        <option value="MEDIUM">MEDIUM</option>
+        <option value="LOW">LOW</option>
+        <option value="NA">N/A</option>
+      </select>
+      <small className="text-muted">Security criticality classification for this workgroup</small>
+    </div>
+  </>
+);
+
+interface WorkgroupFormModalProps {
+  /** Workgroup being edited, or null to create a new one. */
+  workgroup: Workgroup | null;
+  onClose: () => void;
+  /** Called after a successful create/update; parent refetches and closes. */
+  onSaved: () => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+/** Read-only parent/path/level context shown when editing (moves happen in the Tree View). */
+const WorkgroupHierarchyInfo: React.FC<{ workgroup: Workgroup }> = ({ workgroup }) => (
+  <div className="mb-3 pb-3 border-bottom">
+    <div className="alert alert-info mb-0">
+      <h6 className="alert-heading mb-2">
+        <i className="bi bi-diagram-3 me-2"></i>
+        Hierarchy Information
+      </h6>
+      {workgroup.parentId ? (
+        <>
+          <div className="mb-1">
+            <strong>Parent Workgroup:</strong>{' '}
+            {workgroup.parentName || `ID ${workgroup.parentId}`}
+          </div>
+          {workgroup.ancestors && workgroup.ancestors.length > 0 && (
+            <div>
+              <strong>Full Path:</strong>{' '}
+              <span className="text-muted">
+                {workgroup.ancestors.map(a => a.name).join(' > ')} &gt; {workgroup.name}
+              </span>
+            </div>
+          )}
+          {workgroup.depth && (
+            <div className="mt-1">
+              <span className="badge bg-secondary">Level {workgroup.depth}</span>
+            </div>
+          )}
+        </>
+      ) : (
+        <div>
+          <strong>Location:</strong> Root level (no parent)
+          {workgroup.depth && (
+            <span className="badge bg-secondary ms-2">Level {workgroup.depth}</span>
+          )}
+        </div>
+      )}
+      <div className="mt-2">
+        <small className="text-muted">
+          <i className="bi bi-info-circle me-1"></i>
+          To move this workgroup to a different parent, use the Tree View and click "Move"
+        </small>
+      </div>
+    </div>
+  </div>
+);
+
+/**
+ * Create/edit dialog for a workgroup, extracted from WorkgroupManagement.tsx.
+ * Owns its own form state (seeded from the workgroup being edited) and the
+ * create/update API calls; the parent only learns "saved" or "closed".
+ */
+const WorkgroupFormModal: React.FC<WorkgroupFormModalProps> = ({ workgroup, onClose, onSaved, onError }) => {
+  const [formData, setFormData] = useState<WorkgroupFormData>({
+    name: workgroup?.name ?? '',
+    description: workgroup?.description ?? '',
+    criticality: workgroup?.criticality ?? 'MEDIUM',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      if (workgroup) {
+        await putJson(`/api/workgroups/${workgroup.id}`, formData, 'Failed to update workgroup');
+      } else {
+        await postJson('/api/workgroups', formData, 'Failed to create workgroup');
+      }
+      await onSaved();
+    } catch (err) {
+      onError(err instanceof ApiError || err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  return (
+    <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">{workgroup ? 'Edit Workgroup' : 'Create Workgroup'}</h5>
+            <button type="button" className="btn-close" onClick={onClose}></button>
+          </div>
+          <form onSubmit={handleSubmit}>
+            <div className="modal-body">
+              {/* Parent Workgroup Info (read-only, only shown when editing) */}
+              {workgroup && <WorkgroupHierarchyInfo workgroup={workgroup} />}
+              <WorkgroupFormFields formData={formData} onChange={setFormData} />
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" onClick={onClose}>
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-primary">
+                {workgroup ? 'Update' : 'Create'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkgroupFormModal;

--- a/src/frontend/src/components/WorkgroupManagement.tsx
+++ b/src/frontend/src/components/WorkgroupManagement.tsx
@@ -1,116 +1,35 @@
 import React, { useState, useEffect } from 'react';
-import { authenticatedGet, authenticatedPost, authenticatedPut, authenticatedDelete } from '../utils/auth';
+import { getJson, ApiError, deleteJson } from '../utils/apiJson';
 import WorkgroupAccountsModal from './WorkgroupAccountsModal';
 import WorkgroupDomainsModal from './WorkgroupDomainsModal';
+import WorkgroupFormModal from './WorkgroupFormModal';
+import WorkgroupAssignUsersModal from './WorkgroupAssignUsersModal';
+import WorkgroupAssignAssetsModal from './WorkgroupAssignAssetsModal';
 import { isAwsWorkgroup } from '../services/workgroupApi';
 import { formatServerDate } from '../utils/dateUtils';
-
-// Extract a useful error message from a non-OK Response. Handles the three
-// shapes we see in this app: our own `{error: "..."}`, Micronaut's default
-// `{message: "..."}`, and Bean-Validation `{_embedded:{errors:[{message:...}]}}`.
-// Falls back to status text so we never show the literal string "Unknown error".
-async function extractErrorMessage(response: Response, fallback: string): Promise<string> {
-  try {
-    const body = await response.json();
-    if (body && typeof body === 'object') {
-      if (typeof body.error === 'string' && body.error) return body.error;
-      if (typeof body.message === 'string' && body.message) return body.message;
-      const violations = body?._embedded?.errors;
-      if (Array.isArray(violations) && violations.length > 0) {
-        return violations.map((v: any) => v?.message).filter(Boolean).join('; ') || fallback;
-      }
-    }
-  } catch {
-    // body wasn't JSON — fall through
-  }
-  return `${fallback} (HTTP ${response.status})`;
-}
-
-interface Workgroup {
-  id: number;
-  name: string;
-  description?: string;
-  criticality: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'NA';
-  userCount: number;
-  assetCount: number;
-  awsAccountsCount?: number;
-  adDomainsCount?: number;
-  createdAt: string;
-  updatedAt: string;
-  parentId?: number;
-  parentName?: string;
-  depth?: number;
-  ancestors?: Array<{ id: number; name: string }>;
-}
-
-interface User {
-  id: number | null;
-  username: string;
-  email: string;
-  isPending?: boolean;
-}
-
-type UserRef = { id?: number; email: string };
-
-interface Asset {
-  id: number;
-  name: string;
-  type: string;
-}
-
-// Shape returned by GET /api/workgroups/{id}/assets — includes owner/ip for context
-// rows in the "Currently assigned" panel. `type` is nullable on the backend Asset.
-interface AssignedAsset {
-  id: number;
-  name: string;
-  type: string | null;
-  ip: string | null;
-  owner: string | null;
-}
-
-const getEffectiveAssignedUserCount = (
-  assignedUsers: Array<{ id: number; username: string; email: string }>,
-  userIdsToRemove: number[]
-): number => {
-  const assignedIds = new Set(assignedUsers.map(user => user.id));
-  const pendingRemovals = userIdsToRemove.filter(id => assignedIds.has(id)).length;
-  return Math.max(0, assignedUsers.length - pendingRemovals);
-};
-
+import type { Workgroup, WorkgroupAsset, WorkgroupUser } from './workgroupTypes';
 
 interface WorkgroupManagementProps {
   /** When false (default), workgroups named "AWS-…" are hidden from the table. */
   showAwsWorkgroups?: boolean;
 }
 
+/**
+ * Workgroup admin screen: the table plus launcher state for the five dialogs.
+ * Each dialog (create/edit form, assign users, manage assets, AWS accounts,
+ * AD domains) is its own component owning its modal-scoped state; this parent
+ * fetches the shared lists, renders the table, and refetches after saves.
+ */
 const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgroups = false }) => {
   const [workgroups, setWorkgroups] = useState<Workgroup[]>([]);
-  const [users, setUsers] = useState<User[]>([]);
-  const [assets, setAssets] = useState<Asset[]>([]);
+  const [users, setUsers] = useState<WorkgroupUser[]>([]);
+  const [assets, setAssets] = useState<WorkgroupAsset[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingWorkgroup, setEditingWorkgroup] = useState<Workgroup | null>(null);
-  const [formData, setFormData] = useState<{ name: string; description: string; criticality: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'NA' }>({
-    name: '',
-    description: '',
-    criticality: 'MEDIUM'
-  });
-  const [showAssignUsers, setShowAssignUsers] = useState(false);
-  const [showAssignAssets, setShowAssignAssets] = useState(false);
-  const [selectedWorkgroup, setSelectedWorkgroup] = useState<Workgroup | null>(null);
-  const [selectedUserRefs, setSelectedUserRefs] = useState<UserRef[]>([]);
-  const [selectedAssetIds, setSelectedAssetIds] = useState<number[]>([]);
-  const [assetSearchTerm, setAssetSearchTerm] = useState<string>('');
-  const [userSearchTerm, setUserSearchTerm] = useState<string>('');
-  const [assignedUsers, setAssignedUsers] = useState<Array<{ id: number; username: string; email: string }>>([]);
-  const [assignedUsersError, setAssignedUsersError] = useState<string | null>(null);
-  const [assignedAssets, setAssignedAssets] = useState<AssignedAsset[]>([]);
-  const [assignedAssetsError, setAssignedAssetsError] = useState<string | null>(null);
-  // Pending removals: ids the user has marked × in the "Currently assigned" panel.
-  // Strikethrough until Save changes — keeps the operation reversible inside the modal.
-  const [assetIdsToRemove, setAssetIdsToRemove] = useState<number[]>([]);
-  const [userIdsToRemove, setUserIdsToRemove] = useState<number[]>([]);
+  const [assignUsersWorkgroup, setAssignUsersWorkgroup] = useState<Workgroup | null>(null);
+  const [assignAssetsWorkgroup, setAssignAssetsWorkgroup] = useState<Workgroup | null>(null);
   const [accountsModalState, setAccountsModalState] = useState<{
     isOpen: boolean;
     workgroupId: number | null;
@@ -130,13 +49,7 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
 
   const fetchWorkgroups = async () => {
     try {
-      const response = await authenticatedGet('/api/workgroups');
-      if (response.ok) {
-        const data = await response.json() as Workgroup[];
-        setWorkgroups(data);
-      } else {
-        setError(`Failed to fetch workgroups: ${response.status}`);
-      }
+      setWorkgroups(await getJson<Workgroup[]>('/api/workgroups', 'Failed to fetch workgroups'));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -151,11 +64,7 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
     // See AwsAccountSharingController.listUsersForSharing — deprecated pending a generic
     // public-safe replacement on /api/users.
     try {
-      const response = await authenticatedGet('/api/aws-account-sharing/users');
-      if (response.ok) {
-        const data = await response.json();
-        setUsers(data);
-      }
+      setUsers(await getJson<WorkgroupUser[]>('/api/aws-account-sharing/users', 'Failed to fetch users'));
     } catch (err) {
       console.error('Failed to fetch users:', err);
     }
@@ -163,48 +72,10 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
 
   const fetchAssets = async () => {
     try {
-      const response = await authenticatedGet('/api/assets');
-      if (response.ok) {
-        const data = await response.json();
-        setAssets(data);
-      }
+      setAssets(await getJson<WorkgroupAsset[]>('/api/assets', 'Failed to fetch assets'));
     } catch (err) {
       console.error('Failed to fetch assets:', err);
     }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    try {
-      if (editingWorkgroup) {
-        const response = await authenticatedPut(`/api/workgroups/${editingWorkgroup.id}`, formData);
-        if (!response.ok) {
-          throw new Error(await extractErrorMessage(response, 'Failed to update workgroup'));
-        }
-      } else {
-        const response = await authenticatedPost('/api/workgroups', formData);
-        if (!response.ok) {
-          throw new Error(await extractErrorMessage(response, 'Failed to create workgroup'));
-        }
-      }
-
-      await fetchWorkgroups();
-      resetForm();
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-    }
-  };
-
-  const handleEdit = (workgroup: Workgroup) => {
-    setEditingWorkgroup(workgroup);
-    setFormData({
-      name: workgroup.name,
-      description: workgroup.description || '',
-      criticality: workgroup.criticality
-    });
-    setShowForm(true);
   };
 
   const handleDelete = async (id: number) => {
@@ -213,237 +84,20 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
     }
 
     try {
-      const response = await authenticatedDelete(`/api/workgroups/${id}`);
-
-      if (!response.ok) {
-        throw new Error(await extractErrorMessage(response, 'Failed to delete workgroup'));
-      }
-
+      await deleteJson(`/api/workgroups/${id}`, undefined, 'Failed to delete workgroup');
       await fetchWorkgroups();
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred while deleting the workgroup');
+      const message = err instanceof ApiError || err instanceof Error
+        ? err.message
+        : 'An error occurred while deleting the workgroup';
+      setError(message);
     }
   };
 
-  const handleAssignUsers = (workgroup: Workgroup) => {
-    setSelectedWorkgroup(workgroup);
-    setSelectedUserRefs([]);
-    setUserSearchTerm('');
-    setAssignedUsers([]);
-    setAssignedUsersError(null);
-    setUserIdsToRemove([]);
-    setShowAssignUsers(true);
-    fetchAssignedUsers(workgroup.id);
-  };
-
-  const fetchAssignedUsers = async (workgroupId: number) => {
-    try {
-      const response = await authenticatedGet(`/api/workgroups/${workgroupId}/users`);
-      if (response.ok) {
-        const data = await response.json();
-        setAssignedUsers(Array.isArray(data) ? data : []);
-      } else {
-        const body = await response.json().catch(() => ({}));
-        setAssignedUsersError(body.error || `Failed to load current members (HTTP ${response.status})`);
-      }
-    } catch (err) {
-      setAssignedUsersError(err instanceof Error ? err.message : 'Failed to load current members');
-    }
-  };
-
-  const handleAssignAssets = (workgroup: Workgroup) => {
-    setSelectedWorkgroup(workgroup);
-    setSelectedAssetIds([]);
-    setAssetSearchTerm('');
-    setAssignedAssets([]);
-    setAssignedAssetsError(null);
-    setAssetIdsToRemove([]);
-    setShowAssignAssets(true);
-    fetchAssignedAssets(workgroup.id);
-  };
-
-  const fetchAssignedAssets = async (workgroupId: number) => {
-    try {
-      const response = await authenticatedGet(`/api/workgroups/${workgroupId}/assets`);
-      if (response.ok) {
-        const data = await response.json();
-        setAssignedAssets(Array.isArray(data) ? data : []);
-      } else {
-        const body = await response.json().catch(() => ({}));
-        setAssignedAssetsError(body.error || `Failed to load current assets (HTTP ${response.status})`);
-      }
-    } catch (err) {
-      setAssignedAssetsError(err instanceof Error ? err.message : 'Failed to load current assets');
-    }
-  };
-
-  // Toggle a row in the "Currently assigned" panel between kept and pending-removal.
-  const toggleAssetRemoval = (assetId: number) => {
-    setAssetIdsToRemove(prev =>
-      prev.includes(assetId) ? prev.filter(id => id !== assetId) : [...prev, assetId]
-    );
-  };
-
-  const toggleUserRemoval = (userId: number) => {
-    setUserIdsToRemove(prev =>
-      prev.includes(userId) ? prev.filter(id => id !== userId) : [...prev, userId]
-    );
-  };
-
-  /**
-   * Filter assets based on search term with wildcard support
-   * Supports: partial match, * wildcard, case-insensitive
-   */
-  const filterAssets = (searchTerm: string): Asset[] => {
-    if (!searchTerm.trim()) {
-      return assets;
-    }
-
-    const term = searchTerm.toLowerCase().trim();
-
-    // Convert wildcard pattern to regex
-    // * matches any characters, ? matches single character
-    const regexPattern = term
-      .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex special chars except * and ?
-      .replace(/\*/g, '.*')  // * becomes .*
-      .replace(/\?/g, '.');  // ? becomes .
-
-    try {
-      const regex = new RegExp(regexPattern);
-      return assets.filter(asset =>
-        regex.test(asset.name.toLowerCase()) ||
-        regex.test(asset.type.toLowerCase())
-      );
-    } catch {
-      // If regex is invalid, fall back to simple includes
-      return assets.filter(asset =>
-        asset.name.toLowerCase().includes(term) ||
-        asset.type.toLowerCase().includes(term)
-      );
-    }
-  };
-
-  const filteredAssets = filterAssets(assetSearchTerm);
-  const modalExpectedUserCount = selectedWorkgroup?.userCount ?? 0;
-  const modalEffectiveUserCount = getEffectiveAssignedUserCount(assignedUsers, userIdsToRemove);
-  const hasUserCountMismatch = showAssignUsers
-    && !!selectedWorkgroup
-    && !assignedUsersError
-    && modalExpectedUserCount !== modalEffectiveUserCount;
-
-  const submitAssignUsers = async () => {
-    if (!selectedWorkgroup) return;
-    if (selectedUserRefs.length === 0 && userIdsToRemove.length === 0) {
-      setError('Select at least one user to add or remove');
-      return;
-    }
-
-    try {
-      // Removals first (same ordering rationale as submitAssignAssets): if the add
-      // step fails, the workgroup is still in its intended steady state for what
-      // succeeded. Partial progress is not regression.
-      if (userIdsToRemove.length > 0) {
-        const removeResp = await authenticatedDelete(
-          `/api/workgroups/${selectedWorkgroup.id}/users`,
-          { userIds: userIdsToRemove }
-        );
-        if (!removeResp.ok) {
-          throw new Error(await extractErrorMessage(removeResp, 'Failed to remove users'));
-        }
-      }
-
-      if (selectedUserRefs.length > 0) {
-        const addResp = await authenticatedPost(
-          `/api/workgroups/${selectedWorkgroup.id}/users`,
-          { userRefs: selectedUserRefs }
-        );
-        if (!addResp.ok) {
-          throw new Error(await extractErrorMessage(addResp, 'Failed to assign users'));
-        }
-      }
-
-      await fetchWorkgroups();
-      setShowAssignUsers(false);
-      setSelectedWorkgroup(null);
-      setSelectedUserRefs([]);
-      setUserSearchTerm('');
-      setAssignedUsers([]);
-      setAssignedUsersError(null);
-      setUserIdsToRemove([]);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-    }
-  };
-
-  const submitAssignAssets = async () => {
-    if (!selectedWorkgroup) return;
-    if (selectedAssetIds.length === 0 && assetIdsToRemove.length === 0) {
-      setError('Select at least one asset to add or remove');
-      return;
-    }
-
-    try {
-      // Removals first so the workgroup is in its intended steady state even if the
-      // subsequent add fails — partially-applied changes are still progress, never regress.
-      if (assetIdsToRemove.length > 0) {
-        const removeResp = await authenticatedDelete(
-          `/api/workgroups/${selectedWorkgroup.id}/assets`,
-          { assetIds: assetIdsToRemove }
-        );
-        if (!removeResp.ok) {
-          throw new Error(await extractErrorMessage(removeResp, 'Failed to remove assets'));
-        }
-      }
-
-      if (selectedAssetIds.length > 0) {
-        const addResp = await authenticatedPost(
-          `/api/workgroups/${selectedWorkgroup.id}/assets`,
-          { assetIds: selectedAssetIds }
-        );
-        if (!addResp.ok) {
-          throw new Error(await extractErrorMessage(addResp, 'Failed to assign assets'));
-        }
-      }
-
-      await fetchWorkgroups();
-      setShowAssignAssets(false);
-      setSelectedWorkgroup(null);
-      setSelectedAssetIds([]);
-      setAssetIdsToRemove([]);
-      setAssignedAssets([]);
-      setAssignedAssetsError(null);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-    }
-  };
-
-  const toggleUserSelection = (user: User) => {
-    setSelectedUserRefs(prev => {
-      const matches = (r: UserRef) =>
-        (user.id != null && r.id === user.id) ||
-        (user.id == null && r.email.toLowerCase() === user.email.toLowerCase());
-      if (prev.some(matches)) {
-        return prev.filter(r => !matches(r));
-      }
-      return user.id != null
-        ? [...prev, { id: user.id, email: user.email }]
-        : [...prev, { email: user.email }];
-    });
-  };
-
-  const toggleAssetSelection = (assetId: number) => {
-    setSelectedAssetIds(prev =>
-      prev.includes(assetId) ? prev.filter(id => id !== assetId) : [...prev, assetId]
-    );
-  };
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', criticality: 'MEDIUM' });
-    setEditingWorkgroup(null);
+  const closeForm = () => {
     setShowForm(false);
+    setEditingWorkgroup(null);
   };
 
   if (loading) {
@@ -468,583 +122,46 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
 
       {/* Create/Edit Form Modal */}
       {showForm && (
-        <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
-          <div className="modal-dialog">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">{editingWorkgroup ? 'Edit Workgroup' : 'Create Workgroup'}</h5>
-                <button type="button" className="btn-close" onClick={resetForm}></button>
-              </div>
-              <form onSubmit={handleSubmit}>
-                <div className="modal-body">
-                  {/* Parent Workgroup Info (read-only, only shown when editing) */}
-                  {editingWorkgroup && (
-                    <div className="mb-3 pb-3 border-bottom">
-                      <div className="alert alert-info mb-0">
-                        <h6 className="alert-heading mb-2">
-                          <i className="bi bi-diagram-3 me-2"></i>
-                          Hierarchy Information
-                        </h6>
-                        {editingWorkgroup.parentId ? (
-                          <>
-                            <div className="mb-1">
-                              <strong>Parent Workgroup:</strong>{' '}
-                              {editingWorkgroup.parentName || `ID ${editingWorkgroup.parentId}`}
-                            </div>
-                            {editingWorkgroup.ancestors && editingWorkgroup.ancestors.length > 0 && (
-                              <div>
-                                <strong>Full Path:</strong>{' '}
-                                <span className="text-muted">
-                                  {editingWorkgroup.ancestors.map(a => a.name).join(' > ')} &gt; {editingWorkgroup.name}
-                                </span>
-                              </div>
-                            )}
-                            {editingWorkgroup.depth && (
-                              <div className="mt-1">
-                                <span className="badge bg-secondary">Level {editingWorkgroup.depth}</span>
-                              </div>
-                            )}
-                          </>
-                        ) : (
-                          <div>
-                            <strong>Location:</strong> Root level (no parent)
-                            {editingWorkgroup.depth && (
-                              <span className="badge bg-secondary ms-2">Level {editingWorkgroup.depth}</span>
-                            )}
-                          </div>
-                        )}
-                        <div className="mt-2">
-                          <small className="text-muted">
-                            <i className="bi bi-info-circle me-1"></i>
-                            To move this workgroup to a different parent, use the Tree View and click "Move"
-                          </small>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  <div className="mb-3">
-                    <label className="form-label">Name *</label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      value={formData.name}
-                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                      required
-                      pattern="[-a-zA-Z0-9 ]+"
-                      maxLength={100}
-                      title="Name must contain only letters, numbers, spaces, and hyphens"
-                    />
-                    <small className="text-muted">1-100 characters, alphanumeric + spaces + hyphens</small>
-                  </div>
-                  <div className="mb-3">
-                    <label className="form-label">Description</label>
-                    <textarea
-                      className="form-control"
-                      value={formData.description}
-                      onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                      rows={3}
-                      maxLength={512}
-                    />
-                    <small className="text-muted">Optional, max 512 characters</small>
-                  </div>
-                  <div className="mb-3">
-                    <label className="form-label">Criticality *</label>
-                    <select
-                      className="form-select"
-                      value={formData.criticality}
-                      onChange={(e) => setFormData({ ...formData, criticality: e.target.value as 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'NA' })}
-                      required
-                    >
-                      <option value="CRITICAL">CRITICAL</option>
-                      <option value="HIGH">HIGH</option>
-                      <option value="MEDIUM">MEDIUM</option>
-                      <option value="LOW">LOW</option>
-                      <option value="NA">N/A</option>
-                    </select>
-                    <small className="text-muted">Security criticality classification for this workgroup</small>
-                  </div>
-                </div>
-                <div className="modal-footer">
-                  <button type="button" className="btn btn-secondary" onClick={resetForm}>
-                    Cancel
-                  </button>
-                  <button type="submit" className="btn btn-primary">
-                    {editingWorkgroup ? 'Update' : 'Create'}
-                  </button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
+        <WorkgroupFormModal
+          workgroup={editingWorkgroup}
+          onClose={closeForm}
+          onSaved={async () => {
+            await fetchWorkgroups();
+            closeForm();
+            setError(null);
+          }}
+          onError={setError}
+        />
       )}
 
       {/* Assign Users Modal */}
-      {showAssignUsers && selectedWorkgroup && (
-        <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
-          <div className="modal-dialog modal-lg">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">Assign Users to {selectedWorkgroup.name}</h5>
-                <button type="button" className="btn-close" onClick={() => setShowAssignUsers(false)}></button>
-              </div>
-              <div className="modal-body">
-                {/* Currently assigned members — mirrors the Manage Assets dialog. The × marks
-                    a row for removal but does not call the API until "Save changes" is pressed. */}
-                <div className="mb-3 p-2 border rounded bg-light">
-                  <div className="d-flex justify-content-between align-items-center mb-1">
-                    <strong>Currently assigned ({assignedUsers.length})</strong>
-                    {userIdsToRemove.length > 0 && (
-                      <span className="badge bg-warning text-dark">
-                        {userIdsToRemove.length} pending removal
-                      </span>
-                    )}
-                  </div>
-                  {hasUserCountMismatch && (
-                    <div className="alert alert-warning py-2 px-2 my-2 small mb-0" role="alert">
-                      <i className="bi bi-exclamation-triangle me-1"></i>
-                      Count mismatch: table shows <strong>{modalExpectedUserCount}</strong>, but current members in this
-                      dialog are <strong>{modalEffectiveUserCount}</strong>.
-                    </div>
-                  )}
-                  {assignedUsersError && (
-                    <div className="alert alert-warning py-1 px-2 my-1 small mb-0" role="alert">
-                      {assignedUsersError}
-                    </div>
-                  )}
-                  {assignedUsers.length === 0 && !assignedUsersError && (
-                    <div className="text-muted small fst-italic">No users assigned yet.</div>
-                  )}
-                  {assignedUsers.length > 0 && (
-                    <div style={{ maxHeight: '180px', overflowY: 'auto' }}>
-                      {assignedUsers.map(u => {
-                        const pending = userIdsToRemove.includes(u.id);
-                        return (
-                          <div
-                            key={u.id}
-                            className="d-flex justify-content-between align-items-center py-1 px-1 border-bottom"
-                          >
-                            <span
-                              style={{
-                                textDecoration: pending ? 'line-through' : 'none',
-                                color: pending ? 'var(--scand-text-secondary)' : 'inherit',
-                              }}
-                            >
-                              <i className="bi bi-person-check me-1"></i>
-                              <strong>{u.username}</strong>
-                              <span className="text-muted small"> ({u.email})</span>
-                            </span>
-                            <button
-                              type="button"
-                              className={`btn btn-sm ${pending ? 'btn-outline-secondary' : 'btn-outline-danger'}`}
-                              onClick={() => toggleUserRemoval(u.id)}
-                              title={pending ? 'Undo removal' : 'Mark for removal'}
-                            >
-                              {pending ? 'Undo' : '× Remove'}
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                <p className="text-muted mb-2">Select users to add to this workgroup:</p>
-
-                {/* Search input — mirrors the asset-assign modal, debounced via React's controlled-input render cycle. */}
-                <div className="mb-3">
-                  <div className="input-group">
-                    <span className="input-group-text">
-                      <i className="bi bi-search"></i>
-                    </span>
-                    <input
-                      type="text"
-                      className="form-control"
-                      placeholder="Search existing users — or type a full email to invite someone new"
-                      value={userSearchTerm}
-                      onChange={(e) => setUserSearchTerm(e.target.value)}
-                      autoFocus
-                    />
-                    {userSearchTerm && (
-                      <button
-                        type="button"
-                        className="btn btn-outline-secondary"
-                        onClick={() => setUserSearchTerm('')}
-                        title="Clear search"
-                      >
-                        <i className="bi bi-x-lg"></i>
-                      </button>
-                    )}
-                  </div>
-                  {/* Persistent helper — many users never realize the search box doubles as an invite-by-email
-                      field. State the affordance up front so they don't have to discover it. */}
-                  {(() => {
-                    const caller = (typeof window !== 'undefined' ? window.currentUser : null) || null;
-                    const dom = caller?.email?.split('@')[1] || 'your-domain.com';
-                    const isAdmin = (caller?.roles || []).includes('ADMIN');
-                    return (
-                      <div className="form-text mt-1">
-                        <i className="bi bi-lightbulb me-1"></i>
-                        Not in the list? Type a full email like <code>name@{dom}</code> to invite a new user.
-                        {!isAdmin && (
-                          <> New users must be at <code>@{dom}</code> (your domain).</>
-                        )}
-                      </div>
-                    );
-                  })()}
-                </div>
-
-                {(() => {
-                  const assignedIds = new Set(assignedUsers.map(u => u.id));
-                  const assignedEmails = new Set(assignedUsers.map(u => u.email.toLowerCase()));
-                  const termRaw = userSearchTerm.trim();
-                  const term = termRaw.toLowerCase();
-                  const filtered = users.filter(u => {
-                    if (!term) return true;
-                    return (u.username || '').toLowerCase().includes(term)
-                        || (u.email || '').toLowerCase().includes(term);
-                  });
-                  // Sort: already-assigned first (so the admin sees who is in the group at a glance), then alpha by username.
-                  const sorted = [...filtered].sort((a, b) => {
-                    const aAssigned = (a.id != null && assignedIds.has(a.id)) || assignedEmails.has(a.email.toLowerCase());
-                    const bAssigned = (b.id != null && assignedIds.has(b.id)) || assignedEmails.has(b.email.toLowerCase());
-                    if (aAssigned !== bAssigned) return aAssigned ? -1 : 1;
-                    return (a.username || a.email).localeCompare(b.username || b.email);
-                  });
-
-                  // Invite-by-email affordance: visible when the search term parses as an
-                  // email that isn't already in the user list. Domain-restricted on the
-                  // client (UX), enforced again on the server (security).
-                  const looksLikeEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(termRaw);
-                  const matchesExistingEmail = users.some(u => u.email.toLowerCase() === term);
-                  const caller = (typeof window !== 'undefined' ? window.currentUser : null) || null;
-                  const callerEmail = caller?.email || '';
-                  const callerDomain = callerEmail.split('@')[1]?.toLowerCase() || '';
-                  const callerIsAdmin = (caller?.roles || []).includes('ADMIN');
-                  const inviteDomain = looksLikeEmail ? (termRaw.split('@')[1]?.toLowerCase() || '') : '';
-                  const inviteShouldShow = looksLikeEmail && !matchesExistingEmail;
-                  const inviteAllowed = inviteShouldShow && (callerIsAdmin || (!!callerDomain && callerDomain === inviteDomain));
-                  const inviteChecked = inviteShouldShow && selectedUserRefs.some(r => r.email.toLowerCase() === term);
-
-                  const inviteRow = inviteShouldShow ? (
-                    <label
-                      key={`invite:${term}`}
-                      className={`list-group-item list-group-item-action ${inviteAllowed ? '' : 'list-group-item-light text-muted'}`}
-                      title={
-                        inviteAllowed
-                          ? 'Invite this email as a new pending user'
-                          : `New users must share your email domain (@${callerDomain || '?'})`
-                      }
-                    >
-                      <input
-                        type="checkbox"
-                        className="form-check-input me-2"
-                        checked={inviteChecked}
-                        disabled={!inviteAllowed}
-                        onChange={() => toggleUserSelection({ id: null, username: termRaw.split('@')[0], email: termRaw, isPending: true })}
-                      />
-                      <i className={`bi ${inviteAllowed ? 'bi-person-plus' : 'bi-shield-lock'} me-1`}></i>
-                      <strong>Invite new user:</strong> {termRaw}
-                      <span className={`badge ms-2 ${inviteAllowed ? 'scand-success' : 'scand-critical'}`}>
-                        {inviteAllowed ? 'new pending' : 'wrong domain'}
-                      </span>
-                    </label>
-                  ) : null;
-
-                  if (sorted.length === 0 && !inviteRow) {
-                    // No existing user match AND not a parseable email yet. Tell the
-                    // user exactly what to type next so they don't get stuck — the
-                    // common failure mode is typing a username and giving up.
-                    const hasAtSign = termRaw.includes('@');
-                    return (
-                      <div className="text-center text-muted py-4 border rounded bg-light">
-                        <div className="mb-2">
-                          <i className="bi bi-search me-1"></i>
-                          No users match "<strong>{userSearchTerm}</strong>"
-                        </div>
-                        <div className="small">
-                          <i className="bi bi-person-plus me-1"></i>
-                          {hasAtSign
-                            ? <>Keep typing the rest of the email address to invite a new user.</>
-                            : <>To invite someone new, type their <strong>complete email address</strong> here.</>}
-                        </div>
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <div className="list-group" style={{ maxHeight: '400px', overflowY: 'auto' }}>
-                      {/* Invite row first — putting it at the top of a possibly-long list
-                          guarantees the user sees it without scrolling. */}
-                      {inviteRow}
-                      {sorted.map(user => {
-                        const isAssigned = (user.id != null && assignedIds.has(user.id))
-                          || assignedEmails.has(user.email.toLowerCase());
-                        const checked = selectedUserRefs.some(r =>
-                          (user.id != null && r.id === user.id) ||
-                          (user.id == null && r.email.toLowerCase() === user.email.toLowerCase())
-                        );
-                        return (
-                          <label
-                            key={user.id ?? `pending:${user.email}`}
-                            className={`list-group-item list-group-item-action ${isAssigned ? 'list-group-item-light' : ''}`}
-                            title={isAssigned ? 'Already a member of this workgroup' : undefined}
-                          >
-                            <input
-                              type="checkbox"
-                              className="form-check-input me-2"
-                              checked={isAssigned || checked}
-                              disabled={isAssigned}
-                              onChange={() => toggleUserSelection(user)}
-                            />
-                            <strong>{user.username}</strong> ({user.email})
-                            {isAssigned && (
-                              <span className="badge bg-success ms-2">
-                                <i className="bi bi-check-circle me-1"></i>assigned
-                              </span>
-                            )}
-                            {user.isPending && (
-                              <span
-                                className="badge bg-warning text-dark ms-2"
-                                title="This email is known via AWS / domain mapping but has never logged in. Selecting it will create an account placeholder."
-                              >
-                                pending
-                              </span>
-                            )}
-                          </label>
-                        );
-                      })}
-                    </div>
-                  );
-                })()}
-
-                {(() => {
-                  // Show staged "new pending" invites separately from existing-user picks so
-                  // the admin can audit them even after clearing the search box.
-                  const knownEmails = new Set(users.map(u => u.email.toLowerCase()));
-                  const stagedInvites = selectedUserRefs.filter(
-                    r => r.id == null && !knownEmails.has(r.email.toLowerCase())
-                  );
-                  if (stagedInvites.length === 0) return null;
-                  return (
-                    <div className="mt-3 p-2 border rounded border-success-subtle bg-success-subtle">
-                      <div className="d-flex align-items-center mb-1">
-                        <i className="bi bi-person-plus me-1 text-success"></i>
-                        <strong className="small">Will create {stagedInvites.length} new user{stagedInvites.length !== 1 ? 's' : ''}</strong>
-                      </div>
-                      <div className="d-flex flex-wrap gap-1">
-                        {stagedInvites.map(r => (
-                          <span key={`staged:${r.email}`} className="badge scand-success">
-                            {r.email}
-                            <button
-                              type="button"
-                              className="btn-close btn-close-sm ms-2"
-                              style={{ fontSize: '0.6rem' }}
-                              aria-label={`Cancel invite for ${r.email}`}
-                              onClick={() => toggleUserSelection({ id: null, username: r.email.split('@')[0], email: r.email, isPending: true })}
-                            ></button>
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })()}
-
-                <p className="mt-3 text-muted small">
-                  {selectedUserRefs.length} new user(s) selected · showing {users.length} total
-                </p>
-              </div>
-              <div className="modal-footer">
-                <button type="button" className="btn btn-secondary" onClick={() => setShowAssignUsers(false)}>
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={submitAssignUsers}
-                  disabled={selectedUserRefs.length === 0 && userIdsToRemove.length === 0}
-                >
-                  Save changes
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+      {assignUsersWorkgroup && (
+        <WorkgroupAssignUsersModal
+          workgroup={assignUsersWorkgroup}
+          users={users}
+          onClose={() => setAssignUsersWorkgroup(null)}
+          onSaved={async () => {
+            await fetchWorkgroups();
+            setAssignUsersWorkgroup(null);
+            setError(null);
+          }}
+          onError={setError}
+        />
       )}
 
       {/* Manage Assets Modal */}
-      {showAssignAssets && selectedWorkgroup && (
-        <div className="modal show d-block" tabIndex={-1} style={{ backgroundColor: 'var(--scand-overlay)' }}>
-          <div className="modal-dialog modal-lg">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">Manage Assets in {selectedWorkgroup.name}</h5>
-                <button type="button" className="btn-close" onClick={() => setShowAssignAssets(false)}></button>
-              </div>
-              <div className="modal-body">
-                {/* Currently assigned — mirrors the Assign Users dialog. The × marks a row
-                    for removal but does not call the API until "Save changes" is pressed. */}
-                <div className="mb-3 p-2 border rounded bg-light">
-                  <div className="d-flex justify-content-between align-items-center mb-1">
-                    <strong>Currently assigned ({assignedAssets.length})</strong>
-                    {assetIdsToRemove.length > 0 && (
-                      <span className="badge bg-warning text-dark">
-                        {assetIdsToRemove.length} pending removal
-                      </span>
-                    )}
-                  </div>
-                  {assignedAssetsError && (
-                    <div className="alert alert-warning py-1 px-2 my-1 small mb-0" role="alert">
-                      {assignedAssetsError}
-                    </div>
-                  )}
-                  {assignedAssets.length === 0 && !assignedAssetsError && (
-                    <div className="text-muted small fst-italic">No assets assigned yet.</div>
-                  )}
-                  {assignedAssets.length > 0 && (
-                    <div style={{ maxHeight: '180px', overflowY: 'auto' }}>
-                      {assignedAssets.map(a => {
-                        const pending = assetIdsToRemove.includes(a.id);
-                        return (
-                          <div
-                            key={a.id}
-                            className="d-flex justify-content-between align-items-center py-1 px-1 border-bottom"
-                          >
-                            <span
-                              style={{
-                                textDecoration: pending ? 'line-through' : 'none',
-                                color: pending ? 'var(--scand-text-secondary)' : 'inherit',
-                              }}
-                            >
-                              <strong>{a.name}</strong>
-                              {a.type && <span className="text-muted small"> ({a.type})</span>}
-                              {a.ip && <span className="text-muted small"> · {a.ip}</span>}
-                            </span>
-                            <button
-                              type="button"
-                              className={`btn btn-sm ${pending ? 'btn-outline-secondary' : 'btn-outline-danger'}`}
-                              onClick={() => toggleAssetRemoval(a.id)}
-                              title={pending ? 'Undo removal' : 'Mark for removal'}
-                            >
-                              {pending ? 'Undo' : '× Remove'}
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                <p className="text-muted">Add more assets to this workgroup:</p>
-
-                {/* Search input */}
-                <div className="mb-3">
-                  <div className="input-group">
-                    <span className="input-group-text">
-                      <i className="bi bi-search"></i>
-                    </span>
-                    <input
-                      type="text"
-                      className="form-control"
-                      placeholder="Search assets... (use * for wildcard, e.g. ip-10-* or *prod*)"
-                      value={assetSearchTerm}
-                      onChange={(e) => setAssetSearchTerm(e.target.value)}
-                      autoFocus
-                    />
-                    {assetSearchTerm && (
-                      <button
-                        className="btn btn-outline-secondary"
-                        type="button"
-                        onClick={() => setAssetSearchTerm('')}
-                        title="Clear search"
-                      >
-                        <i className="bi bi-x-lg"></i>
-                      </button>
-                    )}
-                  </div>
-                  <small className="text-muted">
-                    {filteredAssets.length} of {assets.length} assets shown
-                    {assetSearchTerm && ` matching "${assetSearchTerm}"`}
-                  </small>
-                </div>
-
-                {/* Select all filtered / Clear selection buttons */}
-                {filteredAssets.length > 0 && (() => {
-                  const assignedIds = new Set(assignedAssets.map(a => a.id));
-                  const addable = filteredAssets.filter(a => !assignedIds.has(a.id));
-                  return (
-                  <div className="mb-2">
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-outline-primary me-2"
-                      disabled={addable.length === 0}
-                      onClick={() => {
-                        const addableIds = addable.map(a => a.id);
-                        setSelectedAssetIds(prev => [...new Set([...prev, ...addableIds])]);
-                      }}
-                    >
-                      Select all shown ({addable.length})
-                    </button>
-                    {selectedAssetIds.length > 0 && (
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-outline-secondary"
-                        onClick={() => setSelectedAssetIds([])}
-                      >
-                        Clear selection
-                      </button>
-                    )}
-                  </div>
-                  );
-                })()}
-
-                <div className="list-group" style={{ maxHeight: '350px', overflowY: 'auto' }}>
-                  {filteredAssets.length === 0 ? (
-                    <div className="list-group-item text-center text-muted">
-                      {assetSearchTerm
-                        ? `No assets found matching "${assetSearchTerm}"`
-                        : 'No assets available'}
-                    </div>
-                  ) : (
-                    (() => {
-                      // Hide assets already in the workgroup from the "add more" picker —
-                      // they can only be removed via the Currently assigned panel. Keep
-                      // the lookup O(1) so the 119-row dataset doesn't blow rendering.
-                      const assignedIds = new Set(assignedAssets.map(a => a.id));
-                      return filteredAssets
-                        .filter(asset => !assignedIds.has(asset.id))
-                        .map(asset => (
-                          <label key={asset.id} className="list-group-item list-group-item-action">
-                            <input
-                              type="checkbox"
-                              className="form-check-input me-2"
-                              checked={selectedAssetIds.includes(asset.id)}
-                              onChange={() => toggleAssetSelection(asset.id)}
-                            />
-                            <strong>{asset.name}</strong> ({asset.type})
-                          </label>
-                        ));
-                    })()
-                  )}
-                </div>
-                <p className="mt-3 text-muted">{selectedAssetIds.length} asset(s) selected</p>
-              </div>
-              <div className="modal-footer">
-                <button type="button" className="btn btn-secondary" onClick={() => setShowAssignAssets(false)}>
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={submitAssignAssets}
-                  disabled={selectedAssetIds.length === 0 && assetIdsToRemove.length === 0}
-                >
-                  Save changes
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+      {assignAssetsWorkgroup && (
+        <WorkgroupAssignAssetsModal
+          workgroup={assignAssetsWorkgroup}
+          assets={assets}
+          onClose={() => setAssignAssetsWorkgroup(null)}
+          onSaved={async () => {
+            await fetchWorkgroups();
+            setAssignAssetsWorkgroup(null);
+            setError(null);
+          }}
+          onError={setError}
+        />
       )}
 
       {/* Accounts Modal */}
@@ -1133,14 +250,17 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
                     <div className="btn-group btn-group-sm">
                       <button
                         className="btn btn-outline-primary"
-                        onClick={() => handleEdit(workgroup)}
+                        onClick={() => {
+                          setEditingWorkgroup(workgroup);
+                          setShowForm(true);
+                        }}
                         title="Edit workgroup"
                       >
                         Edit
                       </button>
                       <button
                         className="btn btn-outline-info"
-                        onClick={() => handleAssignUsers(workgroup)}
+                        onClick={() => setAssignUsersWorkgroup(workgroup)}
                         title="Assign users"
                       >
                         Users
@@ -1175,7 +295,7 @@ const WorkgroupManagement: React.FC<WorkgroupManagementProps> = ({ showAwsWorkgr
                       </button>
                       <button
                         className="btn btn-outline-success"
-                        onClick={() => handleAssignAssets(workgroup)}
+                        onClick={() => setAssignAssetsWorkgroup(workgroup)}
                         title="Manage assets"
                       >
                         Assets

--- a/src/frontend/src/components/requirementDownloadUrl.test.ts
+++ b/src/frontend/src/components/requirementDownloadUrl.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildPublicStandardUrl, buildRequirementDownloadUrl } from './requirementDownloadUrl';
+import { buildAuthenticatedRequirementExportUrl, buildPublicStandardUrl, buildRequirementDownloadUrl } from './requirementDownloadUrl';
 
 test('an unscoped download keeps the bare export path', () => {
   assert.equal(buildRequirementDownloadUrl({ format: 'docx' }), '/api/requirements/export/docx');
@@ -65,5 +65,43 @@ test('the public standard URL pins an explicit release version when given', () =
   assert.equal(
     buildPublicStandardUrl('https://secman.example.net', 'IT/OT Security', 'xlsx', '98.739714.0'),
     'https://secman.example.net/api/requirements/export/xlsx?standard=IT%2FOT+Security&release=98.739714.0',
+  );
+});
+
+test('authenticated export: plain endpoint with no scope', () => {
+  assert.equal(
+    buildAuthenticatedRequirementExportUrl({ format: 'docx' }),
+    '/api/requirements/export/docx',
+  );
+});
+
+test('authenticated export: use case rides as a path segment', () => {
+  assert.equal(
+    buildAuthenticatedRequirementExportUrl({ format: 'xlsx', useCaseId: 7 }),
+    '/api/requirements/export/xlsx/usecase/7',
+  );
+});
+
+test('authenticated export: translated variant appends the language segment', () => {
+  assert.equal(
+    buildAuthenticatedRequirementExportUrl({ format: 'docx', translationLanguage: 'german' }),
+    '/api/requirements/export/docx/translated/german',
+  );
+});
+
+test('authenticated export: use case + translation + release compose', () => {
+  assert.equal(
+    buildAuthenticatedRequirementExportUrl({
+      format: 'docx', useCaseId: 3, translationLanguage: 'french', releaseId: 12,
+    }),
+    '/api/requirements/export/docx/usecase/3/translated/french?releaseId=12',
+  );
+});
+
+test('authenticated export: releaseId is carried on the use-case route too', () => {
+  // The Import/Export screen had drifted and dropped releaseId here — pinned so it cannot again.
+  assert.equal(
+    buildAuthenticatedRequirementExportUrl({ format: 'xlsx', useCaseId: 5, releaseId: 2 }),
+    '/api/requirements/export/xlsx/usecase/5?releaseId=2',
   );
 });

--- a/src/frontend/src/components/requirementDownloadUrl.ts
+++ b/src/frontend/src/components/requirementDownloadUrl.ts
@@ -10,6 +10,7 @@
 
 export type RequirementExportFormat = 'docx' | 'xlsx';
 
+/** Scope for the anonymous public download route (no translation variant). */
 export interface RequirementDownloadScope {
     format: RequirementExportFormat;
     /** Narrow to one use case. Takes precedence over standardId if both are somehow set. */
@@ -42,6 +43,45 @@ export function buildRequirementDownloadUrl(scope: RequirementDownloadScope): st
 
     const query = params.toString();
     return query ? `${base}?${query}` : base;
+}
+
+/**
+ * Scope for the authenticated requirement exports on the Export and Import/Export
+ * screens. Differs from RequirementDownloadScope in supporting the translated
+ * endpoint variants (`/translated/{language}`), which the public download does not have.
+ */
+export interface AuthenticatedRequirementExportScope {
+    format: RequirementExportFormat;
+    /** Narrow to one use case (path segment, like the public route). */
+    useCaseId?: number | null;
+    /** Freeze to a release. Null or undefined means the live requirement set. */
+    releaseId?: number | null;
+    /**
+     * Language for a translated export, or null for the plain endpoint.
+     * Callers pass null for 'english' — English is the untranslated source.
+     */
+    translationLanguage?: string | null;
+}
+
+/**
+ * Build the endpoint for an authenticated requirement export.
+ *
+ * One builder for both the Export and Import/Export screens — their four
+ * hand-rolled copies had drifted (the Import/Export side lost the releaseId
+ * parameter on the use-case route and never gained the translated variants).
+ * Route shapes, matching RequirementController:
+ *   /api/requirements/export/{format}[/usecase/{id}][/translated/{language}][?releaseId=N]
+ */
+export function buildAuthenticatedRequirementExportUrl(scope: AuthenticatedRequirementExportScope): string {
+    let base = scope.useCaseId != null
+        ? `/api/requirements/export/${scope.format}/usecase/${scope.useCaseId}`
+        : `/api/requirements/export/${scope.format}`;
+
+    if (scope.translationLanguage) {
+        base += `/translated/${encodeURIComponent(scope.translationLanguage)}`;
+    }
+
+    return scope.releaseId != null ? `${base}?releaseId=${scope.releaseId}` : base;
 }
 
 /**

--- a/src/frontend/src/components/workgroupAssignLogic.test.ts
+++ b/src/frontend/src/components/workgroupAssignLogic.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getEffectiveAssignedUserCount, filterAssetsByWildcard } from './workgroupAssignLogic';
+
+const users = [
+    { id: 1, username: 'a', email: 'a@x.io' },
+    { id: 2, username: 'b', email: 'b@x.io' },
+    { id: 3, username: 'c', email: 'c@x.io' },
+];
+
+test('effective count subtracts only removals that target assigned members', () => {
+    assert.equal(getEffectiveAssignedUserCount(users, []), 3);
+    assert.equal(getEffectiveAssignedUserCount(users, [1, 3]), 1);
+    assert.equal(getEffectiveAssignedUserCount(users, [99]), 3);
+    assert.equal(getEffectiveAssignedUserCount([], [1]), 0);
+});
+
+const assets = [
+    { id: 1, name: 'ip-10-0-0-1', type: 'SERVER' },
+    { id: 2, name: 'prod-db', type: 'DATABASE' },
+    { id: 3, name: 'Staging-Web', type: 'SERVER' },
+];
+
+test('empty search returns everything', () => {
+    assert.equal(filterAssetsByWildcard(assets, '  '), assets);
+});
+
+test('partial match is case-insensitive against name and type', () => {
+    assert.deepEqual(filterAssetsByWildcard(assets, 'PROD').map(a => a.id), [2]);
+    assert.deepEqual(filterAssetsByWildcard(assets, 'database').map(a => a.id), [2]);
+});
+
+test('* wildcard matches any characters', () => {
+    assert.deepEqual(filterAssetsByWildcard(assets, 'ip-10-*').map(a => a.id), [1]);
+    assert.deepEqual(filterAssetsByWildcard(assets, '*web*').map(a => a.id), [3]);
+});
+
+test('? wildcard matches a single character', () => {
+    assert.deepEqual(filterAssetsByWildcard(assets, 'prod-d?').map(a => a.id), [2]);
+});

--- a/src/frontend/src/components/workgroupAssignLogic.ts
+++ b/src/frontend/src/components/workgroupAssignLogic.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure logic for the workgroup assign-users / assign-assets modals, extracted
+ * from WorkgroupManagement.tsx so the Node test tier (which cannot parse JSX)
+ * can exercise it.
+ */
+
+import type { AssignedUser, WorkgroupAsset } from './workgroupTypes';
+
+/**
+ * Members remaining after the pending removals are applied — drives the
+ * count-mismatch warning in the assign-users dialog. Only removals that
+ * actually target an assigned member count; never below zero.
+ */
+export function getEffectiveAssignedUserCount(
+    assignedUsers: AssignedUser[],
+    userIdsToRemove: number[]
+): number {
+    const assignedIds = new Set(assignedUsers.map(user => user.id));
+    const pendingRemovals = userIdsToRemove.filter(id => assignedIds.has(id)).length;
+    return Math.max(0, assignedUsers.length - pendingRemovals);
+}
+
+/**
+ * Filter assets by a search term with wildcard support:
+ * partial match, `*` for any characters, `?` for a single character,
+ * case-insensitive against name and type. An invalid resulting regex
+ * falls back to a plain substring match.
+ */
+export function filterAssetsByWildcard(assets: WorkgroupAsset[], searchTerm: string): WorkgroupAsset[] {
+    if (!searchTerm.trim()) {
+        return assets;
+    }
+
+    const term = searchTerm.toLowerCase().trim();
+
+    const regexPattern = term
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex special chars except * and ?
+        .replace(/\*/g, '.*')
+        .replace(/\?/g, '.');
+
+    try {
+        const regex = new RegExp(regexPattern);
+        return assets.filter(asset =>
+            regex.test(asset.name.toLowerCase()) ||
+            regex.test(asset.type.toLowerCase())
+        );
+    } catch {
+        return assets.filter(asset =>
+            asset.name.toLowerCase().includes(term) ||
+            asset.type.toLowerCase().includes(term)
+        );
+    }
+}

--- a/src/frontend/src/components/workgroupTypes.ts
+++ b/src/frontend/src/components/workgroupTypes.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared shapes for the workgroup management screen and its extracted modals
+ * (WorkgroupFormModal, WorkgroupAssignUsersModal, WorkgroupAssignAssetsModal).
+ * Kept in a .ts module so the Node test tier can import them alongside the
+ * pure logic in workgroupAssignLogic.ts.
+ */
+
+export type WorkgroupCriticality = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'NA';
+
+/** A workgroup row as the management table receives it from GET /api/workgroups. */
+export interface Workgroup {
+    id: number;
+    name: string;
+    description?: string;
+    criticality: WorkgroupCriticality;
+    userCount: number;
+    assetCount: number;
+    awsAccountsCount?: number;
+    adDomainsCount?: number;
+    createdAt: string;
+    updatedAt: string;
+    parentId?: number;
+    parentName?: string;
+    depth?: number;
+    ancestors?: Array<{ id: number; name: string }>;
+}
+
+/** A candidate user for assignment; id is null for known-but-never-logged-in emails. */
+export interface WorkgroupUser {
+    id: number | null;
+    username: string;
+    email: string;
+    isPending?: boolean;
+}
+
+/** A user picked for assignment: existing users by id, invited-by-email users by email only. */
+export type UserRef = { id?: number; email: string };
+
+/** The slim asset shape the assign-assets picker needs. */
+export interface WorkgroupAsset {
+    id: number;
+    name: string;
+    type: string;
+}
+
+/**
+ * Shape returned by GET /api/workgroups/{id}/assets — includes owner/ip for context
+ * rows in the "Currently assigned" panel. `type` is nullable on the backend Asset.
+ */
+export interface AssignedAsset {
+    id: number;
+    name: string;
+    type: string | null;
+    ip: string | null;
+    owner: string | null;
+}
+
+/** A current member row from GET /api/workgroups/{id}/users. */
+export interface AssignedUser {
+    id: number;
+    username: string;
+    email: string;
+}

--- a/src/frontend/src/utils/apiJson.test.ts
+++ b/src/frontend/src/utils/apiJson.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ApiError, extractErrorMessage, parseJsonResponse } from './apiJson';
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+test('parseJsonResponse returns parsed body on OK', async () => {
+    const result = await parseJsonResponse<{ a: number }>(jsonResponse({ a: 1 }), 'x');
+    assert.deepEqual(result, { a: 1 });
+});
+
+test('parseJsonResponse resolves undefined for an empty body', async () => {
+    const result = await parseJsonResponse<void>(new Response(null, { status: 200 }), 'x');
+    assert.equal(result, undefined);
+});
+
+test('parseJsonResponse throws ApiError with backend error message and status', async () => {
+    await assert.rejects(
+        parseJsonResponse(jsonResponse({ error: 'nope' }, 403), 'Failed to save'),
+        (err: unknown) => err instanceof ApiError && err.message === 'nope' && err.status === 403,
+    );
+});
+
+test('extractErrorMessage prefers error over message', async () => {
+    assert.equal(await extractErrorMessage(jsonResponse({ error: 'e', message: 'm' }, 400), 'f'), 'e');
+});
+
+test('extractErrorMessage falls back to Micronaut message shape', async () => {
+    assert.equal(await extractErrorMessage(jsonResponse({ message: 'm' }, 400), 'f'), 'm');
+});
+
+test('extractErrorMessage joins Bean-Validation violations', async () => {
+    const body = { _embedded: { errors: [{ message: 'a' }, { message: 'b' }] } };
+    assert.equal(await extractErrorMessage(jsonResponse(body, 400), 'f'), 'a; b');
+});
+
+test('extractErrorMessage falls back with HTTP status on a non-JSON body', async () => {
+    const response = new Response('<html>oops</html>', { status: 502 });
+    assert.equal(await extractErrorMessage(response, 'Failed to load'), 'Failed to load (HTTP 502)');
+});

--- a/src/frontend/src/utils/apiJson.ts
+++ b/src/frontend/src/utils/apiJson.ts
@@ -1,0 +1,89 @@
+/**
+ * Thin JSON layer over the authenticated* fetch helpers in utils/auth.ts.
+ *
+ * The authenticated* helpers return a raw Response, which left every call site
+ * re-implementing the same dozen lines of `if (ok) json else extract-error`
+ * (~65 components at the time this was extracted). These wrappers return parsed
+ * data or throw an ApiError carrying the backend's message, so a component's
+ * fetch collapses to `setX(await getJson<X>('/api/x'))` inside its try/catch.
+ *
+ * This sits ON TOP of utils/auth.ts — auth stays in the HttpOnly cookie and the
+ * 401-redirect behavior of authenticatedFetch is unchanged. Never add token
+ * handling here.
+ */
+
+import {
+    authenticatedGet,
+    authenticatedPost,
+    authenticatedPut,
+    authenticatedDelete,
+} from './auth';
+
+/** Error thrown for a non-OK response; message is the backend's, status the HTTP code. */
+export class ApiError extends Error {
+    readonly status: number;
+
+    /** Message is what the UI shows; status lets callers branch (403 vs 404 vs 5xx). */
+    constructor(message: string, status: number) {
+        super(message);
+        this.name = 'ApiError';
+        this.status = status;
+    }
+}
+
+/**
+ * Extract a useful error message from a non-OK Response. Handles the three
+ * shapes this app produces: our own `{error: "..."}`, Micronaut's default
+ * `{message: "..."}`, and Bean-Validation `{_embedded:{errors:[{message:...}]}}`.
+ * Falls back to "<fallback> (HTTP <status>)" so we never show "Unknown error".
+ *
+ * (Moved here from WorkgroupManagement.tsx so every component shares one copy.)
+ */
+export async function extractErrorMessage(response: Response, fallback: string): Promise<string> {
+    try {
+        const body = await response.json();
+        if (body && typeof body === 'object') {
+            if (typeof body.error === 'string' && body.error) return body.error;
+            if (typeof body.message === 'string' && body.message) return body.message;
+            const violations = body?._embedded?.errors;
+            if (Array.isArray(violations) && violations.length > 0) {
+                return violations.map((v: any) => v?.message).filter(Boolean).join('; ') || fallback;
+            }
+        }
+    } catch {
+        // body wasn't JSON — fall through
+    }
+    return `${fallback} (HTTP ${response.status})`;
+}
+
+/**
+ * Turn a Response into parsed JSON or an ApiError. Exported for tests and for
+ * call sites that already hold a Response. An empty body (204, or a write
+ * endpoint that returns nothing) resolves to undefined rather than a parse error.
+ */
+export async function parseJsonResponse<T>(response: Response, errorLabel: string): Promise<T> {
+    if (!response.ok) {
+        throw new ApiError(await extractErrorMessage(response, errorLabel), response.status);
+    }
+    const text = await response.text();
+    if (!text) {
+        return undefined as T;
+    }
+    return JSON.parse(text) as T;
+}
+
+export async function getJson<T>(url: string, errorLabel = 'Request failed'): Promise<T> {
+    return parseJsonResponse<T>(await authenticatedGet(url), errorLabel);
+}
+
+export async function postJson<T = void>(url: string, body?: unknown, errorLabel = 'Request failed'): Promise<T> {
+    return parseJsonResponse<T>(await authenticatedPost(url, body), errorLabel);
+}
+
+export async function putJson<T = void>(url: string, body?: unknown, errorLabel = 'Request failed'): Promise<T> {
+    return parseJsonResponse<T>(await authenticatedPut(url, body), errorLabel);
+}
+
+export async function deleteJson<T = void>(url: string, body?: unknown, errorLabel = 'Request failed'): Promise<T> {
+    return parseJsonResponse<T>(await authenticatedDelete(url, body), errorLabel);
+}


### PR DESCRIPTION
## Summary

- Frontend-only continuation of `docs/SOURCE_REVIEW_COMPLEXITY_SPEED.md` §6 Phase 3. The Kotlin parts (controller error-handling migration across ~349 catch sites, CLI Picocli consolidation, `ConfigBundleService`/`RequirementController` de-duplication) need a working Gradle build to verify safely — this environment has no reachable Gradle distribution/dependency mirror, so they're left for a session with that.
- New `utils/apiJson.ts` (`getJson`/`postJson`/`putJson`/`deleteJson`) sits on top of the existing `authenticated*` fetch helpers and returns parsed data or throws `ApiError` with the backend's message — replacing the copy-pasted try/ok/catch/finally block found at roughly 65 call sites across the frontend (this PR migrates one: `WorkgroupManagement`, as the exemplar).
- `WorkgroupManagement.tsx` (1,204 lines, the review's #4 flagged component) split into a ~300-line table/launcher parent plus three owned dialogs (`WorkgroupFormModal`, `WorkgroupAssignUsersModal`, `WorkgroupAssignAssetsModal`), with shared types and pure assign-logic (effective-count math, wildcard asset filter) extracted into `.ts` modules that the Node test tier can now exercise directly.
- `Export.tsx` / `ImportExport.tsx`: their four duplicated docx/xlsx endpoint builders replaced with one `buildAuthenticatedRequirementExportUrl` helper (extends the existing `requirementDownloadUrl.ts`). This also **fixes a real bug**: `ImportExport`'s use-case xlsx export had silently dropped the `releaseId` parameter — a drift the review flagged as a risk of the fork existing at all.

## Changes

- New: `src/frontend/src/utils/apiJson.ts` (+test), `src/frontend/src/components/{WorkgroupFormModal,WorkgroupAssignUsersModal,WorkgroupAssignAssetsModal,workgroupTypes,workgroupAssignLogic}.tsx/.ts` (+test).
- Modified: `WorkgroupManagement.tsx` (rewritten as the slim parent), `Export.tsx`, `ImportExport.tsx`, `requirementDownloadUrl.ts` (+test, new `buildAuthenticatedRequirementExportUrl`).
- No backend/API changes — same endpoints, same request/response shapes, same role gates. Nothing in `extensions/` is affected.

## Testing

- [x] `cd src/frontend && npm ci && npm run build` exits 0
- [x] Frontend unit tier: 274 pass, 0 fail (17 new tests: `apiJson`, `workgroupAssignLogic`, `requirementDownloadUrl` additions)
- [x] `./scripts/owasp-check.sh`: 0 findings
- [x] `./scripts/humanizer-scan.sh`: 0 BLOCK; 7 REVIEW remain, all pre-existing `FUNC-MAX` on `Export`/`ImportExport` (756/720 lines, each shrank this pass but a full split is a separate future PR) and `WorkgroupManagement` (now 300 lines, down from 1,204, table-row extraction deferred) — decided and left, not silently skipped
- [ ] `./gradlew build`, `./scripts/startbackenddev.sh`, `/e2ejs`, `/e2evulnexception` — **not run**; this PR touches only `src/frontend`, and no backend file changed, but the mandatory gates still need a machine that can start the stack. The areas to click through: Workgroup Management (create/edit, assign users incl. invite-by-email, manage assets incl. wildcard search), and both Export/Import-Export screens' docx and xlsx buttons (plain, by-use-case, translated).

## Backend contract changes

- [x] N/A — frontend-only, no backend files touched.

## Security

- [x] RBAC unaffected — no endpoint, role, or auth logic changed; `apiJson` wraps the existing cookie-based `authenticated*` helpers without adding token handling.
- [x] No secrets hardcoded.

## Related issues

- Continues #482 (source review) and #483 (Phase 1–2 execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ddJtT5YJtqwEWUoUMwC8V

---
_Generated by [Claude Code](https://claude.ai/code/session_012ddJtT5YJtqwEWUoUMwC8V)_